### PR TITLE
fix(asr): 修复 ASR 能力探测将空转录误判为格式不兼容的问题

### DIFF
--- a/modules/asr_api_client.py
+++ b/modules/asr_api_client.py
@@ -104,6 +104,10 @@ class AsrFormatIncompatibleError(RuntimeError):
     pass
 
 
+class AsrRequestError(RuntimeError):
+    pass
+
+
 class ImplausibleAsrResultError(RuntimeError):
     pass
 
@@ -149,13 +153,49 @@ class AsrApiClient:
 
     @staticmethod
     def _is_format_error(exc: Exception) -> bool:
+        if isinstance(exc, AsrRequestError):
+            return False
         err_str = str(exc).lower()
-        return (
-            'response_format' in err_str
-            or 'timestamp_granularities' in err_str
-            or 'unsupported format' in err_str
-            or ('format' in err_str and ('not supported' in err_str or 'invalid' in err_str))
+        status_code = getattr(exc, 'status_code', None)
+        if status_code is None:
+            response = getattr(exc, 'response', None)
+            status_code = getattr(response, 'status_code', None)
+        if status_code is not None and int(status_code) not in (400, 422):
+            return False
+        parameter_markers = (
+            'response_format',
+            'response format',
+            'timestamp_granularities',
+            'timestamp granularities',
+            'unsupported format',
         )
+        rejection_markers = (
+            'unsupported',
+            'not supported',
+            'invalid',
+            'unknown',
+            'unrecognized',
+            'not allowed',
+            'not permitted',
+        )
+        return (
+            'unsupported format' in err_str
+            or (
+                any(marker in err_str for marker in parameter_markers)
+                and any(marker in err_str for marker in rejection_markers)
+            )
+        )
+
+    @staticmethod
+    def _validate_verbose_json_payload(payload: Any) -> Dict[str, Any]:
+        if not isinstance(payload, dict):
+            raise RuntimeError("ASR verbose_json 响应不是 JSON 对象")
+        if payload.get('error'):
+            raise RuntimeError(f"ASR API 返回错误对象: {str(payload['error'])[:300]}")
+        expected_fields = {'text', 'segments', 'words', 'language', 'duration'}
+        if not expected_fields.intersection(payload):
+            raise RuntimeError("ASR verbose_json 响应缺少预期字段")
+        return payload
 
     @staticmethod
     def _text_density_metrics(text: str) -> Tuple[int, int]:
@@ -293,6 +333,7 @@ class AsrApiClient:
         for granularities in self._whisper_granularity_candidates():
             try:
                 # Prefer raw HTTP to preserve segment-level words.
+                raw_exc: Optional[Exception] = None
                 try:
                     payload = self._request_whisper_raw_json(
                         wav_path,
@@ -301,16 +342,27 @@ class AsrApiClient:
                         include_language_hint=include_language_hint,
                         include_prompt=include_prompt,
                     )
-                except Exception:
-                    response = self._request_whisper_response(
-                        wav_path,
-                        model,
-                        'verbose_json',
-                        granularities=granularities,
-                        include_language_hint=include_language_hint,
-                        include_prompt=include_prompt,
-                    )
-                    payload = self._as_dict(response) or {}
+                except Exception as exc:
+                    raw_exc = exc
+                    try:
+                        response = self._request_whisper_response(
+                            wav_path,
+                            model,
+                            'verbose_json',
+                            granularities=granularities,
+                            include_language_hint=include_language_hint,
+                            include_prompt=include_prompt,
+                        )
+                        payload = self._as_dict(response)
+                    except Exception as sdk_exc:
+                        if self._is_format_error(raw_exc) and self._is_format_error(sdk_exc):
+                            raise sdk_exc
+                        raise AsrRequestError(
+                            "ASR verbose_json 请求失败；"
+                            f"raw={type(raw_exc).__name__}: {str(raw_exc)[:300]}; "
+                            f"sdk={type(sdk_exc).__name__}: {str(sdk_exc)[:300]}"
+                        ) from sdk_exc
+                payload = self._validate_verbose_json_payload(payload)
                 result = self._payload_to_transcription_result(
                     payload,
                     provider='whisper',
@@ -319,14 +371,13 @@ class AsrApiClient:
                     window=window,
                     granularities=granularities,
                 )
-                if result.ok:
-                    return _AsrCapabilityProbeResult(
-                        transcription_format='verbose_json',
-                        language_detection_format='verbose_json',
-                        transcription_granularities=granularities,
-                        transcription_result=result,
-                        language_data=payload,
-                    )
+                return _AsrCapabilityProbeResult(
+                    transcription_format='verbose_json',
+                    language_detection_format='verbose_json',
+                    transcription_granularities=granularities,
+                    transcription_result=result,
+                    language_data=payload,
+                )
             except Exception as exc:
                 if self._is_format_error(exc):
                     format_errors.append(exc)
@@ -344,20 +395,19 @@ class AsrApiClient:
                     include_prompt=include_prompt,
                 )
             )
