### PR TITLE
feat: 统一 Prompt 中心 - 支持自定义翻译提示词 (resolve #57)

### DIFF
--- a/app.py
+++ b/app.py
@@ -2574,7 +2574,8 @@ def settings():
     try:
         from modules.prompt_manager import get_builtin_prompt_previews
         builtin_prompts = get_builtin_prompt_previews()
-    except Exception:
+    except Exception as exc:
+        logger.debug("获取内置 Prompt 预览失败，将不显示预览: %s", exc)
         builtin_prompts = {}
     return render_template(
         'settings.html',

--- a/app.py
+++ b/app.py
@@ -2571,12 +2571,18 @@ def settings():
     config = load_config()
     acfun_partition_mapping = _load_acfun_partition_mapping()
     bilibili_partition_mapping = _build_bilibili_partition_mapping()
+    try:
+        from modules.prompt_manager import get_builtin_prompt_previews
+        builtin_prompts = get_builtin_prompt_previews()
+    except Exception:
+        builtin_prompts = {}
     return render_template(
         'settings.html',
         config=config,
         whisper_languages=WHISPER_LANGUAGE_LIST,
         acfun_partition_mapping=acfun_partition_mapping,
-        bilibili_partition_mapping=bilibili_partition_mapping
+        bilibili_partition_mapping=bilibili_partition_mapping,
+        builtin_prompts=builtin_prompts,
     )
 
 

--- a/modules/ai_enhancer.py
+++ b/modules/ai_enhancer.py
@@ -490,27 +490,38 @@ def _build_fallback_text(
     )
 
 
-def _build_metadata_translation_system_prompt(target_language: str, retry: bool = False) -> str:
-    target_name = _target_language_name(target_language)
-    prompt = (
-        f"你是视频标题和简介翻译器。将输入字段改写为{target_name}。"
-        "只允许重述原文事实，删除导流、社媒、外链、联系方式和互动引导。"
-        "title 必须是自然单行标题；description 必须是自然简介，可多段，但不能写成列表、备注或说明。"
-        "禁止补充新事实、解释或备注。"
-        '只返回 JSON：{"title":"","description":""}。'
+def _build_metadata_translation_system_prompt(target_language: str, retry: bool = False, openai_config=None) -> str:
+    """构建元数据翻译 system prompt（委托给统一 Prompt 中心）。"""
+    from .prompt_manager import get_metadata_translate_prompt, read_prompt_config_from_app_config
+    mode = 'builtin'
+    user_text = ''
+    if openai_config:
+        try:
+            mode, user_text = read_prompt_config_from_app_config(openai_config, 'METADATA_TRANSLATE')
+        except Exception:
+            pass
+    return get_metadata_translate_prompt(
+        mode=mode,
+        user_text=user_text,
+        target_language=target_language,
+        retry=retry,
     )
-    if retry:
-        prompt += "仅重写本次输入中提供的失败字段；无法安全输出时返回空字符串。"
-    return prompt
 
 
-def _build_description_retry_system_prompt(target_language: str) -> str:
-    target_name = _target_language_name(target_language)
-    return (
-        f"你是视频简介翻译器。将 description 翻译并改写为{target_name}自然简介。"
-        "只允许重述原文事实，删除导流、社媒、外链、联系方式和互动引导。"
-        "description 可以多段，不限制段落数，但不能输出列表、备注、解释或额外说明。"
-        '只返回 JSON：{"description":""}。'
+def _build_description_retry_system_prompt(target_language: str, openai_config=None) -> str:
+    """构建简介重试 system prompt（委托给统一 Prompt 中心）。"""
+    from .prompt_manager import get_metadata_desc_retry_prompt, read_prompt_config_from_app_config
+    mode = 'builtin'
+    user_text = ''
+    if openai_config:
+        try:
+            mode, user_text = read_prompt_config_from_app_config(openai_config, 'METADATA_DESC_RETRY')
+        except Exception:
+            pass
+    return get_metadata_desc_retry_prompt(
+        mode=mode,
+        user_text=user_text,
+        target_language=target_language,
     )
 
 
@@ -802,6 +813,7 @@ def _translate_video_metadata_once(
     logger,
     title_limit: int = 50,
     description_limit: int = 1000,
+    openai_config=None,
 ) -> Dict[str, Any]:
     translated_fields = {
         "title": "",
@@ -842,7 +854,7 @@ def _translate_video_metadata_once(
     translated_fields = _request_translated_metadata_fields(
         client=client,
         model_name=model_name,
-        system_prompt=_build_metadata_translation_system_prompt(target_language, retry=False),
+        system_prompt=_build_metadata_translation_system_prompt(target_language, retry=False, openai_config=openai_config),
         payload=payload,
         max_tokens=_estimate_metadata_max_tokens(requestable_fields),
         thinking_enabled=thinking_enabled,
@@ -873,7 +885,7 @@ def _translate_video_metadata_once(
             retry_fields = _request_translated_metadata_fields(
                 client=client,
                 model_name=model_name,
-                system_prompt=_build_metadata_translation_system_prompt(target_language, retry=True),
+                system_prompt=_build_metadata_translation_system_prompt(target_language, retry=True, openai_config=openai_config),
                 payload=retry_payload,
                 max_tokens=_estimate_metadata_max_tokens(["title"]),
                 thinking_enabled=thinking_enabled,
@@ -886,13 +898,13 @@ def _translate_video_metadata_once(
             translated_fields["title"] = retry_fields["title"]
 
         if "description" in invalid_fields:
-            description_retry_prompt = _build_metadata_translation_system_prompt(target_language, retry=True)
+            description_retry_prompt = _build_metadata_translation_system_prompt(target_language, retry=True, openai_config=openai_config)
             description_retry_scene = "ai_enhancer_metadata_translate_retry"
             if _should_use_description_only_retry(invalid_fields["description"]):
                 logger.info(
                     f"description 字段触发定向重试，失败原因: {invalid_fields['description']}"
                 )
-                description_retry_prompt = _build_description_retry_system_prompt(target_language)
+                description_retry_prompt = _build_description_retry_system_prompt(target_language, openai_config=openai_config)
                 description_retry_scene = "ai_enhancer_metadata_translate_description_retry"
 
             description_retry_payload = _build_metadata_translation_payload(
@@ -1033,6 +1045,7 @@ def translate_video_metadata(
                     logger=logger,
                     title_limit=title_limit,
                     description_limit=description_limit,
+                    openai_config=openai_config,
                 )
             except Exception as exc:
                 logger.error(f"第 {attempt} 次元数据翻译尝试发生异常: {exc}")

--- a/modules/ai_enhancer.py
+++ b/modules/ai_enhancer.py
@@ -498,8 +498,8 @@ def _build_metadata_translation_system_prompt(target_language: str, retry: bool 
     if openai_config:
         try:
             mode, user_text = read_prompt_config_from_app_config(openai_config, 'METADATA_TRANSLATE')
-        except Exception:
-            pass
+        except Exception as exc:
+            logging.getLogger(__name__).debug("读取 Prompt 配置失败（METADATA_TRANSLATE），将回退 builtin: %s", exc)
     return get_metadata_translate_prompt(
         mode=mode,
         user_text=user_text,
@@ -516,8 +516,8 @@ def _build_description_retry_system_prompt(target_language: str, openai_config=N
     if openai_config:
         try:
             mode, user_text = read_prompt_config_from_app_config(openai_config, 'METADATA_DESC_RETRY')
-        except Exception:
-            pass
+        except Exception as exc:
+            logging.getLogger(__name__).debug("读取 Prompt 配置失败（METADATA_DESC_RETRY），将回退 builtin: %s", exc)
     return get_metadata_desc_retry_prompt(
         mode=mode,
         user_text=user_text,

--- a/modules/config_manager.py
+++ b/modules/config_manager.py
@@ -329,8 +329,8 @@ def load_config():
                             if normalized != config[mode_key]:
                                 config[mode_key] = normalized
                                 prompt_mode_changed = True
-                except Exception:
-                    pass
+                except Exception as exc:
+                    logger.debug("Prompt 中心模式值标准化失败，将跳过本轮标准化: %s", exc)
 
                 # 如果有新添加的默认键或需要纠正的项，则保存更新后的配置
                 if (

--- a/modules/config_manager.py
+++ b/modules/config_manager.py
@@ -9,6 +9,7 @@ from .speech_pipeline_settings import (
     inject_speech_pipeline_defaults,
     migrate_legacy_speech_pipeline_config,
 )
+from .prompt_manager import get_default_config_entries as _get_prompt_default_entries
 
 # 获取日志记录器
 logger = logging.getLogger('config_manager')
@@ -212,6 +213,9 @@ DEFAULT_CONFIG = {
 
 DEFAULT_CONFIG = inject_speech_pipeline_defaults(DEFAULT_CONFIG)
 
+# Prompt 中心默认键（4 组翻译 Prompt 的 mode + text）
+DEFAULT_CONFIG.update(_get_prompt_default_entries())
+
 
 def normalize_youtube_download_quality_mode(value):
     normalized = str(value or _YOUTUBE_DOWNLOAD_QUALITY_MODE_DEFAULT).strip().lower()
@@ -314,6 +318,20 @@ def load_config():
                 )
                 removed_unknown_keys = bool(removed_keys)
 
+                # Prompt 中心模式值标准化
+                prompt_mode_changed = False
+                try:
+                    from .prompt_manager import normalize_mode, get_prompt_ids, config_key_for_mode
+                    for pid in get_prompt_ids():
+                        mode_key = config_key_for_mode(pid)
+                        if mode_key in config:
+                            normalized = normalize_mode(config[mode_key])
+                            if normalized != config[mode_key]:
+                                config[mode_key] = normalized
+                                prompt_mode_changed = True
+                except Exception:
+                    pass
+
                 # 如果有新添加的默认键或需要纠正的项，则保存更新后的配置
                 if (
                     missing_keys
@@ -324,6 +342,7 @@ def load_config():
                     or session_timeout_changed
                     or migrated_legacy_speech
                     or removed_unknown_keys
+                    or prompt_mode_changed
                 ):
                     if migrated_legacy_speech:
                         logger.info("检测到旧版 ASR/VAD 默认值，已自动迁移到质量优先默认配置")
@@ -407,6 +426,13 @@ def update_config(new_config):
                 current_config[key] = normalize_youtube_download_max_height(new_config[key])
             elif key == 'LOGIN_SESSION_TIMEOUT_MINUTES':
                 current_config[key] = normalize_login_session_timeout_minutes(new_config[key])
+            elif key.endswith('_MODE') and key.startswith(('SUBTITLE_', 'METADATA_')):
+                # Prompt 中心模式值标准化
+                try:
+                    from .prompt_manager import normalize_mode
+                    current_config[key] = normalize_mode(new_config[key])
+                except Exception:
+                    current_config[key] = new_config[key]
             else:
                 current_config[key] = new_config[key]
 

--- a/modules/prompt_manager.py
+++ b/modules/prompt_manager.py
@@ -290,7 +290,7 @@ def get_final_system_prompt(
     if mode == MODE_BUILTIN:
         return builtin_rendered
 
-    user_text = normalize_text(user_text)
+    user_text = _render_template(normalize_text(user_text), render_vars)
     if not user_text:
         # 用户文本为空，无论 append 还是 override 都回退 builtin
         logger.info("Prompt %s 用户文本为空，回退 builtin", prompt_id)

--- a/modules/prompt_manager.py
+++ b/modules/prompt_manager.py
@@ -1,0 +1,455 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+统一 Prompt 中心
+
+职责：
+- 注册与管理所有 LLM system prompt 的定义（ID、默认模板、模式等）
+- 提供模板渲染（变量替换）与协议壳拼装
+- 保证 JSON 输出、一一对应、残句边界等硬约束不被用户自定义 Prompt 破坏
+- 回退机制：渲染失败或文本为空时自动回退 builtin 模式
+
+首期覆盖 4 组翻译 Prompt：
+  - SUBTITLE_TRANSLATE:        字幕翻译主 Prompt
+  - SUBTITLE_TRANSLATE_STRICT: 字幕翻译严格补救 Prompt
+  - METADATA_TRANSLATE:        标题/简介翻译主 Prompt
+  - METADATA_DESC_RETRY:       简介重试 Prompt
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger("prompt_manager")
+
+# ---------------------------------------------------------------------------
+# 常量
+# ---------------------------------------------------------------------------
+
+MODE_BUILTIN = "builtin"
+MODE_APPEND = "append"
+MODE_OVERRIDE = "override"
+VALID_MODES = frozenset({MODE_BUILTIN, MODE_APPEND, MODE_OVERRIDE})
+
+# 后端字符上限（保护 system prompt 不要过长，压缩正文 token 空间）
+MAX_PROMPT_TEXT_LENGTH = 3000
+
+# ---------------------------------------------------------------------------
+# Prompt 定义注册表
+# ---------------------------------------------------------------------------
+
+_PROMPT_REGISTRY: Dict[str, Dict[str, Any]] = {}
+
+
+def _register_prompt(
+    prompt_id: str,
+    *,
+    label: str,
+    description: str,
+    builtin_template: str,
+    variables: Optional[List[str]] = None,
+    is_advanced: bool = False,
+    applies_to: str = "subtitle",
+) -> None:
+    """注册一个 Prompt 定义。仅模块加载时调用。"""
+    _PROMPT_REGISTRY[prompt_id] = {
+        "id": prompt_id,
+        "label": label,
+        "description": description,
+        "builtin_template": builtin_template,
+        "variables": variables or [],
+        "is_advanced": is_advanced,
+        "applies_to": applies_to,
+    }
+
+
+# ---------------------------------------------------------------------------
+# 内置协议壳（硬约束，不可被用户覆盖）
+# ---------------------------------------------------------------------------
+
+_SUBTITLE_SHARED_RULES = (
+    "必须保持与输入数组一一对应：第 N 条输入只翻译成第 N 条输出。"
+    "禁止跨条目借用、合并、拆分、提前翻译下一条或重复上一条内容。"
+    "若某条源文本本身是不完整短语、半句或续句，译文也必须保持同样边界，不要擅自补成完整句。"
+    "不要根据上下文重写相邻条目，不要消除原始断句。"
+)
+
+_SUBTITLE_STRICT_SHARED_RULES = (
+    "必须保持与输入数组一一对应：第 N 条输入只翻译成第 N 条输出。"
+    "禁止跨条目借用、合并、拆分、提前翻译下一条或重复上一条内容。"
+    "即使上下文相关，也不得把相邻条目的信息揉进当前条目。"
+    "若源文本是不完整短语、半句或续句，译文也保持不完整，不要补全。"
+)
+
+_SUBTITLE_JSON_SUFFIX = '只返回 JSON：{"translations":["译文1","译文2"]}。'
+
+_METADATA_JSON_SUFFIX = '只返回 JSON：{"title":"","description":""}。'
+_METADATA_DESC_RETRY_JSON_SUFFIX = '只返回 JSON：{"description":""}。'
+
+# ---------------------------------------------------------------------------
+# 首期 4 组 Prompt 的内置行为层模板
+# ---------------------------------------------------------------------------
+
+# ---------- 字幕翻译主 Prompt ----------
+_SUBTITLE_ZH_BUILTIN_BEHAVIOR = (
+    "你是字幕翻译器。按顺序把 texts 每一项翻译成简体中文。"
+    "等价翻译，不解释、不扩写；数字、代码、URL、占位符和无公认译法的专有名词可保留，"
+    "其余可翻译内容尽量译成自然简体中文。"
+)
+
+_SUBTITLE_DEFAULT_BUILTIN_BEHAVIOR = (
+    "你是字幕翻译器。按顺序把 texts 每一项翻译成{target_language_name}。"
+    "等价翻译，不解释、不扩写；保留数字、代码、URL、占位符和无公认译名的专有名词。"
+)
+
+# ---------- 字幕翻译严格补救 Prompt ----------
+_SUBTITLE_STRICT_ZH_BUILTIN_BEHAVIOR = (
+    "你是字幕翻译器（严格模式）。按顺序把 texts 每一项尽量完整翻译成自然简体中文。"
+    "普通句子和说明文字不得整句保留原文；仅保留数字、代码、URL、占位符和必要专有名词。"
+)
+
+_SUBTITLE_STRICT_DEFAULT_BUILTIN_BEHAVIOR = (
+    "你是字幕翻译器（严格模式）。按顺序把 texts 每一项完整翻译成{target_language_name}。"
+    "除数字、代码、URL、占位符和专有名词外，不要保留原文。"
+)
+
+# ---------- 标题/简介翻译主 Prompt ----------
+_METADATA_BUILTIN_BEHAVIOR = (
+    "你是视频标题和简介翻译器。将输入字段改写为{target_language_name}。"
+    "只允许重述原文事实，删除导流、社媒、外链、联系方式和互动引导。"
+    "title 必须是自然单行标题；description 必须是自然简介，可多段，但不能写成列表、备注或说明。"
+    "禁止补充新事实、解释或备注。"
+)
+
+# ---------- 简介重试 Prompt ----------
+_DESC_RETRY_BUILTIN_BEHAVIOR = (
+    "你是视频简介翻译器。将 description 翻译并改写为{target_language_name}自然简介。"
+    "只允许重述原文事实，删除导流、社媒、外链、联系方式和互动引导。"
+    "description 可以多段，不限制段落数，但不能输出列表、备注、解释或额外说明。"
+)
+
+
+# ---------------------------------------------------------------------------
+# 注册 4 组 Prompt
+# ---------------------------------------------------------------------------
+
+_register_prompt(
+    "SUBTITLE_TRANSLATE",
+    label="字幕翻译主提示词",
+    description="控制字幕批量翻译时的 system prompt。会影响翻译风格、术语策略等。",
+    builtin_template=_SUBTITLE_ZH_BUILTIN_BEHAVIOR,
+    variables=["target_language_name"],
+    applies_to="subtitle",
+)
+
+_register_prompt(
+    "SUBTITLE_TRANSLATE_STRICT",
+    label="字幕翻译严格补救提示词",
+    description="首轮翻译后若检测到大量漏译条目，会用此 Prompt 再补翻一次。",
+    builtin_template=_SUBTITLE_STRICT_ZH_BUILTIN_BEHAVIOR,
+    is_advanced=True,
+    variables=["target_language_name"],
+    applies_to="subtitle",
+)
+
+_register_prompt(
+    "METADATA_TRANSLATE",
+    label="标题/简介翻译主提示词",
+    description="控制标题和简介翻译时的 system prompt。",
+    builtin_template=_METADATA_BUILTIN_BEHAVIOR,
+    variables=["target_language_name"],
+    applies_to="metadata",
+)
+
+_register_prompt(
+    "METADATA_DESC_RETRY",
+    label="简介重试提示词",
+    description="标题/简介首轮翻译后，若简介字段校验失败，会用此 Prompt 单独重试简介。",
+    builtin_template=_DESC_RETRY_BUILTIN_BEHAVIOR,
+    is_advanced=True,
+    variables=["target_language_name"],
+    applies_to="metadata",
+)
+
+
+# ---------------------------------------------------------------------------
+# 辅助函数
+# ---------------------------------------------------------------------------
+
+def get_prompt_ids() -> List[str]:
+    """返回所有已注册的 Prompt ID（按注册顺序）。"""
+    return list(_PROMPT_REGISTRY.keys())
+
+
+def get_prompt_info(prompt_id: str) -> Optional[Dict[str, Any]]:
+    """返回某个 Prompt 的元数据。"""
+    return _PROMPT_REGISTRY.get(prompt_id)
+
+
+def normalize_mode(value: Any) -> str:
+    """标准化模式值，非法值回退 builtin。"""
+    text = str(value or "").strip().lower()
+    return text if text in VALID_MODES else MODE_BUILTIN
+
+
+def normalize_text(value: Any, max_length: int = MAX_PROMPT_TEXT_LENGTH) -> str:
+    """标准化 Prompt 文本：strip、换行规范化、长度截断。"""
+    text = str(value or "")
+    # 统一换行符
+    text = text.replace("\r\n", "\n").replace("\r", "\n")
+    text = text.strip()
+    # 长度兜底
+    if max_length > 0 and len(text) > max_length:
+        text = text[:max_length]
+    return text
+
+
+def _render_template(template: str, variables: Dict[str, Any]) -> str:
+    """用简单占位符 {key} 渲染模板。缺少变量时保留原始占位符。"""
+    result = template
+    for key, value in (variables or {}).items():
+        result = result.replace("{" + key + "}", str(value))
+    return result
+
+
+def _target_language_name(target_language: str) -> str:
+    """目标语言代码 → 自然语言名称。"""
+    code = str(target_language or "").strip().lower()
+    mapping = {
+        "zh": "简体中文",
+        "zh-cn": "简体中文",
+        "en": "English",
+        "ja": "日本語",
+        "ko": "한국어",
+    }
+    # 匹配前缀
+    for prefix, name in mapping.items():
+        if code.startswith(prefix):
+            return name
+    return code or "简体中文"
+
+
+# ---------------------------------------------------------------------------
+# 核心 API
+# ---------------------------------------------------------------------------
+
+def _resolve_builtin_template(prompt_id: str, target_language: str) -> str:
+    """根据目标语言解析对应的内置模板。
+
+    字幕翻译系列在非中文目标时需要使用带 {target_language_name} 占位符的模板，
+    而不是硬编码中文的模板。
+    """
+    info = _PROMPT_REGISTRY.get(prompt_id)
+    if not info:
+        return ""
+    target_lang = str(target_language or "zh").strip().lower()
+
+    if prompt_id == "SUBTITLE_TRANSLATE":
+        return _SUBTITLE_DEFAULT_BUILTIN_BEHAVIOR if target_lang != "zh" else _SUBTITLE_ZH_BUILTIN_BEHAVIOR
+    if prompt_id == "SUBTITLE_TRANSLATE_STRICT":
+        return _SUBTITLE_STRICT_DEFAULT_BUILTIN_BEHAVIOR if target_lang != "zh" else _SUBTITLE_STRICT_ZH_BUILTIN_BEHAVIOR
+
+    return info["builtin_template"]
+
+
+def get_final_system_prompt(
+    prompt_id: str,
+    *,
+    mode: str = MODE_BUILTIN,
+    user_text: str = "",
+    target_language: str = "zh",
+    extra_variables: Optional[Dict[str, Any]] = None,
+) -> str:
+    """
+    获取最终 system prompt 的行为层文本。
+
+    模式处理逻辑：
+    - builtin:  直接使用内置模板
+    - append:   内置模板 + 换行 + 用户文本
+    - override: 用户文本替换内置模板
+    - 任何异常/空值回退 builtin
+
+    注意：此处只返回 **行为层**，不包含协议壳。
+    调用方需要自行拼装协议壳 + 行为层 + JSON 后缀。
+    """
+    info = _PROMPT_REGISTRY.get(prompt_id)
+    if not info:
+        logger.warning("未知 Prompt ID: %s，回退空字符串", prompt_id)
+        return ""
+
+    # 构建渲染变量
+    render_vars = {"target_language_name": _target_language_name(target_language)}
+    if extra_variables:
+        render_vars.update(extra_variables)
+
+    mode = normalize_mode(mode)
+    builtin_template = _resolve_builtin_template(prompt_id, target_language)
+    builtin_rendered = _render_template(builtin_template, render_vars)
+
+    if mode == MODE_BUILTIN:
+        return builtin_rendered
+
+    user_text = normalize_text(user_text)
+    if not user_text:
+        # 用户文本为空，无论 append 还是 override 都回退 builtin
+        logger.info("Prompt %s 用户文本为空，回退 builtin", prompt_id)
+        return builtin_rendered
+
+    if mode == MODE_APPEND:
+        return builtin_rendered + "\n" + user_text
+
+    # MODE_OVERRIDE
+    return user_text
+
+
+# ---------------------------------------------------------------------------
+# 字幕翻译专用 API（封装协议壳）
+# ---------------------------------------------------------------------------
+
+def get_subtitle_system_prompt(
+    *,
+    mode: str = MODE_BUILTIN,
+    user_text: str = "",
+    target_language: str = "zh",
+) -> str:
+    """获取字幕翻译最终 system prompt（含协议壳和 JSON 后缀）。"""
+    behavior = get_final_system_prompt(
+        "SUBTITLE_TRANSLATE",
+        mode=mode,
+        user_text=user_text,
+        target_language=target_language,
+    )
+    return f"{behavior}{_SUBTITLE_SHARED_RULES}{_SUBTITLE_JSON_SUFFIX}"
+
+
+def get_subtitle_strict_system_prompt(
+    *,
+    mode: str = MODE_BUILTIN,
+    user_text: str = "",
+    target_language: str = "zh",
+) -> str:
+    """获取字幕翻译严格补救最终 system prompt（含协议壳和 JSON 后缀）。"""
+    behavior = get_final_system_prompt(
+        "SUBTITLE_TRANSLATE_STRICT",
+        mode=mode,
+        user_text=user_text,
+        target_language=target_language,
+    )
+    return f"{behavior}{_SUBTITLE_STRICT_SHARED_RULES}{_SUBTITLE_JSON_SUFFIX}"
+
+
+# ---------------------------------------------------------------------------
+# 元数据翻译专用 API（封装协议壳）
+# ---------------------------------------------------------------------------
+
+def get_metadata_translate_prompt(
+    *,
+    mode: str = MODE_BUILTIN,
+    user_text: str = "",
+    target_language: str = "zh",
+    retry: bool = False,
+) -> str:
+    """获取元数据翻译最终 system prompt（含 JSON 后缀）。
+
+    retry=True 时追加重试说明。
+    """
+    behavior = get_final_system_prompt(
+        "METADATA_TRANSLATE",
+        mode=mode,
+        user_text=user_text,
+        target_language=target_language,
+    )
+    suffix = _METADATA_JSON_SUFFIX
+    if retry:
+        suffix = "仅重写本次输入中提供的失败字段；无法安全输出时返回空字符串。" + suffix
+    return behavior + suffix
+
+
+def get_metadata_desc_retry_prompt(
+    *,
+    mode: str = MODE_BUILTIN,
+    user_text: str = "",
+    target_language: str = "zh",
+) -> str:
+    """获取简介重试最终 system prompt（含 JSON 后缀）。"""
+    behavior = get_final_system_prompt(
+        "METADATA_DESC_RETRY",
+        mode=mode,
+        user_text=user_text,
+        target_language=target_language,
+    )
+    return behavior + _METADATA_DESC_RETRY_JSON_SUFFIX
+
+
+# ---------------------------------------------------------------------------
+# 配置键映射辅助
+# ---------------------------------------------------------------------------
+
+def config_key_for_mode(prompt_id: str) -> str:
+    """Prompt ID → 配置文件中的模式键名。"""
+    return f"{prompt_id}_MODE"
+
+
+def config_key_for_text(prompt_id: str) -> str:
+    """Prompt ID → 配置文件中的文本键名。"""
+    return f"{prompt_id}_TEXT"
+
+
+def get_default_config_entries() -> Dict[str, Any]:
+    """返回所有 Prompt 中心在 DEFAULT_CONFIG 中需要注册的键值对。"""
+    entries: Dict[str, Any] = {}
+    for prompt_id in _PROMPT_REGISTRY:
+        entries[config_key_for_mode(prompt_id)] = MODE_BUILTIN
+        entries[config_key_for_text(prompt_id)] = ""
+    return entries
+
+
+def read_prompt_config_from_app_config(app_config: Dict[str, Any], prompt_id: str) -> tuple:
+    """
+    从 app_config 中读取某个 Prompt 的 (mode, text)。
+
+    Returns:
+        (mode, text) 标准化后的元组。
+    """
+    mode = normalize_mode(app_config.get(config_key_for_mode(prompt_id), MODE_BUILTIN))
+    text = normalize_text(app_config.get(config_key_for_text(prompt_id), ""))
+    return mode, text
+
+
+# ---------------------------------------------------------------------------
+# 内置 Prompt 预览（供设置页展示）
+# ---------------------------------------------------------------------------
+
+def get_builtin_prompt_previews() -> Dict[str, Dict[str, str]]:
+    """返回所有 Prompt 的内置模板预览，供设置页面展示。
+
+    Returns:
+        dict: {prompt_id: {"label": str, "description": str, "builtin_text": str}}
+    """
+    previews: Dict[str, Dict[str, str]] = {}
+    # 使用默认目标语言（简体中文）渲染变量占位符
+    render_vars = {"target_language_name": "简体中文"}
+    for prompt_id, info in _PROMPT_REGISTRY.items():
+        rendered = _render_template(
+            _resolve_builtin_template(prompt_id, "zh"),
+            render_vars,
+        )
+        # 拼接协议壳和 JSON 后缀，展示最终完整 system prompt
+        full_prompt = rendered
+        if prompt_id == "SUBTITLE_TRANSLATE":
+            full_prompt = rendered + _SUBTITLE_SHARED_RULES + _SUBTITLE_JSON_SUFFIX
+        elif prompt_id == "SUBTITLE_TRANSLATE_STRICT":
+            full_prompt = rendered + _SUBTITLE_STRICT_SHARED_RULES + _SUBTITLE_JSON_SUFFIX
+        elif prompt_id == "METADATA_TRANSLATE":
+            full_prompt = rendered + _METADATA_JSON_SUFFIX
+        elif prompt_id == "METADATA_DESC_RETRY":
+            full_prompt = rendered + _METADATA_DESC_RETRY_JSON_SUFFIX
+
+        previews[prompt_id] = {
+            "label": info["label"],
+            "description": info["description"],
+            "builtin_text": full_prompt,
+        }
+    return previews

--- a/modules/prompt_manager.py
+++ b/modules/prompt_manager.py
@@ -19,7 +19,6 @@
 from __future__ import annotations
 
 import logging
-import re
 from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger("prompt_manager")

--- a/modules/subtitle_translator.py
+++ b/modules/subtitle_translator.py
@@ -130,6 +130,7 @@ class TranslationConfig:
     # Prompt 中心配置
     prompt_mode: str = "builtin"
     prompt_text: str = ""         # 字幕翻译主 Prompt 用户文本
+    prompt_strict_mode: str = "builtin"  # 字幕翻译严格补救 Prompt 模式
     prompt_strict_text: str = ""  # 字幕翻译严格补救 Prompt 用户文本
 
 class SubtitleReader:
@@ -512,7 +513,10 @@ class LLMRequester:
         """严格模式提示词（委托给统一 Prompt 中心）。"""
         from .prompt_manager import get_subtitle_strict_system_prompt
         return get_subtitle_strict_system_prompt(
-            mode=self.openai_config.get('PROMPT_MODE', 'builtin'),
+            mode=self.openai_config.get(
+                'PROMPT_STRICT_MODE',
+                self.openai_config.get('PROMPT_MODE', 'builtin'),
+            ),
             user_text=self.openai_config.get('PROMPT_STRICT_TEXT', ''),
             target_language=target_language,
         )
@@ -590,7 +594,8 @@ class SubtitleTranslator:
             'OPENAI_MODEL_NAME': config.model_name or 'gpt-3.5-turbo',
             'OPENAI_THINKING_ENABLED': str(config.thinking_enabled).strip().lower() in ('true', '1', 'on', 'yes'),
             'OPENAI_TIMEOUT_SECONDS': config.timeout_seconds,
-            # Prompt 中心配置（快照，避免热修改影响进行中的翻译）
+            # Prompt 中心配置（快MODE': getattr(config, 'prompt_strict_mode', 'builtin'),
+            'PROMPT_STRICT_照，避免热修改影响进行中的翻译）
             'PROMPT_MODE': getattr(config, 'prompt_mode', 'builtin'),
             'PROMPT_TEXT': getattr(config, 'prompt_text', ''),
             'PROMPT_STRICT_TEXT': getattr(config, 'prompt_strict_text', ''),
@@ -1123,11 +1128,12 @@ def create_translator_from_config(app_config: Dict, task_id: Optional[str] = Non
 
         # 读取 Prompt 中心配置
         prompt_mode = 'builtin'
-        prompt_text = ''
+        prompt_text = mode = 'builtin'
         prompt_strict_text = ''
         try:
-            from .prompt_manager import read_prompt_config_from_app_config, normalize_mode
+            from .prompt_manager import read_prompt_config_from_app_config
             prompt_mode, prompt_text = read_prompt_config_from_app_config(app_config, 'SUBTITLE_TRANSLATE')
+            prompt_strict_moderompt_mode, prompt_text = read_prompt_config_from_app_config(app_config, 'SUBTITLE_TRANSLATE')
             _, prompt_strict_text = read_prompt_config_from_app_config(app_config, 'SUBTITLE_TRANSLATE_STRICT')
         except Exception:
             pass
@@ -1145,7 +1151,8 @@ def create_translator_from_config(app_config: Dict, task_id: Optional[str] = Non
             max_workers=max_workers,
             thinking_enabled=app_config.get('SUBTITLE_OPENAI_THINKING_ENABLED', False),
             timeout_seconds=int(app_config.get('OPENAI_TIMEOUT_SECONDS', 600)),
-            prompt_mode=prompt_mode,
+            prompt_mode=prmode=prompt_strict_mode,
+            prompt_strict_ompt_mode,
             prompt_text=prompt_text,
             prompt_strict_text=prompt_strict_text,
         )

--- a/modules/subtitle_translator.py
+++ b/modules/subtitle_translator.py
@@ -594,10 +594,10 @@ class SubtitleTranslator:
             'OPENAI_MODEL_NAME': config.model_name or 'gpt-3.5-turbo',
             'OPENAI_THINKING_ENABLED': str(config.thinking_enabled).strip().lower() in ('true', '1', 'on', 'yes'),
             'OPENAI_TIMEOUT_SECONDS': config.timeout_seconds,
-            # Prompt 中心配置（快MODE': getattr(config, 'prompt_strict_mode', 'builtin'),
-            'PROMPT_STRICT_照，避免热修改影响进行中的翻译）
+            # Prompt 中心配置（快照，避免热修改影响进行中的翻译）
             'PROMPT_MODE': getattr(config, 'prompt_mode', 'builtin'),
             'PROMPT_TEXT': getattr(config, 'prompt_text', ''),
+            'PROMPT_STRICT_MODE': getattr(config, 'prompt_strict_mode', 'builtin'),
             'PROMPT_STRICT_TEXT': getattr(config, 'prompt_strict_text', ''),
         }
         
@@ -1128,13 +1128,13 @@ def create_translator_from_config(app_config: Dict, task_id: Optional[str] = Non
 
         # 读取 Prompt 中心配置
         prompt_mode = 'builtin'
-        prompt_text = mode = 'builtin'
+        prompt_text = ''
+        prompt_strict_mode = 'builtin'
         prompt_strict_text = ''
         try:
             from .prompt_manager import read_prompt_config_from_app_config
             prompt_mode, prompt_text = read_prompt_config_from_app_config(app_config, 'SUBTITLE_TRANSLATE')
-            prompt_strict_moderompt_mode, prompt_text = read_prompt_config_from_app_config(app_config, 'SUBTITLE_TRANSLATE')
-            _, prompt_strict_text = read_prompt_config_from_app_config(app_config, 'SUBTITLE_TRANSLATE_STRICT')
+            prompt_strict_mode, prompt_strict_text = read_prompt_config_from_app_config(app_config, 'SUBTITLE_TRANSLATE_STRICT')
         except Exception:
             pass
 
@@ -1151,9 +1151,9 @@ def create_translator_from_config(app_config: Dict, task_id: Optional[str] = Non
             max_workers=max_workers,
             thinking_enabled=app_config.get('SUBTITLE_OPENAI_THINKING_ENABLED', False),
             timeout_seconds=int(app_config.get('OPENAI_TIMEOUT_SECONDS', 600)),
-            prompt_mode=prmode=prompt_strict_mode,
-            prompt_strict_ompt_mode,
+            prompt_mode=prompt_mode,
             prompt_text=prompt_text,
+            prompt_strict_mode=prompt_strict_mode,
             prompt_strict_text=prompt_strict_text,
         )
         

--- a/modules/subtitle_translator.py
+++ b/modules/subtitle_translator.py
@@ -127,6 +127,10 @@ class TranslationConfig:
     max_workers: int = 2  # 减少最大并发线程数以降低内存使用
     thinking_enabled: bool = False
     timeout_seconds: int = 600  # API请求超时秒数；思考模型输出可达64k token，建议不低于300
+    # Prompt 中心配置
+    prompt_mode: str = "builtin"
+    prompt_text: str = ""         # 字幕翻译主 Prompt 用户文本
+    prompt_strict_text: str = ""  # 字幕翻译严格补救 Prompt 用户文本
 
 class SubtitleReader:
     """字幕文件读取器"""
@@ -496,68 +500,21 @@ class LLMRequester:
             raise
     
     def _build_structured_system_prompt(self, target_language: str) -> str:
-        """构建结构化系统提示词。"""
-        target_language = str(target_language).lower().strip()
-        target_lang_map = {
-            "zh": "中文",
-            "en": "English",
-            "ja": "日本語",
-            "ko": "한국어",
-        }
-        target_lang_name = target_lang_map.get(target_language, "中文")
-        shared_rules = (
-            "必须保持与输入数组一一对应：第 N 条输入只翻译成第 N 条输出。"
-            "禁止跨条目借用、合并、拆分、提前翻译下一条或重复上一条内容。"
-            "若某条源文本本身是不完整短语、半句或续句，译文也必须保持同样边界，不要擅自补成完整句。"
-            "不要根据上下文重写相邻条目，不要消除原始断句。"
-        )
-
-        if target_language != "zh":
-            return (
-                f"你是字幕翻译器。按顺序把 texts 每一项翻译成{target_lang_name}。"
-                f"{shared_rules}"
-                "等价翻译，不解释、不扩写；保留数字、代码、URL、占位符和无公认译名的专有名词。"
-                '只返回 JSON：{"translations":["译文1","译文2"]}。'
-            )
-
-        return (
-            "你是字幕翻译器。按顺序把 texts 每一项翻译成简体中文。"
-            f"{shared_rules}"
-            "等价翻译，不解释、不扩写；数字、代码、URL、占位符和无公认译法的专有名词可保留，"
-            "其余可翻译内容尽量译成自然简体中文。"
-            '只返回 JSON：{"translations":["译文1","译文2"]}。'
+        """构建结构化系统提示词（委托给统一 Prompt 中心）。"""
+        from .prompt_manager import get_subtitle_system_prompt
+        return get_subtitle_system_prompt(
+            mode=self.openai_config.get('PROMPT_MODE', 'builtin'),
+            user_text=self.openai_config.get('PROMPT_TEXT', ''),
+            target_language=target_language,
         )
 
     def _build_strict_structured_system_prompt(self, target_language: str) -> str:
-        """严格模式提示词：用于补救未译条目。"""
-        target_language = str(target_language).lower().strip()
-        target_lang_map = {
-            "zh": "中文",
-            "en": "English",
-            "ja": "日本語",
-            "ko": "한국어",
-        }
-        target_lang_name = target_lang_map.get(target_language, "中文")
-        shared_rules = (
-            "必须保持与输入数组一一对应：第 N 条输入只翻译成第 N 条输出。"
-            "禁止跨条目借用、合并、拆分、提前翻译下一条或重复上一条内容。"
-            "即使上下文相关，也不得把相邻条目的信息揉进当前条目。"
-            "若源文本是不完整短语、半句或续句，译文也保持不完整，不要补全。"
-        )
-
-        if target_language != "zh":
-            return (
-                f"你是字幕翻译器（严格模式）。按顺序把 texts 每一项完整翻译成{target_lang_name}。"
-                f"{shared_rules}"
-                "除数字、代码、URL、占位符和专有名词外，不要保留原文。"
-                '只返回 JSON：{"translations":["译文1","译文2"]}。'
-            )
-
-        return (
-            "你是字幕翻译器（严格模式）。按顺序把 texts 每一项尽量完整翻译成自然简体中文。"
-            f"{shared_rules}"
-            "普通句子和说明文字不得整句保留原文；仅保留数字、代码、URL、占位符和必要专有名词。"
-            '只返回 JSON：{"translations":["译文1","译文2"]}。'
+        """严格模式提示词（委托给统一 Prompt 中心）。"""
+        from .prompt_manager import get_subtitle_strict_system_prompt
+        return get_subtitle_strict_system_prompt(
+            mode=self.openai_config.get('PROMPT_MODE', 'builtin'),
+            user_text=self.openai_config.get('PROMPT_STRICT_TEXT', ''),
+            target_language=target_language,
         )
     
     def _build_structured_user_prompt(self, texts: List[str]) -> str:
@@ -633,6 +590,10 @@ class SubtitleTranslator:
             'OPENAI_MODEL_NAME': config.model_name or 'gpt-3.5-turbo',
             'OPENAI_THINKING_ENABLED': str(config.thinking_enabled).strip().lower() in ('true', '1', 'on', 'yes'),
             'OPENAI_TIMEOUT_SECONDS': config.timeout_seconds,
+            # Prompt 中心配置（快照，避免热修改影响进行中的翻译）
+            'PROMPT_MODE': getattr(config, 'prompt_mode', 'builtin'),
+            'PROMPT_TEXT': getattr(config, 'prompt_text', ''),
+            'PROMPT_STRICT_TEXT': getattr(config, 'prompt_strict_text', ''),
         }
         
         self.llm_requester = LLMRequester(self.openai_config, task_id)
@@ -1160,6 +1121,17 @@ def create_translator_from_config(app_config: Dict, task_id: Optional[str] = Non
         # 添加调试日志：检查配置值
         logger.debug(f"配置值检查 - subtitle_base_url: {subtitle_base_url is None}, subtitle_api_key: {subtitle_api_key is None}, subtitle_model: {subtitle_model is None}")
 
+        # 读取 Prompt 中心配置
+        prompt_mode = 'builtin'
+        prompt_text = ''
+        prompt_strict_text = ''
+        try:
+            from .prompt_manager import read_prompt_config_from_app_config, normalize_mode
+            prompt_mode, prompt_text = read_prompt_config_from_app_config(app_config, 'SUBTITLE_TRANSLATE')
+            _, prompt_strict_text = read_prompt_config_from_app_config(app_config, 'SUBTITLE_TRANSLATE_STRICT')
+        except Exception:
+            pass
+
         translation_config = TranslationConfig(
             source_language=app_config.get('SUBTITLE_SOURCE_LANGUAGE', 'auto'),
             target_language=app_config.get('SUBTITLE_TARGET_LANGUAGE', 'zh'),
@@ -1173,6 +1145,9 @@ def create_translator_from_config(app_config: Dict, task_id: Optional[str] = Non
             max_workers=max_workers,
             thinking_enabled=app_config.get('SUBTITLE_OPENAI_THINKING_ENABLED', False),
             timeout_seconds=int(app_config.get('OPENAI_TIMEOUT_SECONDS', 600)),
+            prompt_mode=prompt_mode,
+            prompt_text=prompt_text,
+            prompt_strict_text=prompt_strict_text,
         )
         
         if not translation_config.api_key:

--- a/modules/subtitle_translator.py
+++ b/modules/subtitle_translator.py
@@ -1135,8 +1135,8 @@ def create_translator_from_config(app_config: Dict, task_id: Optional[str] = Non
             from .prompt_manager import read_prompt_config_from_app_config
             prompt_mode, prompt_text = read_prompt_config_from_app_config(app_config, 'SUBTITLE_TRANSLATE')
             prompt_strict_mode, prompt_strict_text = read_prompt_config_from_app_config(app_config, 'SUBTITLE_TRANSLATE_STRICT')
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.debug(f"读取 Prompt 中心配置失败，将回退 builtin: {exc}")
 
         translation_config = TranslationConfig(
             source_language=app_config.get('SUBTITLE_SOURCE_LANGUAGE', 'auto'),

--- a/modules/task_manager.py
+++ b/modules/task_manager.py
@@ -2865,6 +2865,13 @@ class TaskProcessor:
             # 可选：允许用户配置固定分区ID，确保一次命中
             'FIXED_PARTITION_ID': self.config.get('FIXED_PARTITION_ID', ''),
         }
+        # 传递 Prompt 中心配置（元数据翻译）
+        for prompt_key in (
+            'METADATA_TRANSLATE_MODE', 'METADATA_TRANSLATE_TEXT',
+            'METADATA_DESC_RETRY_MODE', 'METADATA_DESC_RETRY_TEXT',
+        ):
+            if prompt_key in self.config:
+                openai_config[prompt_key] = self.config[prompt_key]
         
         translate_title = bool(self.config.get('TRANSLATE_TITLE', True) and task.get('video_title_original'))
         translate_description = bool(self.config.get('TRANSLATE_DESCRIPTION', True) and task.get('description_original'))

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -2235,10 +2235,16 @@ document.addEventListener('DOMContentLoaded', function () {
         if (!preview) {
             return;
         }
+        var card = select.closest('article');
+        var textArea = card ? card.querySelector('textarea[name$="_TEXT"]') : null;
         var syncPreview = function () {
-            preview.style.display = (select.value === 'builtin') ? '' : 'none';
+            var hasUserText = textArea ? String(textArea.value || '').trim().length > 0 : true;
+            preview.style.display = (select.value === 'builtin' || !hasUserText) ? '' : 'none';
         };
         select.addEventListener('change', syncPreview);
+        if (textArea) {
+            textArea.addEventListener('input', syncPreview);
+        }
         syncPreview();
     });
 

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -102,6 +102,10 @@
                     <i class="bi bi-badge-cc"></i>
                     <span>字幕处理</span>
                 </a>
+                <a class="nav-link" id="vtab-prompts-tab" data-bs-toggle="pill" href="#vtab-prompts" role="tab" aria-controls="vtab-prompts" aria-selected="false">
+                    <i class="bi bi-chat-text"></i>
+                    <span>提示词</span>
+                </a>
                 <a class="nav-link" id="vtab-asr-tab" data-bs-toggle="pill" href="#vtab-asr" role="tab" aria-controls="vtab-asr" aria-selected="false">
                     <i class="bi bi-mic"></i>
                     <span>语音识别</span>
@@ -963,6 +967,232 @@
                                             </div>
                                         </article>
                                     </div>
+                                </div>
+                            </section>
+                        </div>
+                    </div>
+
+                    <div class="tab-pane fade" id="vtab-prompts" role="tabpanel" aria-labelledby="vtab-prompts-tab">
+                        <div class="settings-stack">
+                            <section class="settings-section">
+                                <div class="settings-section-header">
+                                    <div>
+                                        <h3 class="mb-1">提示词</h3>
+                                        <p class="section-lead mb-0">自定义字幕翻译与标题/简介翻译的 AI 指令。留空即使用内置默认模板。</p>
+                                    </div>
+                                </div>
+
+                                <div class="alert alert-info mb-4">
+                                    <i class="bi bi-info-circle"></i>
+                                    <strong>模式说明：</strong>
+                                    <ul class="mb-0 mt-1">
+                                        <li><strong>内置</strong>：使用系统默认模板，推荐大多数用户。</li>
+                                        <li><strong>追加</strong>：在默认模板后附加你的指令（推荐的自定义方式）。</li>
+                                        <li><strong>覆盖</strong>：用你的文本替换默认行为层，但 JSON 输出格式和逐条对齐等硬约束仍保留。</li>
+                                    </ul>
+                                </div>
+
+                                <div class="row g-4 settings-pane-grid">
+                                    <!-- 字幕翻译 -->
+                                    <div class="col-12">
+                                        <article class="settings-card">
+                                            <div class="settings-card-header">
+                                                <div>
+                                                    <span class="section-eyebrow">字幕翻译</span>
+                                                    <h4>字幕翻译主提示词</h4>
+                                                </div>
+                                                <span class="settings-status-badge {{ 'is-info' if config.get('SUBTITLE_TRANSLATE_TEXT', '') else 'is-neutral' }}">
+                                                    {{ '已自定义' if config.get('SUBTITLE_TRANSLATE_TEXT', '') else '使用内置' }}
+                                                </span>
+                                            </div>
+                                            <div class="settings-card-body">
+                                                <div class="row g-3">
+                                                    <div class="col-md-4">
+                                                        <div class="form-group">
+                                                            <label for="subtitle-translate-mode" class="form-label">模式</label>
+                                                            <select id="subtitle-translate-mode" name="SUBTITLE_TRANSLATE_MODE" class="form-select prompt-mode-select" data-preview-id="builtin-preview-subtitle-translate">
+                                                                <option value="builtin" {% if config.get('SUBTITLE_TRANSLATE_MODE', 'builtin') == 'builtin' %}selected{% endif %}>内置</option>
+                                                                <option value="append" {% if config.get('SUBTITLE_TRANSLATE_MODE', 'builtin') == 'append' %}selected{% endif %}>追加</option>
+                                                                <option value="override" {% if config.get('SUBTITLE_TRANSLATE_MODE', 'builtin') == 'override' %}selected{% endif %}>覆盖</option>
+                                                            </select>
+                                                        </div>
+                                                    </div>
+                                                    <div class="col-12 builtin-prompt-preview" id="builtin-preview-subtitle-translate" {% if config.get('SUBTITLE_TRANSLATE_MODE', 'builtin') != 'builtin' %}style="display:none"{% endif %}>
+                                                        <div class="alert alert-secondary mb-0">
+                                                            <div class="d-flex justify-content-between align-items-center mb-2">
+                                                                <strong><i class="bi bi-eye"></i> 当前内置提示词</strong>
+                                                                <button class="btn btn-sm btn-outline-secondary py-0" type="button" data-bs-toggle="collapse" data-bs-target="#builtin-text-subtitle-translate" aria-expanded="false">
+                                                                    <i class="bi bi-chevron-down"></i> 展开/收起
+                                                                </button>
+                                                            </div>
+                                                            <div class="collapse" id="builtin-text-subtitle-translate">
+                                                                <pre class="mb-0 small text-muted" style="white-space: pre-wrap; word-break: break-all; max-height: 300px; overflow-y: auto;">{{ builtin_prompts.get('SUBTITLE_TRANSLATE', {}).get('builtin_text', '') }}</pre>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                    <div class="col-12">
+                                                        <div class="form-group">
+                                                            <label for="subtitle-translate-text" class="form-label">自定义指令</label>
+                                                            <textarea id="subtitle-translate-text" name="SUBTITLE_TRANSLATE_TEXT" rows="5" class="form-control" maxlength="3000" placeholder="例如：保留音乐术语不翻译；人名音译用常用写法；技术缩写保留原文">{{ config.get('SUBTITLE_TRANSLATE_TEXT', '') }}</textarea>
+                                                            <p class="help-text mb-0">可用变量：<code>{target_language_name}</code>（目标语言名称）。留空则使用内置默认模板。</p>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </article>
+                                    </div>
+
+                                    <!-- 字幕严格补救 -->
+                                    <div class="col-12">
+                                        <article class="settings-card">
+                                            <div class="settings-card-header">
+                                                <div>
+                                                    <span class="section-eyebrow">字幕翻译 · 高级</span>
+                                                    <h4>严格补救提示词</h4>
+                                                </div>
+                                                <button class="btn btn-sm btn-outline-secondary" type="button" data-bs-toggle="collapse" data-bs-target="#advancedStrictPrompt" aria-expanded="false" aria-controls="advancedStrictPrompt">
+                                                    <i class="bi bi-chevron-down"></i> 展开
+                                                </button>
+                                            </div>
+                                            <div class="collapse mt-2" id="advancedStrictPrompt">
+                                                <div class="settings-card-body pt-0">
+                                                    <p class="help-text">首轮翻译后若检测到大量漏译条目，会用此提示词以严格模式再补翻一次。</p>
+                                                    <div class="row g-3">
+                                                        <div class="col-md-4">
+                                                            <div class="form-group">
+                                                                <label for="subtitle-translate-strict-mode" class="form-label">模式</label>
+                                                                <select id="subtitle-translate-strict-mode" name="SUBTITLE_TRANSLATE_STRICT_MODE" class="form-select prompt-mode-select" data-preview-id="builtin-preview-subtitle-strict">
+                                                                    <option value="builtin" {% if config.get('SUBTITLE_TRANSLATE_STRICT_MODE', 'builtin') == 'builtin' %}selected{% endif %}>内置</option>
+                                                                    <option value="append" {% if config.get('SUBTITLE_TRANSLATE_STRICT_MODE', 'builtin') == 'append' %}selected{% endif %}>追加</option>
+                                                                    <option value="override" {% if config.get('SUBTITLE_TRANSLATE_STRICT_MODE', 'builtin') == 'override' %}selected{% endif %}>覆盖</option>
+                                                                </select>
+                                                            </div>
+                                                        </div>
+                                                        <div class="col-12 builtin-prompt-preview" id="builtin-preview-subtitle-strict" {% if config.get('SUBTITLE_TRANSLATE_STRICT_MODE', 'builtin') != 'builtin' %}style="display:none"{% endif %}>
+                                                            <div class="alert alert-secondary mb-0">
+                                                                <div class="d-flex justify-content-between align-items-center mb-2">
+                                                                    <strong><i class="bi bi-eye"></i> 当前内置提示词</strong>
+                                                                    <button class="btn btn-sm btn-outline-secondary py-0" type="button" data-bs-toggle="collapse" data-bs-target="#builtin-text-subtitle-strict" aria-expanded="false">
+                                                                        <i class="bi bi-chevron-down"></i> 展开/收起
+                                                                    </button>
+                                                                </div>
+                                                                <div class="collapse" id="builtin-text-subtitle-strict">
+                                                                    <pre class="mb-0 small text-muted" style="white-space: pre-wrap; word-break: break-all; max-height: 300px; overflow-y: auto;">{{ builtin_prompts.get('SUBTITLE_TRANSLATE_STRICT', {}).get('builtin_text', '') }}</pre>
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                        <div class="col-12">
+                                                            <div class="form-group mb-0">
+                                                                <label for="subtitle-translate-strict-text" class="form-label">自定义指令</label>
+                                                                <textarea id="subtitle-translate-strict-text" name="SUBTITLE_TRANSLATE_STRICT_TEXT" rows="4" class="form-control" maxlength="3000" placeholder="留空则使用内置默认模板">{{ config.get('SUBTITLE_TRANSLATE_STRICT_TEXT', '') }}</textarea>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </article>
+                                    </div>
+
+                                    <!-- 标题/简介翻译 -->
+                                    <div class="col-12">
+                                        <article class="settings-card">
+                                            <div class="settings-card-header">
+                                                <div>
+                                                    <span class="section-eyebrow">标题/简介翻译</span>
+                                                    <h4>元数据翻译主提示词</h4>
+                                                </div>
+                                                <span class="settings-status-badge {{ 'is-info' if config.get('METADATA_TRANSLATE_TEXT', '') else 'is-neutral' }}">
+                                                    {{ '已自定义' if config.get('METADATA_TRANSLATE_TEXT', '') else '使用内置' }}
+                                                </span>
+                                            </div>
+                                            <div class="settings-card-body">
+                                                <div class="row g-3">
+                                                    <div class="col-md-4">
+                                                        <div class="form-group">
+                                                            <label for="metadata-translate-mode" class="form-label">模式</label>
+                                                            <select id="metadata-translate-mode" name="METADATA_TRANSLATE_MODE" class="form-select prompt-mode-select" data-preview-id="builtin-preview-metadata-translate">
+                                                                <option value="builtin" {% if config.get('METADATA_TRANSLATE_MODE', 'builtin') == 'builtin' %}selected{% endif %}>内置</option>
+                                                                <option value="append" {% if config.get('METADATA_TRANSLATE_MODE', 'builtin') == 'append' %}selected{% endif %}>追加</option>
+                                                                <option value="override" {% if config.get('METADATA_TRANSLATE_MODE', 'builtin') == 'override' %}selected{% endif %}>覆盖</option>
+                                                            </select>
+                                                        </div>
+                                                    </div>
+                                                    <div class="col-12 builtin-prompt-preview" id="builtin-preview-metadata-translate" {% if config.get('METADATA_TRANSLATE_MODE', 'builtin') != 'builtin' %}style="display:none"{% endif %}>
+                                                        <div class="alert alert-secondary mb-0">
+                                                            <div class="d-flex justify-content-between align-items-center mb-2">
+                                                                <strong><i class="bi bi-eye"></i> 当前内置提示词</strong>
+                                                                <button class="btn btn-sm btn-outline-secondary py-0" type="button" data-bs-toggle="collapse" data-bs-target="#builtin-text-metadata-translate" aria-expanded="false">
+                                                                    <i class="bi bi-chevron-down"></i> 展开/收起
+                                                                </button>
+                                                            </div>
+                                                            <div class="collapse" id="builtin-text-metadata-translate">
+                                                                <pre class="mb-0 small text-muted" style="white-space: pre-wrap; word-break: break-all; max-height: 300px; overflow-y: auto;">{{ builtin_prompts.get('METADATA_TRANSLATE', {}).get('builtin_text', '') }}</pre>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                    <div class="col-12">
+                                                        <div class="form-group mb-0">
+                                                            <label for="metadata-translate-text" class="form-label">自定义指令</label>
+                                                            <textarea id="metadata-translate-text" name="METADATA_TRANSLATE_TEXT" rows="5" class="form-control" maxlength="3000" placeholder="例如：标题风格偏口语化；简介保留原始段落结构">{{ config.get('METADATA_TRANSLATE_TEXT', '') }}</textarea>
+                                                            <p class="help-text mb-0">可用变量：<code>{target_language_name}</code>。留空则使用内置默认模板。</p>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </article>
+                                    </div>
+
+                                    <!-- 简介重试 -->
+                                    <div class="col-12">
+                                        <article class="settings-card">
+                                            <div class="settings-card-header">
+                                                <div>
+                                                    <span class="section-eyebrow">标题/简介翻译 · 高级</span>
+                                                    <h4>简介重试提示词</h4>
+                                                </div>
+                                                <button class="btn btn-sm btn-outline-secondary" type="button" data-bs-toggle="collapse" data-bs-target="#advancedDescRetryPrompt" aria-expanded="false" aria-controls="advancedDescRetryPrompt">
+                                                    <i class="bi bi-chevron-down"></i> 展开
+                                                </button>
+                                            </div>
+                                            <div class="collapse mt-2" id="advancedDescRetryPrompt">
+                                                <div class="settings-card-body pt-0">
+                                                    <p class="help-text">标题/简介首轮翻译后，若简介字段校验失败（如格式不自然、含导流残留等），会用此提示词单独重试简介。</p>
+                                                    <div class="row g-3">
+                                                        <div class="col-md-4">
+                                                            <div class="form-group">
+                                                                <label for="metadata-desc-retry-mode" class="form-label">模式</label>
+                                                                <select id="metadata-desc-retry-mode" name="METADATA_DESC_RETRY_MODE" class="form-select prompt-mode-select" data-preview-id="builtin-preview-desc-retry">
+                                                                    <option value="builtin" {% if config.get('METADATA_DESC_RETRY_MODE', 'builtin') == 'builtin' %}selected{% endif %}>内置</option>
+                                                                    <option value="append" {% if config.get('METADATA_DESC_RETRY_MODE', 'builtin') == 'append' %}selected{% endif %}>追加</option>
+                                                                    <option value="override" {% if config.get('METADATA_DESC_RETRY_MODE', 'builtin') == 'override' %}selected{% endif %}>覆盖</option>
+                                                                </select>
+                                                            </div>
+                                                        </div>
+                                                        <div class="col-12 builtin-prompt-preview" id="builtin-preview-desc-retry" {% if config.get('METADATA_DESC_RETRY_MODE', 'builtin') != 'builtin' %}style="display:none"{% endif %}>
+                                                            <div class="alert alert-secondary mb-0">
+                                                                <div class="d-flex justify-content-between align-items-center mb-2">
+                                                                    <strong><i class="bi bi-eye"></i> 当前内置提示词</strong>
+                                                                    <button class="btn btn-sm btn-outline-secondary py-0" type="button" data-bs-toggle="collapse" data-bs-target="#builtin-text-desc-retry" aria-expanded="false">
+                                                                        <i class="bi bi-chevron-down"></i> 展开/收起
+                                                                    </button>
+                                                                </div>
+                                                                <div class="collapse" id="builtin-text-desc-retry">
+                                                                    <pre class="mb-0 small text-muted" style="white-space: pre-wrap; word-break: break-all; max-height: 300px; overflow-y: auto;">{{ builtin_prompts.get('METADATA_DESC_RETRY', {}).get('builtin_text', '') }}</pre>
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                        <div class="col-12">
+                                                            <div class="form-group mb-0">
+                                                                <label for="metadata-desc-retry-text" class="form-label">自定义指令</label>
+                                                                <textarea id="metadata-desc-retry-text" name="METADATA_DESC_RETRY_TEXT" rows="4" class="form-control" maxlength="3000" placeholder="留空则使用内置默认模板">{{ config.get('METADATA_DESC_RETRY_TEXT', '') }}</textarea>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </article>
+                                    </div>
+
                                 </div>
                             </section>
                         </div>
@@ -1993,6 +2223,23 @@ document.addEventListener('DOMContentLoaded', function () {
         };
         checkbox.addEventListener('change', updateInputState);
         updateInputState();
+    });
+
+    // Prompt 中心：根据模式下拉切换内置提示词预览的显示/隐藏
+    document.querySelectorAll('.prompt-mode-select').forEach(function (select) {
+        var previewId = select.getAttribute('data-preview-id');
+        if (!previewId) {
+            return;
+        }
+        var preview = document.getElementById(previewId);
+        if (!preview) {
+            return;
+        }
+        var syncPreview = function () {
+            preview.style.display = (select.value === 'builtin') ? '' : 'none';
+        };
+        select.addEventListener('change', syncPreview);
+        syncPreview();
     });
 
     const settingsToastContainer = document.getElementById('settings-toast-container');

--- a/tests/test_prompt_manager.py
+++ b/tests/test_prompt_manager.py
@@ -1,0 +1,198 @@
+import unittest
+
+from modules.prompt_manager import (
+    MODE_APPEND,
+    MODE_BUILTIN,
+    MODE_OVERRIDE,
+    VALID_MODES,
+    config_key_for_mode,
+    config_key_for_text,
+    get_default_config_entries,
+    get_final_system_prompt,
+    get_metadata_desc_retry_prompt,
+    get_metadata_translate_prompt,
+    get_prompt_ids,
+    get_prompt_info,
+    get_subtitle_strict_system_prompt,
+    get_subtitle_system_prompt,
+    normalize_mode,
+    normalize_text,
+    read_prompt_config_from_app_config,
+)
+
+
+class NormalizeModeTests(unittest.TestCase):
+    def test_valid_modes(self):
+        for mode in VALID_MODES:
+            self.assertEqual(normalize_mode(mode), mode)
+
+    def test_case_insensitive(self):
+        self.assertEqual(normalize_mode("APPEND"), MODE_APPEND)
+        self.assertEqual(normalize_mode(" Override "), MODE_OVERRIDE)
+
+    def test_invalid_fallback(self):
+        self.assertEqual(normalize_mode("bad"), MODE_BUILTIN)
+        self.assertEqual(normalize_mode(""), MODE_BUILTIN)
+        self.assertEqual(normalize_mode(None), MODE_BUILTIN)
+
+
+class NormalizeTextTests(unittest.TestCase):
+    def test_strip(self):
+        self.assertEqual(normalize_text("  hello  "), "hello")
+
+    def test_crlf(self):
+        self.assertEqual(normalize_text("a\r\nb"), "a\nb")
+
+    def test_max_length(self):
+        result = normalize_text("a" * 5000, max_length=100)
+        self.assertEqual(len(result), 100)
+
+    def test_empty(self):
+        self.assertEqual(normalize_text(""), "")
+        self.assertEqual(normalize_text(None), "")
+
+
+class PromptRegistryTests(unittest.TestCase):
+    def test_ids(self):
+        ids = get_prompt_ids()
+        self.assertIn("SUBTITLE_TRANSLATE", ids)
+        self.assertIn("SUBTITLE_TRANSLATE_STRICT", ids)
+        self.assertIn("METADATA_TRANSLATE", ids)
+        self.assertIn("METADATA_DESC_RETRY", ids)
+
+    def test_info(self):
+        info = get_prompt_info("SUBTITLE_TRANSLATE")
+        self.assertIsNotNone(info)
+        self.assertEqual(info["label"], "字幕翻译主提示词")
+        self.assertFalse(info["is_advanced"])
+
+    def test_strict_is_advanced(self):
+        info = get_prompt_info("SUBTITLE_TRANSLATE_STRICT")
+        self.assertTrue(info["is_advanced"])
+
+    def test_unknown_returns_none(self):
+        self.assertIsNone(get_prompt_info("NONEXISTENT"))
+
+
+class ConfigKeyTests(unittest.TestCase):
+    def test_mode_key(self):
+        self.assertEqual(config_key_for_mode("SUBTITLE_TRANSLATE"), "SUBTITLE_TRANSLATE_MODE")
+
+    def test_text_key(self):
+        self.assertEqual(config_key_for_text("SUBTITLE_TRANSLATE"), "SUBTITLE_TRANSLATE_TEXT")
+
+    def test_default_entries(self):
+        entries = get_default_config_entries()
+        self.assertIn("SUBTITLE_TRANSLATE_MODE", entries)
+        self.assertEqual(entries["SUBTITLE_TRANSLATE_MODE"], MODE_BUILTIN)
+        self.assertIn("SUBTITLE_TRANSLATE_TEXT", entries)
+        self.assertEqual(entries["SUBTITLE_TRANSLATE_TEXT"], "")
+        # 检查 4 组 × 2 = 8 个键
+        self.assertEqual(len(entries), 8)
+
+
+class ReadPromptConfigTests(unittest.TestCase):
+    def test_empty_config(self):
+        mode, text = read_prompt_config_from_app_config({}, "SUBTITLE_TRANSLATE")
+        self.assertEqual(mode, MODE_BUILTIN)
+        self.assertEqual(text, "")
+
+    def test_valid_config(self):
+        app_config = {
+            "SUBTITLE_TRANSLATE_MODE": "append",
+            "SUBTITLE_TRANSLATE_TEXT": "保留术语",
+        }
+        mode, text = read_prompt_config_from_app_config(app_config, "SUBTITLE_TRANSLATE")
+        self.assertEqual(mode, MODE_APPEND)
+        self.assertEqual(text, "保留术语")
+
+    def test_invalid_mode_fallback(self):
+        app_config = {"SUBTITLE_TRANSLATE_MODE": "bad"}
+        mode, _ = read_prompt_config_from_app_config(app_config, "SUBTITLE_TRANSLATE")
+        self.assertEqual(mode, MODE_BUILTIN)
+
+
+class FinalSystemPromptTests(unittest.TestCase):
+    def test_builtin_zh(self):
+        prompt = get_final_system_prompt("SUBTITLE_TRANSLATE", target_language="zh")
+        self.assertIn("简体中文", prompt)
+        self.assertNotIn("{target_language_name}", prompt)
+
+    def test_builtin_en(self):
+        prompt = get_final_system_prompt("SUBTITLE_TRANSLATE", target_language="en")
+        self.assertIn("English", prompt)
+
+    def test_append(self):
+        prompt = get_final_system_prompt(
+            "SUBTITLE_TRANSLATE",
+            mode=MODE_APPEND,
+            user_text="保留术语不翻译",
+            target_language="zh",
+        )
+        self.assertIn("简体中文", prompt)
+        self.assertIn("保留术语不翻译", prompt)
+
+    def test_override(self):
+        prompt = get_final_system_prompt(
+            "SUBTITLE_TRANSLATE",
+            mode=MODE_OVERRIDE,
+            user_text="你是一个特殊的翻译器",
+            target_language="zh",
+        )
+        self.assertEqual(prompt, "你是一个特殊的翻译器")
+
+    def test_override_empty_text_fallback(self):
+        builtin = get_final_system_prompt("SUBTITLE_TRANSLATE", target_language="zh")
+        override_empty = get_final_system_prompt(
+            "SUBTITLE_TRANSLATE",
+            mode=MODE_OVERRIDE,
+            user_text="",
+            target_language="zh",
+        )
+        self.assertEqual(override_empty, builtin)
+
+    def test_variable_rendering(self):
+        prompt = get_final_system_prompt("METADATA_TRANSLATE", target_language="ja")
+        self.assertIn("日本語", prompt)
+        self.assertNotIn("{target_language_name}", prompt)
+
+
+class SubtitlePromptTests(unittest.TestCase):
+    def test_subtitle_system_prompt_has_json(self):
+        prompt = get_subtitle_system_prompt(target_language="zh")
+        self.assertIn('"translations"', prompt)
+        self.assertIn("一一对应", prompt)
+
+    def test_subtitle_strict_prompt(self):
+        prompt = get_subtitle_strict_system_prompt(target_language="zh")
+        self.assertIn("严格模式", prompt)
+        self.assertIn('"translations"', prompt)
+
+    def test_append_preserves_protocol(self):
+        prompt = get_subtitle_system_prompt(
+            mode=MODE_APPEND,
+            user_text="保留音乐术语",
+            target_language="zh",
+        )
+        self.assertIn("一一对应", prompt)
+        self.assertIn('"translations"', prompt)
+        self.assertIn("保留音乐术语", prompt)
+
+
+class MetadataPromptTests(unittest.TestCase):
+    def test_metadata_translate_prompt(self):
+        prompt = get_metadata_translate_prompt(target_language="zh")
+        self.assertIn('"title"', prompt)
+        self.assertIn('"description"', prompt)
+
+    def test_metadata_retry_suffix(self):
+        prompt = get_metadata_translate_prompt(target_language="zh", retry=True)
+        self.assertIn("仅重写本次输入", prompt)
+
+    def test_desc_retry_prompt(self):
+        prompt = get_metadata_desc_retry_prompt(target_language="zh")
+        self.assertIn('"description"', prompt)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_prompt_manager.py
+++ b/tests/test_prompt_manager.py
@@ -87,8 +87,8 @@ class ConfigKeyTests(unittest.TestCase):
         self.assertEqual(entries["SUBTITLE_TRANSLATE_MODE"], MODE_BUILTIN)
         self.assertIn("SUBTITLE_TRANSLATE_TEXT", entries)
         self.assertEqual(entries["SUBTITLE_TRANSLATE_TEXT"], "")
-        # 检查 4 组 × 2 = 8 个键
-        self.assertEqual(len(entries), 8)
+        # 每个 Prompt 注册 2 个键：_MODE + _TEXT
+        self.assertEqual(len(entries), len(get_prompt_ids()) * 2)
 
 
 class ReadPromptConfigTests(unittest.TestCase):


### PR DESCRIPTION
## 概述

实现 Issue #57 中"内容翻译的 Prompt 增加配置页面，方便用户自定义"的诉求。

采用**统一 Prompt 中心**架构，支持 `builtin` / `append` / `override` 三种模式，覆盖字幕翻译与标题/简介翻译两大场景。

## 设计要点

- **协议壳固定不可覆盖**：JSON 输出格式、逐条一一对应、残句边界、不跨条目借用等硬约束始终保留，用户自定义 Prompt 无法破坏
- **三种模式**：
  - `builtin`：使用系统默认模板（推荐大多数用户）
  - `append`：在默认模板后附加用户指令（推荐的自定义方式）
  - `override`：用用户文本替换默认行为层，但协议壳仍保留
- **空值自动回退**：自定义文本为空时自动回退 `builtin` 模式
- **零迁移成本**：新配置键默认空字符串，现有用户升级后行为完全不变

## 覆盖的 4 组 Prompt

| Prompt | 用途 | 配置键 |
|--------|------|--------|
| 字幕翻译主提示词 | 字幕批量翻译时的 system prompt | `SUBTITLE_TRANSLATE_MODE` / `SUBTITLE_TRANSLATE_TEXT` |
| 字幕翻译严格补救提示词 | 漏译补翻时的 system prompt | `SUBTITLE_TRANSLATE_STRICT_MODE` / `SUBTITLE_TRANSLATE_STRICT_TEXT` |
| 标题/简介翻译主提示词 | 元数据翻译时的 system prompt | `METADATA_TRANSLATE_MODE` / `METADATA_TRANSLATE_TEXT` |
| 简介重试提示词 | 简介校验失败时的重试 prompt | `METADATA_DESC_RETRY_MODE` / `METADATA_DESC_RETRY_TEXT` |

## 变更文件

| 文件 | 说明 |
|------|------|
| `modules/prompt_manager.py` | **新增** 统一 Prompt 注册/渲染/回退模块 |
| `modules/config_manager.py` | 注册 8 个新配置键（4 组 × mode + text），模式值标准化 |
| `modules/subtitle_translator.py` | `TranslationConfig` 新增 prompt 字段，`LLMRequester` 委托 `prompt_manager` |
| `modules/ai_enhancer.py` | `_build_metadata_translation_system_prompt` / `_build_description_retry_system_prompt` 委托 `prompt_manager` |
| `modules/task_manager.py` | `_translate_content` 透传 Prompt 配置到 `openai_config` |
| `templates/settings.html` | 新增"提示词" Tab，含模式选择、多行 textarea、内置 Prompt 预览 |
| `app.py` | settings GET 路由传入 `builtin_prompts` 上下文 |
| `tests/test_prompt_manager.py` | **新增** 29 个单元测试 |

## 测试

- 全量 98 个测试通过（含新增 29 个 Prompt 中心测试）
- 覆盖：模式标准化、文本标准化、注册表、配置键映射、builtin/append/override 三种模式、变量渲染、空值回退、协议壳拼装

## UI 预览

设置页新增独立"提示词" Tab，每个 Prompt 卡片包含：
- 模式下拉选择（内置/追加/覆盖）
- 多行自定义指令 textarea（最大 3000 字符）
- 选择"内置"时自动显示当前内置 Prompt 完整内容供参考
- 高级 Prompt（严格补救、简介重试）默认折叠

Closes #57