### PR TITLE
Fix settings save and subtitle burn-in warnings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,8 +71,8 @@ RUN set -eux \
     && case "${FFMPEG_VARIANT}" in \
         btbn) \
             case "$arch" in \
-                amd64|x86_64) ffmpeg_url="https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linux64-gpl.tar.xz" ;; \
-                arm64|aarch64) ffmpeg_url="https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linuxarm64-gpl.tar.xz" ;; \
+                amd64|x86_64) ffmpeg_url="https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-n8.1-latest-linux64-gpl-8.1.tar.xz" ;; \
+                arm64|aarch64) ffmpeg_url="https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-n8.1-latest-linuxarm64-gpl-8.1.tar.xz" ;; \
                 *) echo "FFMPEG_VARIANT=btbn is not available for $arch" >&2 && exit 1 ;; \
             esac ;; \
         static) \

--- a/Dockerfile.nobuildkit
+++ b/Dockerfile.nobuildkit
@@ -68,8 +68,8 @@ RUN set -eux \
     && case "${FFMPEG_VARIANT}" in \
         btbn) \
             case "$arch" in \
-                amd64|x86_64) ffmpeg_url="https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linux64-gpl.tar.xz" ;; \
-                arm64|aarch64) ffmpeg_url="https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linuxarm64-gpl.tar.xz" ;; \
+                amd64|x86_64) ffmpeg_url="https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-n8.1-latest-linux64-gpl-8.1.tar.xz" ;; \
+                arm64|aarch64) ffmpeg_url="https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-n8.1-latest-linuxarm64-gpl-8.1.tar.xz" ;; \
                 *) echo "FFMPEG_VARIANT=btbn is not available for $arch" >&2 && exit 1 ;; \
             esac ;; \
         static) \

--- a/modules/asr_api_client.py
+++ b/modules/asr_api_client.py
@@ -223,7 +223,7 @@ class AsrApiClient:
 
     def _build_incompatible_error(self) -> RuntimeError:
         return AsrFormatIncompatibleError(
-            "ASR API incompatible: unable to negotiate a supported transcription format."
+            "ASR API 不兼容：无法协商出支持的转录格式。"
         )
 
     def _parse_requested_granularities(self) -> Tuple[str, ...]:

--- a/modules/speech_recognition.py
+++ b/modules/speech_recognition.py
@@ -225,7 +225,7 @@ class SpeechRecognizer:
             self.logger.info("Subtitle range: %.2fs -> %.2fs", cue_dicts[0]['start'], cue_dicts[-1]['end'])
             return output_path
         except Exception as exc:
-            self.last_error_message = self.last_error_message or f"Transcription failed: {exc}"
+            self.last_error_message = self.last_error_message or f"转录失败: {exc}"
             self.logger.exception("Transcription failed")
             return None
         finally:

--- a/modules/task_manager.py
+++ b/modules/task_manager.py
@@ -501,6 +501,8 @@ def _build_task_notification_payload(task, overrides=None) -> dict:
         'video_title_original': str(merged_task.get('video_title_original') or '').strip(),
         'video_title_translated': str(merged_task.get('video_title_translated') or '').strip(),
         'error_message': str(merged_task.get('error_message') or '').strip(),
+        'asr_warning_message': str(merged_task.get('asr_warning_message') or '').strip(),
+        'subtitle_warning_message': str(merged_task.get('subtitle_warning_message') or '').strip(),
         'acfun_uploaded': bool(merged_task.get('acfun_upload_response')),
         'bilibili_uploaded': bool(merged_task.get('bilibili_upload_response')),
     }
@@ -1000,7 +1002,8 @@ def init_db():
         upload_progress TEXT,  -- 上传进度
         acfun_upload_response TEXT,
         bilibili_upload_response TEXT,