-            if srt_text:
-                return _AsrCapabilityProbeResult(
-                    transcription_format='srt',
-                    language_detection_format='json',
-                    transcription_granularities=tuple(),
-                    transcription_result=AsrTranscriptionResult(
-                        provider='whisper',
-                        response_format='srt',
-                        timestamp_mode='srt',
-                        text=srt_text,
-                        window=window,
-                        failure_token='asr_no_timestamps',
-                    ),
-                )
+            return _AsrCapabilityProbeResult(
+                transcription_format='srt',
+                language_detection_format='json',
+                transcription_granularities=tuple(),
+                transcription_result=AsrTranscriptionResult(
+                    provider='whisper',
+                    response_format='srt',
+                    timestamp_mode='srt',
+                    text=srt_text,
+                    window=window,
+                    failure_token='asr_no_timestamps' if srt_text else 'asr_failed',
+                ),
+            )
         except Exception as exc:
             if self._is_format_error(exc):
                 format_errors.append(exc)
@@ -414,13 +464,27 @@ class AsrApiClient:
             raise
 
         with self._capability_probe_condition:
+            self._capability_cache.transcription_format = probe_result.transcription_format
+            self._capability_cache.language_detection_format = probe_result.language_detection_format
+            self._capability_cache.transcription_granularities = tuple(
+                probe_result.transcription_granularities or ()
+            )
+            self._capability_probe_incompatible = False
             self._capability_probe_in_progress = False
             self._capability_probe_condition.notify_all()
-        self._cache_capabilities(
-            transcription_fmt=probe_result.transcription_format,
-            language_detection_fmt=probe_result.language_detection_format,
-            transcription_granularities=probe_result.transcription_granularities,
-        )
+            signature = (
+                self._capability_cache.transcription_format or '',
+                self._capability_cache.language_detection_format or '',
+                tuple(self._capability_cache.transcription_granularities),
+            )
+            if signature != self._logged_capability_signature:
+                self._logged_capability_signature = signature
+                self.logger.info(
+                    "Cached ASR response mode: format=%s, language_detection=%s, granularity=%s",
+                    signature[0],
+                    signature[1],
+                    ','.join(signature[2]) if signature[2] else 'none',
+                )
         return probe_result
 
     def _request_whisper_response(
@@ -537,7 +601,7 @@ class AsrApiClient:
                     model,
                     window=window,
                 )
