### PR TITLE
Fix Bilibili cookie persistence in portable builds

### DIFF
--- a/app.py
+++ b/app.py
@@ -3029,9 +3029,13 @@ def acfun_qrcode_status(session_id):
 def bilibili_qrcode_start():
     """发起 bilibili 二维码登录并返回二维码图片。"""
     config = load_config()
-    cookie_path = config.get('BILIBILI_COOKIES_PATH', 'cookies/bili_cookies.json')
-    if not os.path.isabs(cookie_path):
-        cookie_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), cookie_path)
+    cookie_path = resolve_cookie_file_path(
+        path_value=config.get('BILIBILI_COOKIES_PATH', 'cookies/bili_cookies.json'),
+        default_relative_path='cookies/bili_cookies.json',
+        service_name='Bilibili',
+        logger_obj=logger,
+        allow_json_txt_fallback=False
+    )
 
     try:
         session_id, qr_session = _create_bilibili_qr_session()
@@ -3057,9 +3061,13 @@ def bilibili_qrcode_status(session_id):
         return jsonify({'success': False, 'message': '二维码会话不存在或已过期'}), 404
 
     config = load_config()
-    cookie_path = config.get('BILIBILI_COOKIES_PATH', 'cookies/bili_cookies.json')
-    if not os.path.isabs(cookie_path):
-        cookie_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), cookie_path)
+    cookie_path = resolve_cookie_file_path(
+        path_value=config.get('BILIBILI_COOKIES_PATH', 'cookies/bili_cookies.json'),
+        default_relative_path='cookies/bili_cookies.json',
+        service_name='Bilibili',
+        logger_obj=logger,
+        allow_json_txt_fallback=False
+    )
 
     try:
         status_data = qr_session.check_status(cookie_file=cookie_path)

