### PR TITLE
feat: add tgbot-specific API token auth

### DIFF
--- a/app.py
+++ b/app.py
@@ -1006,8 +1006,13 @@ def _run_settings_save_operation(operation_id: str, form_data: dict, uploads: di
 
 
 TG_BOT_API_TOKEN_PREFIX = 'y2a_tgbot_v1_'
-TG_BOT_API_TOKEN_HASH_PREFIX = 'sha256:'
+TG_BOT_API_TOKEN_HASH_PREFIX = 'pbkdf2_sha256:'
+TG_BOT_API_TOKEN_HASH_ITERATIONS = 260000
 _TG_BOT_API_TOKEN_RANDOM_RE = re.compile(r'^[A-Za-z0-9_-]{32,}$')
+_TG_BOT_UPLOAD_RATE_LIMIT_WINDOW_SECONDS = 60
+_TG_BOT_UPLOAD_RATE_LIMIT_MAX_REQUESTS = 60
+_TG_BOT_UPLOAD_RATE_LIMIT_BUCKETS = {}
+_TG_BOT_UPLOAD_RATE_LIMIT_LOCK = threading.Lock()
 
 
 def _generate_tgbot_api_token() -> str:
@@ -1023,8 +1028,34 @@ def _is_valid_tgbot_api_token_format(token: str | None) -> bool:
 
 
 def _hash_tgbot_api_token(token: str) -> str:
-    digest = hashlib.sha256(token.encode('utf-8')).hexdigest()
-    return f'{TG_BOT_API_TOKEN_HASH_PREFIX}{digest}'
+    salt = secrets.token_urlsafe(16)
+    digest = hashlib.pbkdf2_hmac(
+        'sha256',
+        token.encode('utf-8'),
+        salt.encode('utf-8'),
+        TG_BOT_API_TOKEN_HASH_ITERATIONS,
+    ).hex()
+    return f'{TG_BOT_API_TOKEN_HASH_PREFIX}{TG_BOT_API_TOKEN_HASH_ITERATIONS}${salt}${digest}'
+
+
+def _verify_tgbot_api_token_hash(token: str, stored_hash: str) -> bool:
+    if not stored_hash.startswith(TG_BOT_API_TOKEN_HASH_PREFIX):
+        return False
+    payload = stored_hash[len(TG_BOT_API_TOKEN_HASH_PREFIX):]
+    try:
+        iterations_text, salt, expected_digest = payload.split('$', 2)
+        iterations = int(iterations_text)
+    except (TypeError, ValueError):
+        return False
+    if iterations < 1 or not salt or not expected_digest:
+        return False
+    actual_digest = hashlib.pbkdf2_hmac(
+        'sha256',
+        token.encode('utf-8'),
+        salt.encode('utf-8'),
+        iterations,
+    ).hex()
+    return secrets.compare_digest(expected_digest, actual_digest)
 
 
 def _extract_bearer_token() -> str:
@@ -1040,9 +1071,7 @@ def _verify_tgbot_api_token(token: str, config: dict | None = None) -> bool:
         return False
     effective_config = config if isinstance(config, dict) else load_config()
     stored_hash = str(effective_config.get('TG_BOT_API_TOKEN_HASH') or '').strip()
-    if not stored_hash.startswith(TG_BOT_API_TOKEN_HASH_PREFIX):
-        return False
-    return secrets.compare_digest(stored_hash, _hash_tgbot_api_token(token))
+    return _verify_tgbot_api_token_hash(token, stored_hash)
 
 
 def _tgbot_api_token_state(config: dict | None = None) -> dict:
@@ -1067,7 +1096,30 @@ def _validate_tgbot_token_csrf(submitted_token: str | None) -> bool:
     expected = session.get('tgbot_token_csrf')
     if not isinstance(expected, str) or not expected:
         return False
-    return secrets.compare_digest(expected, str(submitted_token or ''))
+    if not secrets.compare_digest(expected, str(submitted_token or '')):
+        return False
+    session.pop('tgbot_token_csrf', None)
+    return True
+
+
+def _is_tgbot_upload_rate_limited() -> bool:
+    client_id = request.remote_addr or 'unknown'
+    now = time.time()
+    window_start = now - _TG_BOT_UPLOAD_RATE_LIMIT_WINDOW_SECONDS
+    with _TG_BOT_UPLOAD_RATE_LIMIT_LOCK:
+        for key in list(_TG_BOT_UPLOAD_RATE_LIMIT_BUCKETS.keys()):
+            _TG_BOT_UPLOAD_RATE_LIMIT_BUCKETS[key] = [
+                timestamp for timestamp in _TG_BOT_UPLOAD_RATE_LIMIT_BUCKETS[key]
+                if timestamp >= window_start
+            ]
+            if not _TG_BOT_UPLOAD_RATE_LIMIT_BUCKETS[key]:
+                del _TG_BOT_UPLOAD_RATE_LIMIT_BUCKETS[key]
+
+        bucket = _TG_BOT_UPLOAD_RATE_LIMIT_BUCKETS.setdefault(client_id, [])
+        if len(bucket) >= _TG_BOT_UPLOAD_RATE_LIMIT_MAX_REQUESTS:
+            return True
+        bucket.append(now)
+        return False
 
 
 def tgbot_upload_token_required(f):
@@ -1075,6 +1127,9 @@ def tgbot_upload_token_required(f):
     def decorated_function(*args, **kwargs):
         if request.method == 'OPTIONS':
             return f(*args, **kwargs)
+
+        if _is_tgbot_upload_rate_limited():
+            return jsonify({'success': False, 'message': '请求过于频繁，请稍后再试。'}), 429
 
         config = load_config()
         if not config.get('TG_BOT_API_TOKEN_HASH'):
@@ -2701,6 +2756,7 @@ def settings_tgbot_token():
             'message': 'Telegram Bot API Token 已生成，旧 Token 已失效。请立即复制保存。',
             'token': token,
             'state': _tgbot_api_token_state(updated_config),
+            'csrf_token': _ensure_tgbot_token_csrf_token(),
         })
 
     if action == 'revoke':
