### PR TITLE
Fix YouTube format extraction after yt-dlp updates

### DIFF
--- a/modules/youtube_handler.py
+++ b/modules/youtube_handler.py
@@ -63,11 +63,11 @@ def _resolve_safe_cookies_path(cookies_file_path: str, log: logging.Logger | Non
 
 def _detect_js_runtime_args() -> list[str]:
     """检测可供 yt-dlp 使用的 JS runtime。"""
-    for runtime in ('node', 'deno'):
-        runtime_path = _which(runtime)
-        if runtime_path:
-            return ['--js-runtimes', runtime]
-    return []
+    args: list[str] = []
+    for runtime in ('deno', 'node'):
+        if _which(runtime):
+            args.extend(['--js-runtimes', runtime])
+    return args
 
 
 def _get_youtube_runtime_args() -> list[str]:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Keep yt-dlp rolling because extractor fixes are time-sensitive.
-yt-dlp
+yt-dlp[default]
 
 # Web runtime: lock to the current compatible release line for stability.
 flask~=3.1.3

--- a/tests/test_youtube_subtitle_download_options.py
+++ b/tests/test_youtube_subtitle_download_options.py
@@ -1,6 +1,7 @@
 import ast
 import pathlib
 import unittest
+from unittest import mock
 
 
 def _load_function(name):
@@ -43,6 +44,33 @@ class YouTubeSubtitleDownloadOptionsTests(unittest.TestCase):
 
         self.assertIn("--write-auto-subs", args)
         self.assertEqual(args[:-1], ["--write-subs", "--all-subs", "--convert-subs", "srt"])
+
+
+class YouTubeJsRuntimeOptionsTests(unittest.TestCase):
+    def test_prefers_deno_and_keeps_node_as_fallback(self):
+        detect_args = _load_function("_detect_js_runtime_args")
+        detect_args.__globals__["_which"] = mock.Mock(
+            side_effect=lambda runtime: f"/{runtime}" if runtime in {"deno", "node"} else None
+        )
+
+        self.assertEqual(
+            detect_args(),
+            ["--js-runtimes", "deno", "--js-runtimes", "node"],
+        )
+
+    def test_uses_node_when_deno_is_unavailable(self):
+        detect_args = _load_function("_detect_js_runtime_args")
+        detect_args.__globals__["_which"] = mock.Mock(
+            side_effect=lambda runtime: "/node" if runtime == "node" else None
+        )
+
+        self.assertEqual(detect_args(), ["--js-runtimes", "node"])
+
+    def test_returns_no_args_without_a_runtime(self):
+        detect_args = _load_function("_detect_js_runtime_args")
+        detect_args.__globals__["_which"] = mock.Mock(return_value=None)
+
+        self.assertEqual(detect_args(), [])
 
 
 if __name__ == "__main__":

--- a/tests/test_youtube_subtitle_download_options.py
+++ b/tests/test_youtube_subtitle_download_options.py
@@ -58,6 +58,14 @@ class YouTubeJsRuntimeOptionsTests(unittest.TestCase):
             ["--js-runtimes", "deno", "--js-runtimes", "node"],
         )
 
+    def test_uses_deno_when_node_is_unavailable(self):
+        detect_args = _load_function("_detect_js_runtime_args")
+        detect_args.__globals__["_which"] = mock.Mock(
+            side_effect=lambda runtime: "/deno" if runtime == "deno" else None
+        )
+
+        self.assertEqual(detect_args(), ["--js-runtimes", "deno"])
+
     def test_uses_node_when_deno_is_unavailable(self):
         detect_args = _load_function("_detect_js_runtime_args")
         detect_args.__globals__["_which"] = mock.Mock(


### PR DESCRIPTION
## Summary

- prefer Deno for yt-dlp JavaScript challenge solving while retaining Node.js as a fallback
- install yt-dlp's default extras so `yt-dlp-ejs` is available for full YouTube support
- add regression tests for JavaScript runtime selection

## Testing

- `python -m pytest tests/test_youtube_subtitle_download_options.py -q`
- `python -m pytest -q`

Fixes #78