-                if probe_result.transcription_result and probe_result.transcription_result.ok:
+                if probe_result.transcription_result is not None:
                     return probe_result.transcription_result
                 result = self._transcribe_with_cached_capabilities(
                     wav_path,

--- a/modules/asr_api_client.py
+++ b/modules/asr_api_client.py
@@ -131,8 +131,46 @@ class AsrApiClient:
         self._logged_capability_signature: Optional[Tuple[str, str, Tuple[str, ...]]] = None
         self._init_client()
 
+    @staticmethod
+    def _normalize_language_code(lang: Any) -> str:
+        value = str(lang or '').strip().lower().replace('_', '-')
+        if not value or value == 'unknown':
+            return ''
+        aliases = {
+            'english': 'en',
+            'chinese': 'zh',
+            'mandarin': 'zh',
+            'cantonese': 'zh',
+            'japanese': 'ja',
+            'korean': 'ko',
+            'spanish': 'es',
+            'french': 'fr',
+            'german': 'de',
+            'italian': 'it',
+            'portuguese': 'pt',
+            'russian': 'ru',
+            'arabic': 'ar',
+            'hindi': 'hi',
+            'dutch': 'nl',
+            'turkish': 'tr',
+            'polish': 'pl',
+            'swedish': 'sv',
+            'indonesian': 'id',
+            'vietnamese': 'vi',
+            'thai': 'th',
+        }
+        if value in aliases:
+            return aliases[value]
+        primary = value.split('-', 1)[0]
+        if len(primary) == 2 and primary.isalpha():
+            return primary
+        return ''
+
     def set_language_hint(self, lang: str):
-        self._language_hint = str(lang or '').strip()
+        normalized = self._normalize_language_code(lang)
+        if lang and not normalized:
+            self.logger.warning("Ignoring unsupported ASR language hint: %s", lang)
+        self._language_hint = normalized
 
     def _init_client(self):
         if not self.config.api_key:
@@ -514,8 +552,8 @@ class AsrApiClient:
             if temperature is not None:
                 params['temperature'] = temperature
             if include_language_hint:
-                language = self._language_hint or self.config.language
-                if language and language.lower() != 'unknown':
+                language = self._language_hint or self._normalize_language_code(self.config.language)
+                if language:
                     params['language'] = language
             if include_prompt:
                 prompt = str(self.config.prompt or '').strip()
@@ -565,8 +603,8 @@ class AsrApiClient:
 
         form_data: List[Tuple[str, str]] = [('model', model), ('response_format', 'verbose_json')]
         if include_language_hint:
-            language = (self._language_hint or self.config.language or '').strip()
-            if language and language.lower() != 'unknown':
+            language = self._language_hint or self._normalize_language_code(self.config.language)
+            if language:
                 form_data.append(('language', language))
         if include_prompt:
             prompt = str(self.config.prompt or '').strip()
@@ -1006,7 +1044,7 @@ class AsrApiClient:
         durations: Dict[str, float] = {}
         first_seen: Dict[str, int] = {}
         for index, (lang, duration_s) in enumerate(detected):
-            normalized_lang = str(lang or '').strip()
+            normalized_lang = self._normalize_language_code(lang)
             if not normalized_lang:
                 continue
             counts[normalized_lang] = counts.get(normalized_lang, 0) + 1

--- a/modules/asr_api_client.py
+++ b/modules/asr_api_client.py
@@ -108,6 +108,12 @@ class AsrRequestError(RuntimeError):
     pass
 
 
+class AsrHttpError(RuntimeError):
+    def __init__(self, status_code: int, response_text: str):
+        self.status_code = int(status_code)
+        super().__init__(f"HTTP {self.status_code}: {response_text[:300]}")
+
+
 class ImplausibleAsrResultError(RuntimeError):
     pass
 
@@ -578,7 +584,7 @@ class AsrApiClient:
                 timeout=max(30.0, float(self.config.request_timeout_s or 300.0)),
             )
         if response.status_code != 200:
-            raise RuntimeError(f"HTTP {response.status_code}: {response.text[:300]}")
+            raise AsrHttpError(response.status_code, response.text)
         payload: Dict[str, Any] = response.json()
         return payload
 
@@ -817,7 +823,7 @@ class AsrApiClient:
                             timeout=max(30.0, float(self.config.request_timeout_s or 300.0)),
                         )
                     if response.status_code != 200:
-                        raise RuntimeError(f"HTTP {response.status_code}: {response.text[:300]}")
+                        raise AsrHttpError(response.status_code, response.text)
                     payload = response.json()
                     result = self._payload_to_transcription_result(
                         payload,

--- a/tests/test_asr_api_client.py
+++ b/tests/test_asr_api_client.py
@@ -24,6 +24,18 @@ class AsrApiClientTests(unittest.TestCase):
 
         self.assertFalse(AsrApiClient._is_format_error(error))
 
+    def test_language_names_are_normalized_to_iso_codes(self):
+        self.assertEqual(AsrApiClient._normalize_language_code('english'), 'en')
+        self.assertEqual(AsrApiClient._normalize_language_code('Chinese'), 'zh')
+        self.assertEqual(AsrApiClient._normalize_language_code('en-US'), 'en')
+        self.assertEqual(AsrApiClient._normalize_language_code('unknown'), '')
+        self.assertEqual(AsrApiClient._normalize_language_code('not-a-language'), '')
+
+    def test_set_language_hint_normalizes_detected_language_name(self):
+        client = AsrApiClient(AsrConfig(api_key=''))
+        client.set_language_hint('english')
+        self.assertEqual(client._language_hint, 'en')
+
     def test_raw_http_errors_preserve_status_for_format_classification(self):
         for status_code in (401, 429, 500):
             with self.subTest(status_code=status_code):

--- a/tests/test_asr_api_client.py
+++ b/tests/test_asr_api_client.py
@@ -1,10 +1,68 @@
 import unittest
+from unittest.mock import Mock
 
-from modules.asr_api_client import AsrApiClient, AsrConfig
+from modules.asr_api_client import AsrApiClient, AsrConfig, AsrFormatIncompatibleError
 from modules.subtitle_pipeline_types import DetectedSpeechWindow
 
 
 class AsrApiClientTests(unittest.TestCase):
+    def test_format_error_requires_parameter_rejection(self):
+        plain_error = RuntimeError('request includes response_format')
+        format_error = RuntimeError('invalid response_format: verbose_json')
+
+        self.assertFalse(AsrApiClient._is_format_error(plain_error))
+        self.assertTrue(AsrApiClient._is_format_error(format_error))
+
+    def test_non_validation_http_error_is_not_format_error(self):
+        error = RuntimeError('invalid response_format')
+        error.status_code = 401
+
+        self.assertFalse(AsrApiClient._is_format_error(error))
+
+    def test_probe_accepts_empty_verbose_json_as_supported_format(self):
+        client = AsrApiClient(AsrConfig(api_key=''))
+        client._request_whisper_raw_json = Mock(return_value={
+            'text': '',
+            'segments': [],
+            'language': 'en',
+            'duration': 1.0,
+        })
+        client._request_whisper_response = Mock()
+
+        probe = client._probe_capabilities('clip.wav', 'whisper-1', window=None)
+
+        self.assertEqual(probe.transcription_format, 'verbose_json')
+        self.assertEqual(probe.transcription_granularities, ('segment', 'word'))
+        self.assertIsNotNone(probe.transcription_result)
+        self.assertFalse(probe.transcription_result.ok)
+        client._request_whisper_response.assert_not_called()
+
+    def test_probe_falls_back_after_explicit_format_rejection(self):
+        client = AsrApiClient(AsrConfig(api_key=''))
+        format_error = RuntimeError('invalid timestamp_granularities')
+        client._request_whisper_raw_json = Mock(side_effect=[
+            format_error,
+            {'text': '', 'segments': [], 'duration': 1.0},
+        ])
+        client._request_whisper_response = Mock(side_effect=[format_error])
+
+        probe = client._probe_capabilities('clip.wav', 'whisper-1', window=None)
+
+        self.assertEqual(probe.transcription_format, 'verbose_json')
+        self.assertEqual(probe.transcription_granularities, ('segment',))
+
+    def test_probe_does_not_treat_error_payload_as_empty_transcription(self):
+        client = AsrApiClient(AsrConfig(api_key=''))
+        client._request_whisper_raw_json = Mock(return_value={
+            'error': {'message': 'model unavailable'},
+        })
+
+        with self.assertRaises(RuntimeError) as context:
+            client._probe_capabilities('clip.wav', 'whisper-1', window=None)
+
+        self.assertNotIsInstance(context.exception, AsrFormatIncompatibleError)
+        self.assertIn('错误对象', str(context.exception))
+
     def test_whisper_granularity_candidates_prefer_word_then_fallback(self):
         client = AsrApiClient(AsrConfig(api_key='', timestamp_granularities='segment,word'))
 

--- a/tests/test_asr_api_client.py
+++ b/tests/test_asr_api_client.py
@@ -1,7 +1,12 @@
 import unittest
 from unittest.mock import Mock
 
-from modules.asr_api_client import AsrApiClient, AsrConfig, AsrFormatIncompatibleError
+from modules.asr_api_client import (
+    AsrApiClient,
+    AsrConfig,
+    AsrFormatIncompatibleError,
+    AsrHttpError,
+)
 from modules.subtitle_pipeline_types import DetectedSpeechWindow
 
 
@@ -18,6 +23,16 @@ class AsrApiClientTests(unittest.TestCase):
         error.status_code = 401
 
         self.assertFalse(AsrApiClient._is_format_error(error))
+
+    def test_raw_http_errors_preserve_status_for_format_classification(self):
+        for status_code in (401, 429, 500):
+            with self.subTest(status_code=status_code):
+                error = AsrHttpError(status_code, 'invalid response_format: verbose_json')
+                self.assertEqual(error.status_code, status_code)
+                self.assertFalse(AsrApiClient._is_format_error(error))
+
+        validation_error = AsrHttpError(400, 'invalid response_format: verbose_json')
+        self.assertTrue(AsrApiClient._is_format_error(validation_error))
 
     def test_probe_accepts_empty_verbose_json_as_supported_format(self):
         client = AsrApiClient(AsrConfig(api_key=''))


### PR DESCRIPTION
## 问题
Docker 运行 whisper-1 时频繁出现：
```text
ASR API 不兼容：无法协商出支持的转录格式。
```

## 根因
能力探测阶段把合法的 empty transcription 当成格式不支持；同时错误分类过宽，把鉴权/限流/模型不存在等错误也吞并成通用格式不兼容。

## 修复
- 合法空转录现在会被识别为格式受支持。
- 收紧 `_is_format_error()`，只有 400/422 参数拒绝才进入格式降级。
- raw HTTP 与 SDK 均失败时保留双方错误信息。
- 拒绝 HTTP 200 但返回 `{"error": ...}` 的异常 payload。
- 原子发布能力缓存，避免并发重复探测。
- 补充回归测试。

## 测试
```text
pytest tests/test_asr_api_client.py tests/test_speech_recognition_config.py -q
16 passed
```