### PR TITLE
Fix portable yt-dlp startup and Cookie paths

### DIFF
--- a/app.py
+++ b/app.py
@@ -680,7 +680,7 @@ def _extract_settings_uploads(files_storage) -> dict:
 
 
 def _persist_settings_uploads(form_data: dict, uploads: dict):
-    cookies_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'cookies')
+    cookies_dir = get_app_subdir('cookies')
     os.makedirs(cookies_dir, exist_ok=True)
 
     file_specs = {
@@ -2892,10 +2892,10 @@ def settings_test_cookiecloud():
             'updated_at': updated_at,
             'status': 'success',
         })
-    except CookieCloudError:
+    except CookieCloudError as exc:
         message = _cookiecloud_operation_error_message('test')
         updated_at = _remember_cookiecloud_sync_result(False, message)
-        logger.warning('CookieCloud 连接测试失败')
+        logger.warning('CookieCloud 连接测试失败（%s）: %s', type(exc).__name__, exc)
         return jsonify({
             'success': False,
             'message': message,
@@ -2936,10 +2936,10 @@ def settings_sync_cookiecloud():
             'updated_at': updated_at,
             'status': 'success',
         })
-    except CookieCloudError:
+    except CookieCloudError as exc:
         message = _cookiecloud_operation_error_message('sync')
         updated_at = _remember_cookiecloud_sync_result(False, message)
