### PR TITLE
fix: install Deno as yt-dlp JS runtime for YouTube n challenge

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -133,6 +133,18 @@ RUN --mount=type=cache,target=/var/cache/apt,id=y2a-apt-cache-runtime \
     && apt-get clean \
     && useradd --create-home --shell /bin/bash y2a
 
+# 安装 Deno（yt-dlp 的 YouTube n challenge 解密需要 ≥2.3.0 的 JS 运行时）
+# Debian bookworm 的 nodejs 版本（20.x）低于 yt-dlp 要求的最低版本（22.0.0），
+# 因此需要安装 Deno 作为 JS challenge solver 的运行时
+RUN python3 -c "\
+import urllib.request, zipfile, io, os, stat; \
+url = 'https://github.com/denoland/deno/releases/latest/download/deno-x86_64-unknown-linux-gnu.zip'; \
+data = urllib.request.urlopen(url).read(); \
+with zipfile.ZipFile(io.BytesIO(data)) as z: \
+    z.extract('deno', '/usr/local/bin/'); \
+os.chmod('/usr/local/bin/deno', 0o755)" \
+    && deno --version
+
 # 可选：安装 GPU 编码支持库（VAAPI/Intel/AMD），通过 --build-arg ENABLE_GPU_DRIVERS=true 启用
 RUN --mount=type=cache,target=/var/cache/apt,id=y2a-apt-cache-gpu \
     if [ "${ENABLE_GPU_DRIVERS}" = "true" ]; then \

--- a/Dockerfile.nobuildkit
+++ b/Dockerfile.nobuildkit
@@ -126,6 +126,18 @@ RUN rm -f /var/lib/apt/lists/lock /var/lib/dpkg/lock-frontend /var/cache/apt/arc
     && apt-get clean \
     && useradd --create-home --shell /bin/bash y2a
 
+# 安装 Deno（yt-dlp 的 YouTube n challenge 解密需要 ≥2.3.0 的 JS 运行时）
+# Debian bookworm 的 nodejs 版本（20.x）低于 yt-dlp 要求的最低版本（22.0.0），
+# 因此需要安装 Deno 作为 JS challenge solver 的运行时
+RUN python3 -c "\
+import urllib.request, zipfile, io, os, stat; \
+url = 'https://github.com/denoland/deno/releases/latest/download/deno-x86_64-unknown-linux-gnu.zip'; \
+data = urllib.request.urlopen(url).read(); \
+with zipfile.ZipFile(io.BytesIO(data)) as z: \
+    z.extract('deno', '/usr/local/bin/'); \
+os.chmod('/usr/local/bin/deno', 0o755)" \
+    && deno --version
+
 # 从构建阶段复制 Python 包
 COPY --from=builder /root/.local /home/y2a/.local
 


### PR DESCRIPTION
## 问题

yt-dlp 下载 YouTube 视频时失败，报错：
```
ERROR: [youtube] xxx: Requested format is not available. Use --list-formats for a list of available formats
```

### 根因

yt-dlp 需要 JS 运行时来解密 YouTube 的 n challenge，否则只能看到 storyboard 图片，拿不到真正的视频/音频格式。

- yt-dlp 要求 **Node.js ≥ 22.0.0** 或 **Deno ≥ 2.3.0**
- Debian bookworm-slim 仓库中的 nodejs 是 **20.x**，被 yt-dlp 标记为 `unsupported`
- 容器中没有 Deno

yt-dlp verbose 输出：
```
[debug] JS runtimes: node-20.19.2 (unsupported)
[debug] [youtube] [jsc] JS Challenge Providers: bun (unavailable), deno (unavailable), node (unavailable), quickjs (unavailable)
WARNING: Only images are available for download.
```

## 修复

在两个 Dockerfile 的运行阶段安装 Deno（yt-dlp 推荐的默认 JS 运行时）：

- 使用 Python（base image 自带）下载 Deno 二进制，无需额外安装 curl/wget
- 安装到 `/usr/local/bin/deno`，与现有 `_detect_js_runtime_args()` 代码自动兼容
- 同步修改 `Dockerfile` 和 `Dockerfile.nobuildkit`

修复后 yt-dlp 输出：
```
[debug] JS runtimes: deno-2.8.3
[debug] [youtube] [jsc] JS Challenge Providers: bun (unavailable), deno, node (unavailable), quickjs (unavailable)
[youtube] [jsc:deno] Solving JS challenges using deno
[youtube] [jsc:deno] Downloading challenge solver lib script from https://github.com/yt-dlp/ejs/releases/download/0.8.0/yt.solver.lib.min.js
```