-        asr_warning_message TEXT  -- ASR/VAD阶段的非致命警告（如vad_low_coverage），不影响上传流程
+        asr_warning_message TEXT,  -- ASR/VAD阶段的非致命警告（如vad_low_coverage），不影响上传流程
+        subtitle_warning_message TEXT  -- 字幕处理阶段的非致命警告（如烧录失败），不影响上传流程
     )
     ''')
     
@@ -1203,6 +1206,13 @@ def init_db():
             logger.info("数据库升级：添加asr_warning_message字段")
             conn.commit()
 
+        cursor.execute("PRAGMA table_info(tasks)")
+        columns = [row[1] for row in cursor.fetchall()]
+        if 'subtitle_warning_message' not in columns:
+            cursor.execute("ALTER TABLE tasks ADD COLUMN subtitle_warning_message TEXT")
+            logger.info("数据库升级：添加subtitle_warning_message字段")
+            conn.commit()
+
         # 数据迁移：将 error_message 中纯 ASR/VAD 警告 token 挪至 asr_warning_message，清空 error_message
         cursor.execute(
             "SELECT 1 FROM schema_migrations WHERE migration_key = ? LIMIT 1",
@@ -1387,6 +1397,7 @@ def update_task(task_id, silent=False, **kwargs):
         'acfun_upload_response': 'acfun_upload_response = ?',
         'bilibili_upload_response': 'bilibili_upload_response = ?',
         'asr_warning_message': 'asr_warning_message = ?',
+        'subtitle_warning_message': 'subtitle_warning_message = ?',
     }
 
     # 过滤掉不在白名单中的列
@@ -3093,7 +3104,8 @@ class TaskProcessor:
                             video_path_local=embedded_video_path,
                             subtitle_path_original=subtitle_file,
                             subtitle_path_translated=None,
-                            subtitle_language_detected=subtitle_lang
+                            subtitle_language_detected=subtitle_lang,
+                            subtitle_warning_message=None,
                         )
                         task_logger.info("中文字幕烧录完成")
                         return True
@@ -3103,7 +3115,8 @@ class TaskProcessor:
                             task_id,
                             subtitle_path_original=subtitle_file,
                             subtitle_path_translated=None,
-                            subtitle_language_detected=subtitle_lang
+                            subtitle_language_detected=subtitle_lang,
+                            subtitle_warning_message='subtitle_embed_failed',
                         )
                         return False
                 else:
@@ -3182,7 +3195,8 @@ class TaskProcessor:
                             video_path_local=embedded_video_path,
                             subtitle_path_original=subtitle_file,
                             subtitle_path_translated=translated_subtitle_path,
-                            subtitle_language_detected=subtitle_lang
+                            subtitle_language_detected=subtitle_lang,
+                            subtitle_warning_message=None,
                         )
                     else:
                         task_logger.warning("字幕嵌入失败，保留原视频和字幕文件")
@@ -3190,7 +3204,8 @@ class TaskProcessor:
                             task_id,
                             subtitle_path_original=subtitle_file,
                             subtitle_path_translated=translated_subtitle_path,
-                            subtitle_language_detected=subtitle_lang
+                            subtitle_language_detected=subtitle_lang,
+                            subtitle_warning_message='subtitle_embed_failed',
                         )
                 else:
                     # 不嵌入字幕，只保存字幕文件信息
@@ -3376,6 +3391,12 @@ class TaskProcessor:
         'hwupload',
         'A hardware device reference is required to upload frames to.',
         'Failed to configure output pad on Parsed_hwupload',
+        'Driver does not support the required nvenc API version',
+        'The minimum required Nvidia driver for nvenc is',
+        'libamfrt64.so',
+        "failed to load library 'libX11.so.6'",
+        'cannot open shared object file',
+        'Assertion in generated code',
     )
 
     _HW_PROBE_DEFAULT_SIZE = '640x480'
@@ -7250,10 +7271,12 @@ class TaskProcessor:
                         subtitle_path_original=subtitle_path_original,
                         subtitle_path_translated=subtitle_path_translated,
                         subtitle_language_detected=subtitle_language,
+                        subtitle_warning_message=None,
                     )
                     task_logger.info("检测到已存在翻译字幕，仅补做烧录")
                 else:
                     task_logger.warning("复用已有翻译字幕烧录失败，保留原视频继续上传")
+                    update_task(task_id, subtitle_warning_message='subtitle_embed_failed')
                 return get_task(task_id)
 
             if translation_enabled and subtitle_path_original and str(subtitle_language or '').startswith('zh'):
@@ -7271,10 +7294,12 @@ class TaskProcessor:
                         subtitle_path_original=subtitle_path_original,
                         subtitle_path_translated=None,
                         subtitle_language_detected=subtitle_language or 'zh',
+                        subtitle_warning_message=None,
                     )
                     task_logger.info("检测到已存在中文字幕，仅补做烧录")
                 else:
                     task_logger.warning("复用已有中文字幕烧录失败，保留原视频继续上传")
+                    update_task(task_id, subtitle_warning_message='subtitle_embed_failed')
                 return get_task(task_id)
 
             if not translation_enabled and (subtitle_path_original or subtitle_path_translated):

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -31,11 +31,11 @@ document.addEventListener('DOMContentLoaded', function() {
                 newPassword && confirmPassword && newPassword.value !== confirmPassword.value) {
                 event.preventDefault(); // 阻止表单提交
                 if (passwordError) {
-                    passwordError.style.display = 'block';
+                    passwordError.classList.remove('d-none');
                 }
             } else {
                 if (passwordError) {
-                    passwordError.style.display = 'none';
+                    passwordError.classList.add('d-none');
                 }
             }
         });

--- a/templates/partials/task_card.html
+++ b/templates/partials/task_card.html
@@ -121,6 +121,17 @@
                         {% endif %}
                     </div>
                 {% endif %}
+                {% if task.subtitle_warning_message %}
+                    {% set subtitle_w = task.subtitle_warning_message|trim %}
+                    {% if subtitle_w == 'subtitle_embed_failed' %}
+                        {% set subtitle_w_tip = '字幕烧录失败，已保留字幕文件并继续上传原视频' %}
+                    {% else %}
+                        {% set subtitle_w_tip = '字幕处理警告: ' ~ subtitle_w %}
+                    {% endif %}
+                    <div class="mt-1">
+                        <span class="badge bg-warning text-dark" title="{{ subtitle_w_tip }}" data-bs-toggle="tooltip" data-bs-placement="top">字幕烧录异常</span>
+                    </div>
+                {% endif %}
             </div>
         </div>
 

--- a/templates/partials/task_row.html
+++ b/templates/partials/task_row.html
@@ -120,6 +120,15 @@
                     <span class="badge bg-warning text-dark mt-1" title="{{ asr_w_tip }}" data-bs-toggle="tooltip" data-bs-placement="top">字幕异常</span>
                 {% endif %}
             {% endif %}
+            {% if task.subtitle_warning_message %}
+                {% set subtitle_w = task.subtitle_warning_message|trim %}
+                {% if subtitle_w == 'subtitle_embed_failed' %}
+                    {% set subtitle_w_tip = '字幕烧录失败，已保留字幕文件并继续上传原视频' %}
+                {% else %}
+                    {% set subtitle_w_tip = '字幕处理警告: ' ~ subtitle_w %}
+                {% endif %}
+                <span class="badge bg-warning text-dark mt-1" title="{{ subtitle_w_tip }}" data-bs-toggle="tooltip" data-bs-placement="top">字幕烧录异常</span>
+            {% endif %}
         </div>
     </td>
     <td>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -1321,7 +1321,7 @@
                                                     <div class="col-md-6">
                                                         <div class="form-group">
                                                             <label for="subtitle-single-line-min-font-scale" class="form-label">单行最小字体缩放（0.5-1.0）</label>
-                                                            <input type="number" id="subtitle-single-line-min-font-scale" name="SUBTITLE_SINGLE_LINE_MIN_FONT_SCALE" value="{{ config.get('SUBTITLE_SINGLE_LINE_MIN_FONT_SCALE', 0.78) }}" min="0.5" max="1.0" step="0.05" class="form-control">
+                                                            <input type="number" id="subtitle-single-line-min-font-scale" name="SUBTITLE_SINGLE_LINE_MIN_FONT_SCALE" value="{{ config.get('SUBTITLE_SINGLE_LINE_MIN_FONT_SCALE', 0.78) }}" min="0.5" max="1.0" step="0.01" class="form-control">
                                                             <p class="help-text mb-0">默认字体放不下时，会尝试缩小到该比例；仍放不下则自动换行。</p>
                                                         </div>
                                                     </div>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -2746,13 +2746,22 @@ document.addEventListener('DOMContentLoaded', function () {
                 return;
             }
 
+            const passwordProtectionCheckbox = document.getElementById('password_protection_enabled');
             const newPasswordField = document.getElementById('new_password');
             const confirmPasswordField = document.getElementById('confirm_password');
             if (
-                newPasswordField
+                passwordProtectionCheckbox
+                && passwordProtectionCheckbox.checked
+                && newPasswordField
                 && confirmPasswordField
                 && newPasswordField.value !== confirmPasswordField.value
             ) {
+                event.preventDefault();
+                showSettingsToast('error', '两次输入的密码不匹配，请修正后再保存。');
+                const passwordError = document.getElementById('password-match-error');
+                if (passwordError) {
+                    passwordError.classList.remove('d-none');
+                }
                 return;
             }
 


### PR DESCRIPTION
## Summary
- Fix intermittent settings save-button failures caused by password validation handling
- Add user-visible subtitle burn-in warnings when subtitle embedding fails but upload continues
- Switch Docker FFmpeg downloads from BtbN master builds to n8.1 builds for NVENC driver compatibility and `-vsync` support

## Validation
- `python -m pytest tests/test_task_manager_delete_task_files.py tests/test_replace_task_cover.py`