-        logger.warning('CookieCloud 立即拉取失败')
+        logger.warning('CookieCloud 立即拉取失败（%s）: %s', type(exc).__name__, exc)
         return jsonify({
             'success': False,
             'message': message,
@@ -3713,7 +3713,7 @@ def sync_cookies():
             return jsonify({'error': 'cookie数据无效'}), 400
         
         # 保存cookie到文件
-        cookies_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'cookies')
+        cookies_dir = get_app_subdir('cookies')
         os.makedirs(cookies_dir, exist_ok=True)
         
         youtube_cookies_path = os.path.join(cookies_dir, 'yt_cookies.txt')
@@ -3757,7 +3757,7 @@ def get_cookie_status():
     提供Cookie状态给浏览器扩展
     """
     try:
-        cookies_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'cookies')
+        cookies_dir = get_app_subdir('cookies')
         youtube_cookies_path = os.path.join(cookies_dir, 'yt_cookies.txt')
         
         status = {

--- a/build-tools/build_exe.py
+++ b/build-tools/build_exe.py
@@ -216,7 +216,7 @@ hiddenimports = [
     'alibabacloud_tea_openapi.models',
     'alibabacloud_tea_util',
     'alibabacloud_tea_util.models',
-] + collect_submodules('cryptography')
+] + collect_submodules('cryptography') + collect_submodules('yt_dlp')
 
 a = Analysis(
     ['setup_app.py'],

--- a/build-tools/setup_app.py
+++ b/build-tools/setup_app.py
@@ -11,6 +11,20 @@ import platform
 import locale
 from pathlib import Path
 
+INTERNAL_YT_DLP_FLAG = '--y2a-internal-yt-dlp'
+
+
+def run_internal_yt_dlp_cli(argv=None):
+    """在冻结程序内提供 yt-dlp CLI 入口，正常启动时返回 None。"""
+    args = list(sys.argv[1:] if argv is None else argv)
+    if not args or args[0] != INTERNAL_YT_DLP_FLAG:
+        return None
+
+    from yt_dlp import main as yt_dlp_main
+
+    result = yt_dlp_main(args[1:])
+    return result if isinstance(result, int) else 0
+
 def setup_chinese_encoding():
     """设置中文编码支持"""
     if platform.system() == "Windows":
@@ -180,6 +194,10 @@ def start_application(app_path, is_frozen):
 
 def main():
     """主函数"""
+    internal_exit_code = run_internal_yt_dlp_cli()
+    if internal_exit_code is not None:
+        return internal_exit_code
+
     print("初始化 Y2A-Auto 应用环境...")
     
     try:
@@ -205,4 +223,4 @@ def main():
         sys.exit(1)
 
 if __name__ == '__main__':
-    main() 
+    sys.exit(main())

--- a/modules/cookiecloud.py
+++ b/modules/cookiecloud.py
@@ -5,11 +5,11 @@ import base64
 import hashlib
 import json
 import os
-import sys
 from typing import Any, Iterable
 from urllib.parse import quote, urlparse, urlunparse
 
 import requests
+from .utils import get_app_root_dir
 from cryptography.hazmat.primitives import padding
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
@@ -52,10 +52,8 @@ class CookieCloudDataError(CookieCloudError):
     """返回数据不符合预期。"""
 
 
-def _get_app_root_dir() -> str:
-    if getattr(sys, 'frozen', False):
-        return os.path.dirname(sys.executable)
-    return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+class CookieCloudWriteError(CookieCloudError):
+    """Cookie 文件写入失败。"""
 
 
 def _as_bool(value: Any) -> bool:
@@ -154,8 +152,16 @@ def fetch_cookiecloud_payload(
     try:
         response = requester.get(request_url, timeout=timeout)
         response.raise_for_status()
+    except requests.Timeout as exc:
+        raise CookieCloudRequestError("CookieCloud 服务请求超时。") from exc
+    except requests.HTTPError as exc:
+        status_code = getattr(getattr(exc, "response", None), "status_code", None)
+        status_label = str(status_code) if status_code is not None else "未知"
+        raise CookieCloudRequestError(f"CookieCloud 服务返回 HTTP {status_label}。") from exc
+    except requests.ConnectionError as exc:
+        raise CookieCloudRequestError("CookieCloud 服务连接失败。") from exc
     except requests.RequestException as exc:
-        raise CookieCloudRequestError("CookieCloud 服务请求失败，请检查服务地址与网络连通性。") from exc
+        raise CookieCloudRequestError("CookieCloud 服务请求失败。") from exc
 
     try:
         payload = response.json()
@@ -423,7 +429,7 @@ def build_youtube_netscape_cookies(cookie_payload: dict[str, Any]) -> tuple[str,
 
 def resolve_cookie_output_path(path_value: Any, default_relative_path: str = DEFAULT_YOUTUBE_COOKIES_PATH) -> str:
     raw_path = _coerce_text(path_value) or default_relative_path
-    app_root = os.path.realpath(_get_app_root_dir())
+    app_root = os.path.realpath(get_app_root_dir())
     resolved = os.path.realpath(raw_path) if os.path.isabs(raw_path) else os.path.realpath(os.path.join(app_root, raw_path))
     try:
         common_path = os.path.commonpath([app_root, resolved])
@@ -435,7 +441,7 @@ def resolve_cookie_output_path(path_value: Any, default_relative_path: str = DEF
 
 
 def make_display_path(path_value: str) -> str:
-    app_root = os.path.realpath(_get_app_root_dir())
+    app_root = os.path.realpath(get_app_root_dir())
     resolved = os.path.realpath(path_value)
     try:
         common_path = os.path.commonpath([app_root, resolved])
@@ -483,9 +489,12 @@ def _write_cookie_file(target_path: str, cookie_text: str) -> None:
     after the user has explicitly opted in via COOKIECLOUD_ALLOW_PLAINTEXT_EXPORT.
     The file uses Netscape cookie format consumed by yt-dlp.
     """
-    os.makedirs(os.path.dirname(target_path), exist_ok=True)
-    with open(target_path, "w", encoding="utf-8", newline="\n") as file_obj:
-        file_obj.write(cookie_text)
+    try:
+        os.makedirs(os.path.dirname(target_path), exist_ok=True)
+        with open(target_path, "w", encoding="utf-8", newline="\n") as file_obj:
+            file_obj.write(cookie_text)
+    except OSError as exc:
+        raise CookieCloudWriteError("CookieCloud Cookies 文件写入失败。") from exc
 
 
 def sync_cookiecloud_to_youtube_file(
@@ -549,5 +558,7 @@ def try_cookiecloud_youtube_sync(
             effective_config, timeout=timeout, session=session,
         )
         return True, result
+    except CookieCloudError as exc:
+        return False, f"{type(exc).__name__}: {exc}"
     except Exception:
-        return False, "CookieCloud 同步失败"
+        return False, "CookieCloud 同步发生未预期错误"

--- a/modules/task_manager.py
+++ b/modules/task_manager.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import os
+import sys
 import time
 import json
 import uuid
@@ -20,7 +21,7 @@ from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.executors.pool import ThreadPoolExecutor as APSchedulerThreadPoolExecutor
 from apscheduler.schedulers.base import SchedulerNotRunningError
 import queue
-from .utils import get_app_subdir
+from .utils import get_app_root_dir, get_app_subdir
 from .ffmpeg_manager import get_ffmpeg_path, get_ffprobe_path
 from .notifications import (
     EVENT_TASK_ADDED,
@@ -426,7 +427,7 @@ def resolve_cookie_file_path(
     if not raw_path:
         return ''
 
-    app_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    app_root = get_app_root_dir()
     resolved_path = raw_path if os.path.isabs(raw_path) else os.path.join(app_root, raw_path)
     resolved_path = os.path.normpath(resolved_path)
 
@@ -458,6 +459,45 @@ def resolve_cookie_file_path(
         return alt_path
 
     return resolved_path
+
+
+def resolve_youtube_cookies_path(config, logger_obj=None):
+    """优先解析配置路径，仅在目标缺失时兼容旧版 Cookie 存放位置。"""
+    target_logger = logger_obj if logger_obj is not None else logger
+    configured_path = str((config or {}).get('YOUTUBE_COOKIES_PATH', 'cookies/yt_cookies.txt') or '').strip()
+    resolved_path = resolve_cookie_file_path(
+        configured_path,
+        'cookies/yt_cookies.txt',
+        service_name='YouTube',
+        logger_obj=target_logger,
+    )
+    if os.path.isfile(resolved_path):
+        return resolved_path
+
+    app_root = get_app_root_dir()
+    file_name = os.path.basename(configured_path or 'yt_cookies.txt')
+    legacy_candidates = [os.path.join(app_root, 'config', file_name)]
+    if getattr(sys, 'frozen', False) and configured_path and not os.path.isabs(configured_path):
+        legacy_candidates.append(os.path.join(app_root, '_internal', configured_path))
+
+    normalized_target = os.path.normcase(os.path.normpath(resolved_path))
+    seen = {normalized_target}
+    for candidate in legacy_candidates:
+        normalized_candidate = os.path.normcase(os.path.normpath(candidate))
+        if normalized_candidate in seen:
+            continue
+        seen.add(normalized_candidate)
+        if not os.path.isfile(candidate):
+            continue
+        target_logger.warning(
+            "配置的YouTube Cookies文件不存在，临时回退到旧版路径: %s；"
+            "请重新上传或同步 Cookies 以迁移到配置路径。",
+            candidate,
+        )
+        return candidate
+
+    target_logger.warning("指定的YouTube Cookies文件不存在: %s", resolved_path)
+    return None
 
 
 def _get_task_upload_target(task, fallback=UPLOAD_TARGET_ACFUN):
@@ -2579,19 +2619,7 @@ class TaskProcessor:
 
         _raise_if_cancelled(task_id, task_logger)
         
-        # 获取cookies文件路径，优先使用config目录下的文件
-        cookies_filename = os.path.basename(self.config.get('YOUTUBE_COOKIES_PATH', 'cookies.txt'))
-        # 首先尝试在config目录中查找
-        config_cookies_path = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'config', cookies_filename)
-        if os.path.exists(config_cookies_path):
-            cookies_path = config_cookies_path
-            task_logger.info(f"使用config目录中的cookies文件: {cookies_path}")
-        else:
-            # 如果config目录中不存在，则尝试使用配置中指定的路径
-            cookies_path = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), self.config.get('YOUTUBE_COOKIES_PATH', ''))
-            if not os.path.exists(cookies_path):
-                task_logger.warning(f"指定的YouTube Cookies文件不存在: {cookies_path}")
-                cookies_path = None
+        cookies_path = resolve_youtube_cookies_path(self.config, task_logger)
         
         # 验证cookies文件
         if cookies_path:
@@ -2653,19 +2681,7 @@ class TaskProcessor:
 
         _raise_if_cancelled(task_id, task_logger)
         
-        # 获取cookies文件路径，优先使用config目录下的文件
-        cookies_filename = os.path.basename(self.config.get('YOUTUBE_COOKIES_PATH', 'cookies.txt'))
-        # 首先尝试在config目录中查找
-        config_cookies_path = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'config', cookies_filename)
-        if os.path.exists(config_cookies_path):
-            cookies_path = config_cookies_path
-            task_logger.info(f"使用config目录中的cookies文件: {cookies_path}")
-        else:
-            # 如果config目录中不存在，则尝试使用配置中指定的路径
-            cookies_path = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), self.config.get('YOUTUBE_COOKIES_PATH', ''))
-            if not os.path.exists(cookies_path):
-                task_logger.warning(f"指定的YouTube Cookies文件不存在: {cookies_path}")
-                cookies_path = None
+        cookies_path = resolve_youtube_cookies_path(self.config, task_logger)
         
         # 验证cookies文件
         if cookies_path:
@@ -2839,18 +2855,7 @@ class TaskProcessor:
                 youtube_url,
             ]
 
-            project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-            configured_cookies_path = self.config.get('YOUTUBE_COOKIES_PATH', '')
-            cookies_path = None
-            if configured_cookies_path:
-                cookies_filename = os.path.basename(configured_cookies_path)
-                config_cookies_path = os.path.join(project_root, 'config', cookies_filename)
-                if os.path.isfile(config_cookies_path):
-                    cookies_path = config_cookies_path
-                else:
-                    candidate_cookies_path = os.path.join(project_root, configured_cookies_path)
-                    if os.path.isfile(candidate_cookies_path):
-                        cookies_path = candidate_cookies_path
+            cookies_path = resolve_youtube_cookies_path(self.config, task_logger)
 
             if cookies_path:
                 cookies_path = _resolve_safe_cookies_path(cookies_path, task_logger)

--- a/modules/youtube_handler.py
+++ b/modules/youtube_handler.py
@@ -32,6 +32,18 @@ _YOUTUBE_USER_AGENT = (
     'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 '
     '(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
 )
+_INTERNAL_YT_DLP_FLAG = '--y2a-internal-yt-dlp'
+_YT_DLP_UNAVAILABLE_MESSAGE = '本地 yt-dlp 不可用，请重新安装依赖或重新下载完整便携包。'
+
+
+class YtDlpUnavailableError(RuntimeError):
+    """本地 yt-dlp 命令入口不可用。"""
+
+
+def _format_unexpected_download_error(exc: Exception) -> str:
+    if isinstance(exc, YtDlpUnavailableError):
+        return str(exc)
+    return f"下载过程中发生未预期的错误: {exc}"
 
 # 项目根目录，使用工具函数以兼容开发环境和 PyInstaller 打包环境，并使用 realpath 解析符号链接
 _BASE_DIR = os.path.realpath(get_app_root_dir())