@@ -2713,9 +2769,14 @@ def settings_tgbot_token():
             'success': True,
             'message': 'Telegram Bot API Token 已撤销。',
             'state': _tgbot_api_token_state(updated_config),
+            'csrf_token': _ensure_tgbot_token_csrf_token(),
         })
 
-    return jsonify({'success': False, 'message': '未知的 Token 操作。'}), 400
+    return jsonify({
+        'success': False,
+        'message': '未知的 Token 操作。',
+        'csrf_token': _ensure_tgbot_token_csrf_token(),
+    }), 400
 
 
 @app.route('/settings/save-progress/<operation_id>', methods=['GET'])

--- a/app.py
+++ b/app.py
@@ -3,8 +3,11 @@
 
 import os
 import json
+import hashlib
 import logging
 import mimetypes
+import re
+import secrets
 import shutil
 import time
 import uuid
@@ -1002,6 +1005,92 @@ def _run_settings_save_operation(operation_id: str, form_data: dict, uploads: di
     _finalize_settings_save_operation(operation_id, result)
 
 
+TG_BOT_API_TOKEN_PREFIX = 'y2a_tgbot_v1_'
+TG_BOT_API_TOKEN_HASH_PREFIX = 'sha256:'
+_TG_BOT_API_TOKEN_RANDOM_RE = re.compile(r'^[A-Za-z0-9_-]{32,}$')
+
+
+def _generate_tgbot_api_token() -> str:
+    return f'{TG_BOT_API_TOKEN_PREFIX}{secrets.token_urlsafe(32)}'
+
+
+def _is_valid_tgbot_api_token_format(token: str | None) -> bool:
+    token = str(token or '').strip()
+    if not token.startswith(TG_BOT_API_TOKEN_PREFIX):
+        return False
+    random_part = token[len(TG_BOT_API_TOKEN_PREFIX):]
+    return bool(_TG_BOT_API_TOKEN_RANDOM_RE.fullmatch(random_part))
+
+
+def _hash_tgbot_api_token(token: str) -> str:
+    digest = hashlib.sha256(token.encode('utf-8')).hexdigest()
+    return f'{TG_BOT_API_TOKEN_HASH_PREFIX}{digest}'
+
+
+def _extract_bearer_token() -> str:
+    auth_header = request.headers.get('Authorization') or ''
+    scheme, _, value = auth_header.partition(' ')
+    if scheme.lower() != 'bearer' or not value.strip():
+        return ''
+    return value.strip()
+
+
+def _verify_tgbot_api_token(token: str, config: dict | None = None) -> bool:
+    if not _is_valid_tgbot_api_token_format(token):
+        return False
+    effective_config = config if isinstance(config, dict) else load_config()
+    stored_hash = str(effective_config.get('TG_BOT_API_TOKEN_HASH') or '').strip()
+    if not stored_hash.startswith(TG_BOT_API_TOKEN_HASH_PREFIX):
+        return False
+    return secrets.compare_digest(stored_hash, _hash_tgbot_api_token(token))
+
+
+def _tgbot_api_token_state(config: dict | None = None) -> dict:
+    effective_config = config if isinstance(config, dict) else load_config()
+    token_hash = str(effective_config.get('TG_BOT_API_TOKEN_HASH') or '').strip()
+    return {
+        'configured': bool(token_hash),
+        'created_at': str(effective_config.get('TG_BOT_API_TOKEN_CREATED_AT') or ''),
+        'last4': str(effective_config.get('TG_BOT_API_TOKEN_LAST4') or ''),
+    }
+
+
+def _ensure_tgbot_token_csrf_token() -> str:
+    token = session.get('tgbot_token_csrf')
+    if not isinstance(token, str) or not token:
+        token = secrets.token_urlsafe(32)
+        session['tgbot_token_csrf'] = token
+    return token
+
+
+def _validate_tgbot_token_csrf(submitted_token: str | None) -> bool:
+    expected = session.get('tgbot_token_csrf')
+    if not isinstance(expected, str) or not expected:
+        return False
+    return secrets.compare_digest(expected, str(submitted_token or ''))
+
+
+def tgbot_upload_token_required(f):
+    @wraps(f)
+    def decorated_function(*args, **kwargs):
+        if request.method == 'OPTIONS':
+            return f(*args, **kwargs)
+
+        config = load_config()
+        if not config.get('TG_BOT_API_TOKEN_HASH'):
+            return jsonify({
+                'success': False,
+                'message': 'Telegram Bot API Token 未配置，请先在设置页生成专用 Token。'
+            }), 403
+
+        token = _extract_bearer_token()
+        if not _verify_tgbot_api_token(token, config):
+            return jsonify({'success': False, 'message': 'Telegram Bot API Token 无效或缺失。'}), 401
+
+        return f(*args, **kwargs)
+    return decorated_function
+
+
 # 登录验证装饰器
 def login_required(f):
     @wraps(f)
@@ -1019,7 +1108,7 @@ CORS(app, resources={
     r"/tasks/add_via_extension": {
         "origins": [r"https?://www\.youtube\.com", r"https?://youtube\.com"],
         "methods": ["POST", "OPTIONS"],
-        "allow_headers": ["Content-Type"]
+        "allow_headers": ["Content-Type", "Authorization"]
     }
 })
 
@@ -1852,7 +1941,7 @@ def review_task(task_id):
     return redirect(url_for('edit_task', task_id=task_id))
 
 @app.route('/tasks/add_via_extension', methods=['POST', 'OPTIONS'])
-@login_required
+@tgbot_upload_token_required
 def add_task_via_extension():
     """
     通过浏览器扩展或API添加任务 (JSON格式)
@@ -1878,6 +1967,11 @@ def add_task_via_extension():
         config = load_config()
         if not upload_target:
             upload_target = config.get('UPLOAD_TARGET_DEFAULT', 'acfun')
+        else:
+            upload_target = str(upload_target).strip().lower()
+
+        if upload_target not in ('acfun', 'bilibili', 'both'):
+            return jsonify({'success': False, 'message': '无效的投稿平台参数'}), 400
         
         # 判断是否为播放列表URL
         if 'youtube.com/playlist' in youtube_url or 'youtu.be/playlist' in youtube_url:
@@ -2576,11 +2670,52 @@ def settings():
     return render_template(
         'settings.html',
         config=config,
+        tgbot_token_state=_tgbot_api_token_state(config),
+        tgbot_token_csrf_token=_ensure_tgbot_token_csrf_token(),
         whisper_languages=WHISPER_LANGUAGE_LIST,
         acfun_partition_mapping=acfun_partition_mapping,
         bilibili_partition_mapping=bilibili_partition_mapping,
         builtin_prompts=builtin_prompts,
     )
+
+
+@app.route('/settings/tgbot-token', methods=['POST'])
+@login_required
+def settings_tgbot_token():
+    payload = request.get_json(silent=True) if request.is_json else request.form
+    payload = payload or {}
+    csrf_token = payload.get('csrf_token') or request.headers.get('X-CSRF-Token')
+    if not _validate_tgbot_token_csrf(csrf_token):
+        return jsonify({'success': False, 'message': '安全校验失败，请刷新设置页后重试。'}), 403
+
+    action = str(payload.get('action') or '').strip().lower()
+    if action in ('generate', 'reset'):
+        token = _generate_tgbot_api_token()
+        updated_config = update_config({
+            'TG_BOT_API_TOKEN_HASH': _hash_tgbot_api_token(token),
+            'TG_BOT_API_TOKEN_CREATED_AT': datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
+            'TG_BOT_API_TOKEN_LAST4': token[-4:],
+        })
+        return jsonify({
+            'success': True,
+            'message': 'Telegram Bot API Token 已生成，旧 Token 已失效。请立即复制保存。',
+            'token': token,
+            'state': _tgbot_api_token_state(updated_config),
+        })
+
+    if action == 'revoke':
+        updated_config = update_config({
+            'TG_BOT_API_TOKEN_HASH': '',
+            'TG_BOT_API_TOKEN_CREATED_AT': '',
+            'TG_BOT_API_TOKEN_LAST4': '',
+        })
+        return jsonify({
+            'success': True,
+            'message': 'Telegram Bot API Token 已撤销。',
+            'state': _tgbot_api_token_state(updated_config),
+        })
+
+    return jsonify({'success': False, 'message': '未知的 Token 操作。'}), 400
 
 
 @app.route('/settings/save-progress/<operation_id>', methods=['GET'])

--- a/app.py
+++ b/app.py
@@ -1011,6 +1011,7 @@ TG_BOT_API_TOKEN_HASH_ITERATIONS = 260000
 _TG_BOT_API_TOKEN_RANDOM_RE = re.compile(r'^[A-Za-z0-9_-]{32,}$')
 _TG_BOT_UPLOAD_RATE_LIMIT_WINDOW_SECONDS = 60
 _TG_BOT_UPLOAD_RATE_LIMIT_MAX_REQUESTS = 60
+_TG_BOT_UPLOAD_RATE_LIMIT_MAX_BUCKETS = 10000
 _TG_BOT_UPLOAD_RATE_LIMIT_BUCKETS = {}
 _TG_BOT_UPLOAD_RATE_LIMIT_LOCK = threading.Lock()
 
@@ -1115,10 +1116,27 @@ def _is_tgbot_upload_rate_limited() -> bool:
             if not _TG_BOT_UPLOAD_RATE_LIMIT_BUCKETS[key]:
                 del _TG_BOT_UPLOAD_RATE_LIMIT_BUCKETS[key]
 
+        if len(_TG_BOT_UPLOAD_RATE_LIMIT_BUCKETS) > _TG_BOT_UPLOAD_RATE_LIMIT_MAX_BUCKETS:
+            newest_buckets = sorted(
+                _TG_BOT_UPLOAD_RATE_LIMIT_BUCKETS.items(),
+                key=lambda item: item[1][-1] if item[1] else 0,
+                reverse=True,
+            )[:_TG_BOT_UPLOAD_RATE_LIMIT_MAX_BUCKETS]
+            _TG_BOT_UPLOAD_RATE_LIMIT_BUCKETS.clear()
+            _TG_BOT_UPLOAD_RATE_LIMIT_BUCKETS.update(newest_buckets)
+
         bucket = _TG_BOT_UPLOAD_RATE_LIMIT_BUCKETS.setdefault(client_id, [])
         if len(bucket) >= _TG_BOT_UPLOAD_RATE_LIMIT_MAX_REQUESTS:
             return True
         bucket.append(now)
+        if len(_TG_BOT_UPLOAD_RATE_LIMIT_BUCKETS) > _TG_BOT_UPLOAD_RATE_LIMIT_MAX_BUCKETS:
+            newest_buckets = sorted(
+                _TG_BOT_UPLOAD_RATE_LIMIT_BUCKETS.items(),
+                key=lambda item: item[1][-1] if item[1] else 0,
+                reverse=True,
+            )[:_TG_BOT_UPLOAD_RATE_LIMIT_MAX_BUCKETS]
+            _TG_BOT_UPLOAD_RATE_LIMIT_BUCKETS.clear()
+            _TG_BOT_UPLOAD_RATE_LIMIT_BUCKETS.update(newest_buckets)
         return False
 
 

--- a/modules/config_manager.py
+++ b/modules/config_manager.py
@@ -56,6 +56,9 @@ DEFAULT_CONFIG = {
     "NOTIFY_MESSAGE_PUSHER_CHANNEL": "",
     "password_protection_enabled": False,
     "password": "",
+    "TG_BOT_API_TOKEN_HASH": "",
+    "TG_BOT_API_TOKEN_CREATED_AT": "",
+    "TG_BOT_API_TOKEN_LAST4": "",
     # 登录安全控制
     "LOGIN_MAX_FAILED_ATTEMPTS": 5,  # 达到该失败次数后触发锁定
     "LOGIN_LOCKOUT_MINUTES": 15,     # 被锁定后持续的分钟数

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -2454,6 +2454,9 @@ document.addEventListener('DOMContentLoaded', function () {
                 });
             })
             .then(function (result) {
+                if (result.data.csrf_token) {
+                    tgbotTokenCard.setAttribute('data-token-csrf', result.data.csrf_token);
+                }
                 if (!result.ok || !result.data.success) {
                     throw new Error(result.data.message || 'Token 操作失败');
                 }

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -2037,6 +2037,56 @@
                                         </article>
                                     </div>
 
+                                    <div class="col-12">
+                                        <article class="settings-card" id="tgbot-token-card" data-token-endpoint="{{ url_for('settings_tgbot_token') }}" data-token-csrf="{{ tgbot_token_csrf_token }}">
+                                            <div class="settings-card-header">
+                                                <div>
+                                                    <span class="section-eyebrow">最小权限 API</span>
+                                                    <h4>Telegram Bot API Token</h4>
+                                                </div>
+                                                <span id="tgbot-token-status-badge" class="settings-status-badge {{ 'is-success' if tgbot_token_state.configured else 'is-warning' }}">
+                                                    {{ '已配置' if tgbot_token_state.configured else '未配置' }}
+                                                </span>
+                                            </div>
+                                            <div class="settings-card-body">
+                                                <p class="help-text">
+                                                    该 Token 仅允许调用 <code>/tasks/add_via_extension</code> 提交视频任务，不能访问设置、日志、任务管理或维护接口。
+                                                </p>
+                                                <div class="alert alert-info mb-3">
+                                                    <i class="bi bi-info-circle"></i>
+                                                    明文 Token 只会在生成后显示一次；请复制到 y2a-auto-tgbot 的设置中。生成新 Token 会立即使旧 Token 失效。
+                                                </div>
+                                                <div class="row g-3">
+                                                    <div class="col-md-6">
+                                                        <div class="form-group">
+                                                            <label class="form-label">当前状态</label>
+                                                            <div id="tgbot-token-state-text" class="form-control-plaintext">
+                                                                {% if tgbot_token_state.configured %}
+                                                                    已配置{% if tgbot_token_state.last4 %}，尾号 {{ tgbot_token_state.last4 }}{% endif %}{% if tgbot_token_state.created_at %}，生成于 {{ tgbot_token_state.created_at }}{% endif %}
+                                                                {% else %}
+                                                                    未配置
+                                                                {% endif %}
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                    <div class="col-md-6 d-flex align-items-end gap-2 flex-wrap">
+                                                        <button type="button" id="tgbot-token-generate-btn" class="btn btn-outline-primary">
+                                                            {{ '重置 Token' if tgbot_token_state.configured else '生成 Token' }}
+                                                        </button>
+                                                        <button type="button" id="tgbot-token-revoke-btn" class="btn btn-outline-danger" {% if not tgbot_token_state.configured %}disabled{% endif %}>
+                                                            撤销 Token
+                                                        </button>
+                                                    </div>
+                                                    <div class="col-12 d-none" id="tgbot-token-result-wrap">
+                                                        <label for="tgbot-token-result" class="form-label">新 Token（仅显示一次）</label>
+                                                        <textarea id="tgbot-token-result" class="form-control font-monospace" rows="2" readonly></textarea>
+                                                        <div class="form-text">复制后请妥善保存；刷新页面后无法再次查看明文。</div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </article>
+                                    </div>
+
                                 </div>
                             </section>
                         </div>
@@ -2325,6 +2375,126 @@ document.addEventListener('DOMContentLoaded', function () {
         }, { once: true });
         bootstrap.Toast.getOrCreateInstance(toastEl, { delay: 4500 }).show();
     };
+
+    const tgbotTokenCard = document.getElementById('tgbot-token-card');
+    const tgbotTokenGenerateBtn = document.getElementById('tgbot-token-generate-btn');
+    const tgbotTokenRevokeBtn = document.getElementById('tgbot-token-revoke-btn');
+    const tgbotTokenResultWrap = document.getElementById('tgbot-token-result-wrap');
+    const tgbotTokenResult = document.getElementById('tgbot-token-result');
+    const tgbotTokenStateText = document.getElementById('tgbot-token-state-text');
+    const tgbotTokenStatusBadge = document.getElementById('tgbot-token-status-badge');
+
+    const updateTgbotTokenState = function (state) {
+        const configured = !!(state && state.configured);
+        if (tgbotTokenStatusBadge) {
+            tgbotTokenStatusBadge.textContent = configured ? '已配置' : '未配置';
+            tgbotTokenStatusBadge.classList.toggle('is-success', configured);
+            tgbotTokenStatusBadge.classList.toggle('is-warning', !configured);
+        }
+        if (tgbotTokenStateText) {
+            if (configured) {
+                let text = '已配置';
+                if (state.last4) {
+                    text += '，尾号 ' + state.last4;
+                }
+                if (state.created_at) {
+                    text += '，生成于 ' + state.created_at;
+                }
+                tgbotTokenStateText.textContent = text;
+            } else {
+                tgbotTokenStateText.textContent = '未配置';
+            }
+        }
+        if (tgbotTokenGenerateBtn) {
+            tgbotTokenGenerateBtn.textContent = configured ? '重置 Token' : '生成 Token';
+        }
+        if (tgbotTokenRevokeBtn) {
+            tgbotTokenRevokeBtn.disabled = !configured;
+        }
+    };
+
+    const submitTgbotTokenAction = function (action) {
+        if (!tgbotTokenCard) {
+            return;
+        }
+        const endpoint = tgbotTokenCard.getAttribute('data-token-endpoint');
+        const csrfToken = tgbotTokenCard.getAttribute('data-token-csrf');
+        if (!endpoint || !csrfToken) {
+            showSettingsToast('error', 'Token 管理初始化失败，请刷新页面后重试。');
+            return;
+        }
+        const isGenerate = action === 'generate';
+        const targetButton = isGenerate ? tgbotTokenGenerateBtn : tgbotTokenRevokeBtn;
+        if (targetButton && targetButton.disabled) {
+            return;
+        }
+        if (isGenerate) {
+            if (!confirm('确定要生成新的 Telegram Bot API Token 吗？旧 Token 会立即失效。')) {
+                return;
+            }
+        } else if (!confirm('确定要撤销 Telegram Bot API Token 吗？撤销后 Bot 将无法提交新任务。')) {
+            return;
+        }
+
+        if (targetButton) {
+            targetButton.disabled = true;
+        }
+
+        fetch(endpoint, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Accept': 'application/json'
+            },
+            body: JSON.stringify({ action: action, csrf_token: csrfToken })
+        })
+            .then(function (response) {
+                return response.json().then(function (data) {
+                    return { ok: response.ok, data: data || {} };
+                });
+            })
+            .then(function (result) {
+                if (!result.ok || !result.data.success) {
+                    throw new Error(result.data.message || 'Token 操作失败');
+                }
+                updateTgbotTokenState(result.data.state || {});
+                if (result.data.token && tgbotTokenResult && tgbotTokenResultWrap) {
+                    tgbotTokenResult.value = result.data.token;
+                    tgbotTokenResultWrap.classList.remove('d-none');
+                    tgbotTokenResult.focus();
+                    tgbotTokenResult.select();
+                } else if (tgbotTokenResult && tgbotTokenResultWrap) {
+                    tgbotTokenResult.value = '';
+                    tgbotTokenResultWrap.classList.add('d-none');
+                }
+                showSettingsToast('success', result.data.message || 'Token 操作成功');
+            })
+            .catch(function (error) {
+                showSettingsToast('error', error.message || 'Token 操作失败');
+            })
+            .finally(function () {
+                if (targetButton === tgbotTokenGenerateBtn) {
+                    targetButton.disabled = false;
+                } else if (
+                    targetButton === tgbotTokenRevokeBtn
+                    && tgbotTokenStatusBadge
+                    && tgbotTokenStatusBadge.textContent !== '未配置'
+                ) {
+                    targetButton.disabled = false;
+                }
+            });
+    };
+
+    if (tgbotTokenGenerateBtn) {
+        tgbotTokenGenerateBtn.addEventListener('click', function () {
+            submitTgbotTokenAction('generate');
+        });
+    }
+    if (tgbotTokenRevokeBtn) {
+        tgbotTokenRevokeBtn.addEventListener('click', function () {
+            submitTgbotTokenAction('revoke');
+        });
+    }
 
     const notificationTestEndpoint = '{{ url_for("settings_test_notification") }}';
     document.querySelectorAll('.notify-test-btn').forEach(function (button) {

--- a/tests/test_tgbot_token_auth.py
+++ b/tests/test_tgbot_token_auth.py
@@ -1,0 +1,91 @@
+import ast
+import hashlib
+import pathlib
+import re
+import secrets
+import unittest
+
+
+def _load_token_helpers(*names):
+    app_path = pathlib.Path(__file__).resolve().parents[1] / "app.py"
+    source = app_path.read_text(encoding="utf-8")
+    module_ast = ast.parse(source, filename=str(app_path))
+    requested = set(names)
+    if "_verify_tgbot_api_token" in requested:
+        requested.update({"_is_valid_tgbot_api_token_format", "_hash_tgbot_api_token"})
+
+    selected = []
+    for node in module_ast.body:
+        if isinstance(node, ast.Assign):
+            if any(
+                isinstance(target, ast.Name)
+                and target.id in {
+                    "TG_BOT_API_TOKEN_PREFIX",
+                    "TG_BOT_API_TOKEN_HASH_PREFIX",
+                    "_TG_BOT_API_TOKEN_RANDOM_RE",
+                }
+                for target in node.targets
+            ):
+                selected.append(node)
+        elif isinstance(node, ast.FunctionDef) and node.name in requested:
+            selected.append(node)
+
+    isolated_module = ast.Module(body=selected, type_ignores=[])
+    namespace = {
+        "hashlib": hashlib,
+        "re": re,
+        "secrets": secrets,
+        "load_config": lambda: {},
+    }
+    exec(compile(isolated_module, str(app_path), "exec"), namespace)
+    return [namespace[name] for name in names]
+
+
+class TgbotTokenAuthTests(unittest.TestCase):
+    def test_generated_token_has_expected_format_and_hash(self):
+        generate_token, is_valid_format, hash_token = _load_token_helpers(
+            "_generate_tgbot_api_token",
+            "_is_valid_tgbot_api_token_format",
+            "_hash_tgbot_api_token",
+        )
+
+        token = generate_token()
+        token_hash = hash_token(token)
+
+        self.assertTrue(token.startswith("y2a_tgbot_v1_"))
+        self.assertTrue(is_valid_format(token))
+        self.assertTrue(token_hash.startswith("sha256:"))
+        self.assertNotIn(token, token_hash)
+
+    def test_verify_compares_against_stored_hash(self):
+        generate_token, hash_token, verify_token = _load_token_helpers(
+            "_generate_tgbot_api_token",
+            "_hash_tgbot_api_token",
+            "_verify_tgbot_api_token",
+        )
+
+        token = generate_token()
+        config = {"TG_BOT_API_TOKEN_HASH": hash_token(token)}
+
+        self.assertTrue(verify_token(token, config))
+        self.assertFalse(verify_token(token + "x", config))
+        self.assertFalse(verify_token("not-a-y2a-token", config))
+        self.assertFalse(verify_token(token, {"TG_BOT_API_TOKEN_HASH": ""}))
+
+    def test_token_state_does_not_expose_secret(self):
+        token_state, = _load_token_helpers("_tgbot_api_token_state")
+        state = token_state({
+            "TG_BOT_API_TOKEN_HASH": "sha256:" + "a" * 64,
+            "TG_BOT_API_TOKEN_CREATED_AT": "2026-07-08 12:00:00",
+            "TG_BOT_API_TOKEN_LAST4": "AbCd",
+        })
+
+        self.assertEqual(state, {
+            "configured": True,
+            "created_at": "2026-07-08 12:00:00",
+            "last4": "AbCd",
+        })
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tgbot_token_auth.py
+++ b/tests/test_tgbot_token_auth.py
@@ -4,6 +4,7 @@ import pathlib
 import re
 import secrets
 import unittest
+from functools import wraps
 
 
 def _load_token_helpers(*names):
@@ -12,7 +13,7 @@ def _load_token_helpers(*names):
     module_ast = ast.parse(source, filename=str(app_path))
     requested = set(names)
     if "_verify_tgbot_api_token" in requested:
-        requested.update({"_is_valid_tgbot_api_token_format", "_hash_tgbot_api_token"})
+        requested.update({"_is_valid_tgbot_api_token_format", "_verify_tgbot_api_token_hash"})
 
     selected = []
     for node in module_ast.body:
@@ -22,6 +23,7 @@ def _load_token_helpers(*names):
                 and target.id in {
                     "TG_BOT_API_TOKEN_PREFIX",
                     "TG_BOT_API_TOKEN_HASH_PREFIX",
+                    "TG_BOT_API_TOKEN_HASH_ITERATIONS",
                     "_TG_BOT_API_TOKEN_RANDOM_RE",
                 }
                 for target in node.targets
@@ -35,9 +37,12 @@ def _load_token_helpers(*names):
         "hashlib": hashlib,
         "re": re,
         "secrets": secrets,
+        "wraps": wraps,
         "load_config": lambda: {},
     }
     exec(compile(isolated_module, str(app_path), "exec"), namespace)
+    for name in names:
+        assert name in namespace, f"{name} was not found in app.py"
     return [namespace[name] for name in names]
 
 
@@ -54,8 +59,9 @@ class TgbotTokenAuthTests(unittest.TestCase):
 
         self.assertTrue(token.startswith("y2a_tgbot_v1_"))
         self.assertTrue(is_valid_format(token))
-        self.assertTrue(token_hash.startswith("sha256:"))
+        self.assertTrue(token_hash.startswith("pbkdf2_sha256:"))
         self.assertNotIn(token, token_hash)
+        self.assertNotEqual(hash_token(token), token_hash)
 
     def test_verify_compares_against_stored_hash(self):
         generate_token, hash_token, verify_token = _load_token_helpers(
@@ -72,10 +78,63 @@ class TgbotTokenAuthTests(unittest.TestCase):
         self.assertFalse(verify_token("not-a-y2a-token", config))
         self.assertFalse(verify_token(token, {"TG_BOT_API_TOKEN_HASH": ""}))
 
+    def test_extract_bearer_token_boundaries(self):
+        extract_bearer_token, = _load_token_helpers("_extract_bearer_token")
+
+        class RequestStub:
+            def __init__(self, authorization):
+                self.headers = {"Authorization": authorization}
+
+        cases = [
+            (None, ""),
+            ("", ""),
+            ("Basic abc", ""),
+            ("Bearer", ""),
+            ("Bearer    ", ""),
+            ("Bearer abc", "abc"),
+            ("bearer   abc  ", "abc"),
+        ]
+        for header, expected in cases:
+            with self.subTest(header=header):
+                extract_bearer_token.__globals__["request"] = RequestStub(header)
+                self.assertEqual(extract_bearer_token(), expected)
+
+    def test_upload_token_decorator_handles_auth_states(self):
+        token_required, = _load_token_helpers("tgbot_upload_token_required")
+
+        class RequestStub:
+            method = "POST"
+
+        def jsonify_stub(payload):
+            return payload
+
+        def endpoint():
+            return {"success": True}
+
+        namespace = token_required.__globals__
+        namespace["request"] = RequestStub()
+        namespace["jsonify"] = jsonify_stub
+        namespace["_is_tgbot_upload_rate_limited"] = lambda: False
+        decorated = token_required(endpoint)
+
+        namespace["load_config"] = lambda: {}
+        self.assertEqual(decorated()[1], 403)
+
+        namespace["load_config"] = lambda: {"TG_BOT_API_TOKEN_HASH": "configured"}
+        namespace["_extract_bearer_token"] = lambda: "invalid"
+        namespace["_verify_tgbot_api_token"] = lambda token, config: False
+        self.assertEqual(decorated()[1], 401)
+
+        namespace["_verify_tgbot_api_token"] = lambda token, config: True
+        self.assertEqual(decorated(), {"success": True})
+
+        namespace["_is_tgbot_upload_rate_limited"] = lambda: True
+        self.assertEqual(decorated()[1], 429)
+
     def test_token_state_does_not_expose_secret(self):
         token_state, = _load_token_helpers("_tgbot_api_token_state")
         state = token_state({
-            "TG_BOT_API_TOKEN_HASH": "sha256:" + "a" * 64,
+            "TG_BOT_API_TOKEN_HASH": "pbkdf2_sha256:260000$salt$" + "a" * 64,
             "TG_BOT_API_TOKEN_CREATED_AT": "2026-07-08 12:00:00",
             "TG_BOT_API_TOKEN_LAST4": "AbCd",
         })

--- a/tests/test_tgbot_token_auth.py
+++ b/tests/test_tgbot_token_auth.py
@@ -3,6 +3,7 @@ import hashlib
 import pathlib
 import re
 import secrets
+import threading
 import unittest
 from functools import wraps
 
@@ -25,6 +26,11 @@ def _load_token_helpers(*names):
                     "TG_BOT_API_TOKEN_HASH_PREFIX",
                     "TG_BOT_API_TOKEN_HASH_ITERATIONS",
                     "_TG_BOT_API_TOKEN_RANDOM_RE",
+                    "_TG_BOT_UPLOAD_RATE_LIMIT_WINDOW_SECONDS",
+                    "_TG_BOT_UPLOAD_RATE_LIMIT_MAX_REQUESTS",
+                    "_TG_BOT_UPLOAD_RATE_LIMIT_MAX_BUCKETS",
+                    "_TG_BOT_UPLOAD_RATE_LIMIT_BUCKETS",
+                    "_TG_BOT_UPLOAD_RATE_LIMIT_LOCK",
                 }
                 for target in node.targets
             ):
@@ -37,6 +43,7 @@ def _load_token_helpers(*names):
         "hashlib": hashlib,
         "re": re,
         "secrets": secrets,
+        "threading": threading,
         "wraps": wraps,
         "load_config": lambda: {},
     }
@@ -144,6 +151,34 @@ class TgbotTokenAuthTests(unittest.TestCase):
             "created_at": "2026-07-08 12:00:00",
             "last4": "AbCd",
         })
+
+    def test_upload_rate_limit_buckets_are_bounded(self):
+        rate_limited, = _load_token_helpers("_is_tgbot_upload_rate_limited")
+
+        class RequestStub:
+            remote_addr = "current"
+
+        class TimeStub:
+            @staticmethod
+            def time():
+                return 1000.0
+
+        namespace = rate_limited.__globals__
+        namespace["request"] = RequestStub()
+        namespace["time"] = TimeStub
+        namespace["_TG_BOT_UPLOAD_RATE_LIMIT_MAX_BUCKETS"] = 3
+        buckets = namespace["_TG_BOT_UPLOAD_RATE_LIMIT_BUCKETS"]
+        buckets.clear()
+        buckets.update({
+            "oldest": [990.0],
+            "old": [995.0],
+            "recent": [999.0],
+        })
+
+        self.assertFalse(rate_limited())
+        self.assertLessEqual(len(buckets), 3)
+        self.assertIn("current", buckets)
+        self.assertNotIn("oldest", buckets)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add Telegram Bot-specific API token generation, hashing, verification, and settings UI
- Restrict the token to `POST /tasks/add_via_extension` with Bearer auth
- Add upload target validation and CORS Authorization support

## Validation
- `python -m pytest tests/test_tgbot_token_auth.py`
- Python compile checks
- Editor diagnostics: no errors