--- a/build-tools/build_exe.py
+++ b/build-tools/build_exe.py
@@ -113,7 +113,10 @@ def create_spec_file():
     # 其余内容保持原样（隐藏导入等）
     spec_tail = '''
 
-from PyInstaller.utils.hooks import collect_submodules
+from PyInstaller.utils.hooks import collect_all, collect_submodules
+
+curl_cffi_datas, curl_cffi_binaries, curl_cffi_hiddenimports = collect_all('curl_cffi')
+datas += curl_cffi_datas
 
 # 隐藏导入 - 包含所有可能需要的模块
 hiddenimports = [
@@ -216,12 +219,12 @@ hiddenimports = [
     'alibabacloud_tea_openapi.models',
     'alibabacloud_tea_util',
     'alibabacloud_tea_util.models',
-] + collect_submodules('cryptography') + collect_submodules('yt_dlp')
+] + collect_submodules('cryptography') + collect_submodules('yt_dlp') + curl_cffi_hiddenimports
 
 a = Analysis(
     ['setup_app.py'],
     pathex=[],
-    binaries=[],
+    binaries=curl_cffi_binaries,
     datas=datas,
     hiddenimports=hiddenimports,
     hookspath=[],

--- a/modules/bilibili_auth.py
+++ b/modules/bilibili_auth.py
@@ -175,12 +175,21 @@ def save_credential_to_file(credential: Credential, cookie_file: str) -> bool:
     if not cookie_file:
         return False
 
-    os.makedirs(os.path.dirname(cookie_file) or ".", exist_ok=True)
-
     try:
         cookies = credential.get_cookies()
-    except Exception:
-        cookies = {}
+    except Exception as exc:
+        logger.error("读取 Bilibili 登录 Cookie 失败: %s", exc)
+        return False
+
+    if not isinstance(cookies, dict):
+        logger.error("读取 Bilibili 登录 Cookie 失败: 返回格式无效")
+        return False
+
+    required_keys = ["SESSDATA", "bili_jct", "DedeUserID"]
+    missing_keys = [key for key in required_keys if not str(cookies.get(key) or "").strip()]
+    if missing_keys:
+        logger.error("Bilibili 登录 Cookie 缺少必要字段: %s", ", ".join(missing_keys))
+        return False
 
     ordered_keys = [
         "SESSDATA",
@@ -220,8 +229,13 @@ def save_credential_to_file(credential: Credential, cookie_file: str) -> bool:
             }
         )
 
-    with open(cookie_file, "w", encoding="utf-8") as f:
-        json.dump(cookie_items, f, ensure_ascii=False, indent=2)
+    try:
+        os.makedirs(os.path.dirname(cookie_file) or ".", exist_ok=True)
+        with open(cookie_file, "w", encoding="utf-8") as f:
+            json.dump(cookie_items, f, ensure_ascii=False, indent=2)
+    except (OSError, TypeError, ValueError) as exc:
+        logger.error("保存 Bilibili 登录 Cookie 失败: %s", exc)
+        return False
     return True
 
 
@@ -270,10 +284,20 @@ class BilibiliQrLoginSession:
                 payload["message"] = msg
                 return payload
 
-            if cookie_file:
-                save_credential_to_file(credential, cookie_file)
-                payload["cookies_saved"] = True
-                payload["cookies_path"] = cookie_file
+            if not cookie_file:
+                payload["status"] = "failed"
+                payload["message"] = "Bilibili 登录成功，但未配置 Cookie 保存路径"
+                payload["cookies_saved"] = False
+                return payload
+
+            cookies_saved = save_credential_to_file(credential, cookie_file)
+            payload["cookies_saved"] = cookies_saved
+            if not cookies_saved:
+                payload["status"] = "failed"
+                payload["message"] = "Bilibili 登录成功，但 Cookies 保存失败"
+                return payload
+
+            payload["cookies_path"] = cookie_file
             payload["credential_ok"] = True
 
         return payload

--- a/modules/task_manager.py
+++ b/modules/task_manager.py
@@ -8021,10 +8021,13 @@ class TaskProcessor:
                 except Exception:
                     pass
 
-        bilibili_cookies_path = self.config.get('BILIBILI_COOKIES_PATH', 'cookies/bili_cookies.json')
-        if bilibili_cookies_path and not os.path.isabs(bilibili_cookies_path):
-            app_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-            bilibili_cookies_path = os.path.join(app_root, bilibili_cookies_path)
+        bilibili_cookies_path = resolve_cookie_file_path(
+            path_value=self.config.get('BILIBILI_COOKIES_PATH', 'cookies/bili_cookies.json'),
+            default_relative_path='cookies/bili_cookies.json',
+            service_name='Bilibili',
+            logger_obj=task_logger,
+            allow_json_txt_fallback=False,
+        )
 
         # 固定 bilibili 分区优先；否则使用任务分区。并校验分区合法性
         task_partition_id = _get_task_partition_id(

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -3146,7 +3146,11 @@ document.addEventListener('DOMContentLoaded', function () {
                 } else if (status === 'confirm') {
                     setBiliStatus('等待手机端确认登录', 'neutral');
                 } else if (status === 'done') {
-                    setBiliStatus('登录成功，Cookies 已保存', 'success');
+                    if (data.cookies_saved === true) {
+                        setBiliStatus('登录成功，Cookies 已保存', 'success');
+                    } else {
+                        setBiliStatus(data.message || '登录成功，但 Cookies 保存失败', 'error');
+                    }
                     stopBiliPolling();
                 } else if (status === 'timeout') {
                     setBiliStatus('二维码已过期，请重新获取', 'error');

--- a/tests/test_bilibili_runtime.py
+++ b/tests/test_bilibili_runtime.py
@@ -1,8 +1,10 @@
 import ast
 import importlib
+import json
 import pathlib
 import re
 import sys
+import tempfile
 import types
 import unittest
 from typing import Optional
@@ -10,6 +12,15 @@ from unittest import mock
 
 
 class BilibiliRuntimeTests(unittest.TestCase):
+    def test_pyinstaller_configs_collect_curl_cffi_runtime(self):
+        root = pathlib.Path(__file__).resolve().parents[1]
+        source = (root / "build-tools" / "build_exe.py").read_text(encoding="utf-8")
+
+        self.assertIn("collect_all('curl_cffi')", source)
+        self.assertIn("datas += curl_cffi_datas", source)
+        self.assertIn("binaries=curl_cffi_binaries", source)
+        self.assertIn("+ curl_cffi_hiddenimports", source)
+
     def test_configure_runtime_sets_impersonate_once(self):
         import modules.bilibili_runtime as runtime
 
@@ -59,6 +70,89 @@ class BilibiliRuntimeTests(unittest.TestCase):
         self.assertEqual(cookies["DedeUserID__ckMd5"], "allowed")
         self.assertNotIn("_logger", cookies)
         self.assertNotIn("random_state", cookies)
+
+
+class BilibiliAuthTests(unittest.TestCase):
+    def test_save_credential_writes_required_cookies(self):
+        from modules.bilibili_auth import save_credential_to_file
+
+        credential = mock.Mock()
+        credential.get_cookies.return_value = {
+            "SESSDATA": "sess",
+            "bili_jct": "csrf",
+            "DedeUserID": "123",
+            "buvid3": "buvid",
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cookie_path = pathlib.Path(temp_dir) / "cookies" / "bili_cookies.json"
+
+            self.assertTrue(save_credential_to_file(credential, str(cookie_path)))
+
+            cookie_items = json.loads(cookie_path.read_text(encoding="utf-8"))
+            cookies = {item["name"]: item["value"] for item in cookie_items}
+            self.assertEqual(cookies["SESSDATA"], "sess")
+            self.assertEqual(cookies["bili_jct"], "csrf")
+            self.assertEqual(cookies["DedeUserID"], "123")
+            self.assertEqual(cookies["buvid3"], "buvid")
+
+    def test_save_credential_does_not_write_when_cookie_extraction_fails(self):
+        from modules.bilibili_auth import save_credential_to_file
+
+        credential = mock.Mock()
+        credential.get_cookies.side_effect = RuntimeError("cookie extraction failed")
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cookie_path = pathlib.Path(temp_dir) / "cookies" / "bili_cookies.json"
+
+            self.assertFalse(save_credential_to_file(credential, str(cookie_path)))
+            self.assertFalse(cookie_path.exists())
+
+    def test_save_credential_does_not_overwrite_for_missing_required_cookie(self):
+        from modules.bilibili_auth import save_credential_to_file
+
+        credential = mock.Mock()
+        credential.get_cookies.return_value = {
+            "SESSDATA": "sess",
+            "bili_jct": "csrf",
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cookie_path = pathlib.Path(temp_dir) / "bili_cookies.json"
+            cookie_path.write_text("existing", encoding="utf-8")
+
+            self.assertFalse(save_credential_to_file(credential, str(cookie_path)))
+            self.assertEqual(cookie_path.read_text(encoding="utf-8"), "existing")
+
+    def test_qrcode_done_becomes_failed_when_cookie_save_fails(self):
+        import modules.bilibili_auth as auth
+
+        session = object.__new__(auth.BilibiliQrLoginSession)
+        session.generated = True
+        session.last_state = None
+        session.qr = mock.Mock()
+        credential = mock.Mock()
+        session.qr.get_credential.return_value = credential
+
+        with mock.patch.object(
+            auth,
+            "_run_async",
+            return_value=auth.login_v2.QrCodeLoginEvents.DONE,
+        ), mock.patch.object(
+            auth,
+            "validate_credential_remote",
+            return_value=(True, "ok"),
+        ), mock.patch.object(
+            auth,
+            "save_credential_to_file",
+            return_value=False,
+        ):
+            payload = session.check_status("cookies/bili_cookies.json")
+
+        self.assertEqual(payload["status"], "failed")
+        self.assertFalse(payload["cookies_saved"])
+        self.assertIn("保存失败", payload["message"])
+        self.assertNotIn("credential_ok", payload)
 
 
 class BilibiliUploaderDiagnosticTests(unittest.TestCase):

--- a/tests/test_cookie_path_resolution.py
+++ b/tests/test_cookie_path_resolution.py
@@ -10,6 +10,54 @@ from modules import task_manager
 
 
 class CookiePathResolutionTests(unittest.TestCase):
+    def test_bilibili_cookie_path_uses_application_root(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            expected = pathlib.Path(temp_dir) / "cookies" / "bili_cookies.json"
+
+            with mock.patch.object(task_manager, "get_app_root_dir", return_value=temp_dir):
+                resolved = task_manager.resolve_cookie_file_path(
+                    "cookies/bili_cookies.json",
+                    "cookies/bili_cookies.json",
+                    service_name="Bilibili",
+                )
+
+            self.assertEqual(os.path.normpath(resolved), os.path.normpath(str(expected)))
+
+    def test_bilibili_call_sites_use_shared_cookie_path_resolver(self):
+        root = pathlib.Path(__file__).resolve().parents[1]
+        app_tree = ast.parse((root / "app.py").read_text(encoding="utf-8"))
+        task_manager_tree = ast.parse(
+            (root / "modules" / "task_manager.py").read_text(encoding="utf-8")
+        )
+
+        functions = {
+            node.name: node
+            for tree in (app_tree, task_manager_tree)
+            for node in ast.walk(tree)
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name in {
+                "bilibili_qrcode_start",
+                "bilibili_qrcode_status",
+                "_do_upload_to_bilibili",
+            }
+        }
+
+        self.assertEqual(
+            set(functions),
+            {"bilibili_qrcode_start", "bilibili_qrcode_status", "_do_upload_to_bilibili"},
+        )
+        for function_node in functions.values():
+            called_names = {
+                node.func.id
+                for node in ast.walk(function_node)
+                if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+            }
+            referenced_names = {
+                node.id for node in ast.walk(function_node) if isinstance(node, ast.Name)
+            }
+            self.assertIn("resolve_cookie_file_path", called_names)
+            self.assertNotIn("__file__", referenced_names)
+
     def test_configured_youtube_cookie_path_has_priority_over_legacy_file(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             root = pathlib.Path(temp_dir)


### PR DESCRIPTION
## Summary

- resolve Bilibili QR login and uploader cookie paths from the executable directory in portable builds
- report cookie extraction or write failures instead of displaying a false success state
- package the dynamically loaded `curl_cffi` runtime so Bilibili QR requests work in PyInstaller builds
- add regression coverage for portable paths, cookie persistence, QR status handling, and packaging configuration

## Verification

- `python -m unittest discover -s tests` — 270 tests passed
- rebuilt the Windows portable package successfully
- verified the packaged QR login endpoint returns HTTP 200, a session ID, and a QR image
- verified the returned cookie path targets the executable-level `cookies/bili_cookies.json`

Fixes #84