@@ -258,14 +270,20 @@ def _summarize_yt_dlp_error(stdout_text: str | None, stderr_text: str | None) ->
 
 
 def _find_yt_dlp_command(log: logging.Logger) -> list[str]:
-    """解析 yt-dlp 调用命令，优先使用当前解释器 python -m yt_dlp。"""
+    """解析 yt-dlp 调用命令，冻结环境优先使用主程序内置入口。"""
     log.info("开始查找yt-dlp执行命令...")
 
     current_python = sys.executable
     if current_python:
+        if getattr(sys, 'frozen', False):
+            current_command = [current_python, _INTERNAL_YT_DLP_FLAG]
+            command_label = f"冻结程序内置yt-dlp: {current_python} {_INTERNAL_YT_DLP_FLAG}"
+        else:
+            current_command = [current_python, '-m', 'yt_dlp']
+            command_label = f"当前Python解释器调用yt-dlp: {current_python} -m yt_dlp"
         try:
             result = subprocess.run(
-                [current_python, '-m', 'yt_dlp', '--version'],
+                [*current_command, '--version'],
                 capture_output=True,
                 text=True,
                 timeout=10,
@@ -273,10 +291,10 @@ def _find_yt_dlp_command(log: logging.Logger) -> list[str]:
                 errors='replace'
             )
             if result.returncode == 0:
-                log.info(f"使用当前Python解释器调用yt-dlp: {current_python} -m yt_dlp")
-                return [current_python, '-m', 'yt_dlp']
+                log.info(f"使用{command_label}")
+                return current_command
         except Exception as exc:
-            log.debug(f"验证当前Python解释器中的yt-dlp失败: {exc}")
+            log.debug(f"验证{command_label}失败: {exc}")
 
     found = _which('yt-dlp')
     if found:
@@ -299,8 +317,8 @@ def _find_yt_dlp_command(log: logging.Logger) -> list[str]:
             log.info(f"回退到虚拟环境中的yt-dlp.exe: {venv_path}")
             return [venv_path]
 
-    log.info("未找到显式yt-dlp路径，回退到PATH中的yt-dlp")
-    return ['yt-dlp']
+    log.error(_YT_DLP_UNAVAILABLE_MESSAGE)
+    raise YtDlpUnavailableError(_YT_DLP_UNAVAILABLE_MESSAGE)
 
 
 def is_docker_env() -> bool:
@@ -534,6 +552,9 @@ def test_video_availability(youtube_url, yt_dlp_cmd, cookies_path=None, logger=N
                 time.sleep(2)
                 continue
             return False, None, last_error
+        except FileNotFoundError as exc:
+            logger.error(_YT_DLP_UNAVAILABLE_MESSAGE)
+            raise YtDlpUnavailableError(_YT_DLP_UNAVAILABLE_MESSAGE) from exc
         except Exception as e:
             last_error = str(e)
             logger.error(f"格式检查出错: {last_error}")
@@ -625,7 +646,7 @@ def download_video_data(youtube_url, task_id=None, cookies_file_path=None, skip_
                     else:
                         logger.warning("CookieCloud同步成功但未生成有效的cookie文件")
                 else:
-                    logger.warning("CookieCloud同步失败")
+                    logger.warning("CookieCloud同步失败: %s", sync_info)
             if not available:
                 logger.error("视频不可用或无法访问")
                 return False, "视频不可用或无法访问"
@@ -898,9 +919,9 @@ def download_video_data(youtube_url, task_id=None, cookies_file_path=None, skip_
                                 else:
                                     logger.warning("CookieCloud同步成功但未生成有效的cookie文件")
                             else:
-                                logger.warning("CookieCloud同步失败")
+                                logger.warning("CookieCloud同步失败: %s", sync_info)
                         except Exception as cc_exc:
-                            logger.warning(f"CookieCloud刷新Cookie时出错: {cc_exc}")
+                            logger.warning("CookieCloud刷新Cookie时发生未预期错误: %s", type(cc_exc).__name__)
 
                 if "The page needs to be reloaded." in combined_error:
                     if attempt < max_retries - 1 and '--cookies' in cmd:
@@ -970,6 +991,10 @@ def download_video_data(youtube_url, task_id=None, cookies_file_path=None, skip_
                     return False, error_msg
                 time.sleep(3)  # 超时后等待更长时间
                 continue
+
+            except FileNotFoundError as exc:
+                logger.error(_YT_DLP_UNAVAILABLE_MESSAGE)
+                raise YtDlpUnavailableError(_YT_DLP_UNAVAILABLE_MESSAGE) from exc
                 
             except Exception as e:
                 if cancel_event is not None and cancel_event.is_set():
@@ -1077,7 +1102,7 @@ def download_video_data(youtube_url, task_id=None, cookies_file_path=None, skip_
             return False, error_msg
         
     except Exception as e:
-        error_msg = f"下载过程中发生未预期的错误: {str(e)}"
+        error_msg = _format_unexpected_download_error(e)
         logger.error(error_msg)
         return False, error_msg
 

--- a/tests/test_cookie_path_resolution.py
+++ b/tests/test_cookie_path_resolution.py
@@ -1,0 +1,112 @@
+import ast
+import logging
+import os
+import pathlib
+import tempfile
+import unittest
+from unittest import mock
+
+from modules import task_manager
+
+
+class CookiePathResolutionTests(unittest.TestCase):
+    def test_configured_youtube_cookie_path_has_priority_over_legacy_file(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = pathlib.Path(temp_dir)
+            configured = root / "cookies" / "yt_cookies.txt"
+            legacy = root / "config" / "yt_cookies.txt"
+            configured.parent.mkdir(parents=True)
+            legacy.parent.mkdir(parents=True)
+            configured.write_text("configured", encoding="utf-8")
+            legacy.write_text("legacy", encoding="utf-8")
+
+            with mock.patch.object(task_manager, "get_app_root_dir", return_value=temp_dir):
+                resolved = task_manager.resolve_youtube_cookies_path(
+                    {"YOUTUBE_COOKIES_PATH": "cookies/yt_cookies.txt"},
+                    logging.getLogger("test"),
+                )
+
+            self.assertEqual(os.path.normpath(resolved), os.path.normpath(str(configured)))
+
+    def test_legacy_config_cookie_is_used_only_when_configured_path_is_missing(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = pathlib.Path(temp_dir)
+            legacy = root / "config" / "yt_cookies.txt"
+            legacy.parent.mkdir(parents=True)
+            legacy.write_text("legacy", encoding="utf-8")
+            logger = mock.Mock()
+
+            with mock.patch.object(task_manager, "get_app_root_dir", return_value=temp_dir):
+                resolved = task_manager.resolve_youtube_cookies_path(
+                    {"YOUTUBE_COOKIES_PATH": "cookies/yt_cookies.txt"},
+                    logger,
+                )
+
+            self.assertEqual(os.path.normpath(resolved), os.path.normpath(str(legacy)))
+            logger.warning.assert_called_once()
+            self.assertIn("旧版路径", logger.warning.call_args.args[0])
+
+    def test_frozen_internal_cookie_is_supported_as_last_compatibility_fallback(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = pathlib.Path(temp_dir)
+            legacy = root / "_internal" / "cookies" / "yt_cookies.txt"
+            legacy.parent.mkdir(parents=True)
+            legacy.write_text("legacy-internal", encoding="utf-8")
+
+            with mock.patch.object(task_manager, "get_app_root_dir", return_value=temp_dir), mock.patch.object(
+                task_manager.sys, "frozen", True, create=True
+            ):
+                resolved = task_manager.resolve_youtube_cookies_path(
+                    {"YOUTUBE_COOKIES_PATH": "cookies/yt_cookies.txt"},
+                    logging.getLogger("test"),
+                )
+
+            self.assertEqual(os.path.normpath(resolved), os.path.normpath(str(legacy)))
+
+    def test_settings_upload_uses_application_cookie_directory(self):
+        app_path = pathlib.Path(__file__).resolve().parents[1] / "app.py"
+        source = app_path.read_text(encoding="utf-8")
+        module_ast = ast.parse(source, filename=str(app_path))
+        function_node = next(
+            node for node in module_ast.body
+            if isinstance(node, ast.FunctionDef) and node.name == "_persist_settings_uploads"
+        )
+        namespace = {
+            "os": os,
+            "get_app_subdir": lambda name: str(pathlib.Path(self.temp_dir) / name),
+            "logger": mock.Mock(),
+        }
+        exec(
+            compile(ast.Module(body=[function_node], type_ignores=[]), str(app_path), "exec"),
+            namespace,
+        )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            self.temp_dir = temp_dir
+            form_data = {}
+            namespace["_persist_settings_uploads"](
+                form_data,
+                {
+                    "youtube_cookies_file": {
+                        "filename": "cookies.txt",
+                        "content": b"# Netscape HTTP Cookie File\n",
+                    }
+                },
+            )
+
+            expected = pathlib.Path(temp_dir) / "cookies" / "yt_cookies.txt"
+            self.assertTrue(expected.is_file())
+            self.assertEqual(form_data["YOUTUBE_COOKIES_PATH"], "cookies/yt_cookies.txt")
+
+    def test_browser_cookie_endpoints_use_application_cookie_directory(self):
+        app_source = (pathlib.Path(__file__).resolve().parents[1] / "app.py").read_text(encoding="utf-8")
+
+        self.assertGreaterEqual(app_source.count("cookies_dir = get_app_subdir('cookies')"), 3)
+        self.assertNotIn(
+            "cookies_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'cookies')",
+            app_source,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cookiecloud.py
+++ b/tests/test_cookiecloud.py
@@ -5,20 +5,28 @@ import os
 import pathlib
 import shutil
 import unittest
-from unittest.mock import patch
+from unittest.mock import Mock, patch
+
+import requests
 
 from cryptography.hazmat.primitives import padding
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
 from modules.cookiecloud import (
     CookieCloudConfigError,
+    CookieCloudDecryptError,
+    CookieCloudRequestError,
+    CookieCloudWriteError,
     COOKIECLOUD_CRYPTO_AES_128_CBC_FIXED,
     COOKIECLOUD_CRYPTO_LEGACY,
     build_cookiecloud_get_url,
     build_youtube_netscape_cookies,
     decrypt_cookiecloud_payload,
+    fetch_cookiecloud_payload,
     resolve_cookie_output_path,
     sync_cookiecloud_to_youtube_file,
+    try_cookiecloud_youtube_sync,
+    _write_cookie_file,
 )
 
 
@@ -384,6 +392,67 @@ class CookieCloudTests(unittest.TestCase):
         self.assertTrue(self.sync_absolute_path.exists())
         written = self.sync_absolute_path.read_text(encoding="utf-8")
         self.assertIn("SAPISID", written)
+
+    def test_fetch_cookiecloud_payload_classifies_timeout_without_leaking_credentials(self):
+        session = Mock()
+        session.get.side_effect = requests.Timeout(
+            f"https://cookiecloud.example.com/get/{TEST_CC_USER}?password={TEST_CC_KEY}"
+        )
+
+        with self.assertRaisesRegex(CookieCloudRequestError, "请求超时") as raised:
+            fetch_cookiecloud_payload(
+                "https://cookiecloud.example.com",
+                TEST_CC_USER,
+                session=session,
+            )
+
+        message = str(raised.exception)
+        self.assertNotIn(TEST_CC_USER, message)
+        self.assertNotIn(TEST_CC_KEY, message)
+        self.assertNotIn("cookiecloud.example.com", message)
+
+    def test_fetch_cookiecloud_payload_reports_http_status_only(self):
+        response = requests.Response()
+        response.status_code = 404
+        session = Mock()
+        session.get.side_effect = requests.HTTPError(
+            f"404 for https://cookiecloud.example.com/get/{TEST_CC_USER}",
+            response=response,
+        )
+
+        with self.assertRaisesRegex(CookieCloudRequestError, "HTTP 404") as raised:
+            fetch_cookiecloud_payload(
+                "https://cookiecloud.example.com",
+                TEST_CC_USER,
+                session=session,
+            )
+
+        self.assertNotIn(TEST_CC_USER, str(raised.exception))
+        self.assertNotIn("cookiecloud.example.com", str(raised.exception))
+
+    def test_try_cookiecloud_sync_returns_safe_typed_reason(self):
+        with patch(
+            "modules.cookiecloud.sync_cookiecloud_to_youtube_file",
+            side_effect=CookieCloudDecryptError("CookieCloud 凭据无效或解密失败。"),
+        ):
+            success, reason = try_cookiecloud_youtube_sync({
+                "COOKIECLOUD_ENABLED": True,
+                "COOKIECLOUD_ALLOW_PLAINTEXT_EXPORT": True,
+                "COOKIECLOUD_UUID": TEST_CC_USER,
+                "COOKIECLOUD_PASSWORD": TEST_CC_KEY,
+            })
+
+        self.assertFalse(success)
+        self.assertIn("CookieCloudDecryptError", reason)
+        self.assertNotIn(TEST_CC_USER, reason)
+        self.assertNotIn(TEST_CC_KEY, reason)
+
+    def test_cookie_file_write_wraps_os_errors(self):
+        with patch("builtins.open", side_effect=PermissionError("sensitive local path")):
+            with self.assertRaisesRegex(CookieCloudWriteError, "文件写入失败") as raised:
+                _write_cookie_file(str(self.sync_absolute_path), "cookie-content")
+
+        self.assertNotIn("sensitive local path", str(raised.exception))
 
 
 if __name__ == "__main__":

--- a/tests/test_youtube_runtime_entry.py
+++ b/tests/test_youtube_runtime_entry.py
@@ -1,0 +1,116 @@
+import importlib.util
+import logging
+import pathlib
+import subprocess
+import sys
+import tempfile
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from modules import youtube_handler
+
+
+class YouTubeRuntimeEntryTests(unittest.TestCase):
+    def test_find_command_uses_python_module_in_development(self):
+        completed = subprocess.CompletedProcess([], 0, stdout="2026.07.15", stderr="")
+        with mock.patch.object(youtube_handler.sys, "frozen", False, create=True), mock.patch.object(
+            youtube_handler.sys, "executable", "python.exe"
+        ), mock.patch.object(youtube_handler.subprocess, "run", return_value=completed) as run_mock:
+            command = youtube_handler._find_yt_dlp_command(logging.getLogger("test"))
+
+        self.assertEqual(command, ["python.exe", "-m", "yt_dlp"])
+        self.assertEqual(run_mock.call_args.args[0], ["python.exe", "-m", "yt_dlp", "--version"])
+
+    def test_find_command_uses_internal_cli_when_frozen(self):
+        completed = subprocess.CompletedProcess([], 0, stdout="2026.07.15", stderr="")
+        with mock.patch.object(youtube_handler.sys, "frozen", True, create=True), mock.patch.object(
+            youtube_handler.sys, "executable", "Y2A-Auto.exe"
+        ), mock.patch.object(youtube_handler.subprocess, "run", return_value=completed) as run_mock:
+            command = youtube_handler._find_yt_dlp_command(logging.getLogger("test"))
+
+        self.assertEqual(
+            command,
+            ["Y2A-Auto.exe", youtube_handler._INTERNAL_YT_DLP_FLAG],
+        )
+        self.assertEqual(
+            run_mock.call_args.args[0],
+            ["Y2A-Auto.exe", youtube_handler._INTERNAL_YT_DLP_FLAG, "--version"],
+        )
+
+    def test_find_command_raises_when_all_entries_are_missing(self):
+        failed = subprocess.CompletedProcess([], 1, stdout="", stderr="missing")
+        with mock.patch.object(youtube_handler.sys, "frozen", False, create=True), mock.patch.object(
+            youtube_handler.sys, "executable", "python.exe"
+        ), mock.patch.object(youtube_handler.subprocess, "run", return_value=failed), mock.patch.object(
+            youtube_handler, "_which", return_value=None
+        ), mock.patch.object(youtube_handler.os.path, "exists", return_value=False):
+            with self.assertRaisesRegex(youtube_handler.YtDlpUnavailableError, "本地 yt-dlp 不可用"):
+                youtube_handler._find_yt_dlp_command(logging.getLogger("test"))
+
+    def test_video_precheck_does_not_retry_missing_executable(self):
+        logger = mock.Mock()
+        with mock.patch.object(youtube_handler, "load_config", return_value={}), mock.patch.object(
+            youtube_handler, "_append_yt_dlp_network_args", side_effect=lambda command, **_: command
+        ), mock.patch.object(
+            youtube_handler.subprocess, "run", side_effect=FileNotFoundError(2, "missing")
+        ) as run_mock:
+            with self.assertRaisesRegex(youtube_handler.YtDlpUnavailableError, "本地 yt-dlp 不可用"):
+                youtube_handler.test_video_availability(
+                    "https://www.youtube.com/watch?v=test",
+                    ["missing-yt-dlp"],
+                    logger=logger,
+                )
+
+        self.assertEqual(run_mock.call_count, 1)
+
+    def test_download_preserves_local_yt_dlp_unavailable_message(self):
+        logger = mock.Mock()
+        with tempfile.TemporaryDirectory() as temp_dir, mock.patch.object(
+            youtube_handler, "get_app_subdir", side_effect=lambda name: str(pathlib.Path(temp_dir) / name)
+        ), mock.patch.object(
+            youtube_handler, "setup_task_logger", return_value=logger
+        ), mock.patch.object(
+            youtube_handler,
+            "_find_yt_dlp_command",
+            side_effect=youtube_handler.YtDlpUnavailableError(
+                youtube_handler._YT_DLP_UNAVAILABLE_MESSAGE
+            ),
+        ):
+            success, error = youtube_handler.download_video_data(
+                "https://www.youtube.com/watch?v=test",
+                task_id="missing-runtime",
+                skip_download=True,
+            )
+
+        self.assertFalse(success)
+        self.assertEqual(error, youtube_handler._YT_DLP_UNAVAILABLE_MESSAGE)
+        self.assertNotIn("视频不可用", error)
+
+    def test_internal_dispatch_only_handles_reserved_flag(self):
+        setup_path = pathlib.Path(__file__).resolve().parents[1] / "build-tools" / "setup_app.py"
+        spec = importlib.util.spec_from_file_location("y2a_setup_app_test", setup_path)
+        module = importlib.util.module_from_spec(spec)
+        assert spec and spec.loader
+        spec.loader.exec_module(module)
+
+        self.assertIsNone(module.run_internal_yt_dlp_cli(["--version"]))
+
+        fake_yt_dlp = SimpleNamespace(main=mock.Mock(return_value=None))
+        with mock.patch.dict(sys.modules, {"yt_dlp": fake_yt_dlp}):
+            exit_code = module.run_internal_yt_dlp_cli(
+                [module.INTERNAL_YT_DLP_FLAG, "--version"]
+            )
+
+        self.assertEqual(exit_code, 0)
+        fake_yt_dlp.main.assert_called_once_with(["--version"])
+
+    def test_pyinstaller_spec_generator_collects_all_yt_dlp_submodules(self):
+        root = pathlib.Path(__file__).resolve().parents[1]
+        generator = (root / "build-tools" / "build_exe.py").read_text(encoding="utf-8")
+
+        self.assertIn("collect_submodules('yt_dlp')", generator)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add an internal `yt-dlp` CLI entry to the PyInstaller executable and collect all required `yt_dlp` submodules
- report missing local `yt-dlp` accurately instead of classifying it as an unavailable YouTube video
- unify Cookie upload, CookieCloud export, browser sync, and task lookup under the portable application root
- prefer the configured YouTube Cookie file while retaining read-only fallback for legacy `config/` and `_internal/` paths
- add safe CookieCloud request/write diagnostics without logging credentials, URLs, or Cookie contents
- add regression coverage for frozen runtime dispatch, Cookie path precedence, legacy fallback, and CookieCloud error sanitization

## Verification

- `263 passed, 10 subtests passed`
- Windows portable build completed successfully
- packaged `Y2A-Auto.exe --y2a-internal-yt-dlp --version` returned `2026.03.17`
- editor diagnostics and `git diff --check` passed

Related to #82