### PR TITLE
Fix Bilibili chunk upload stalls and progress reporting

### DIFF
--- a/modules/bili_sdk/video_uploader.py
+++ b/modules/bili_sdk/video_uploader.py
@@ -1035,39 +1035,44 @@ class VideoUploader(AsyncEvent):
         total_chunk_count = len(chunk_offset_list)
         # 并发上传分块
         chunk_number = 0
-        # 上传队列
+        # 上传队列仅保存分块参数；单个分块的有限重试由 _upload_chunk 负责。
         chunks_pending = []
         # 缓存 upload_id，这玩意只能从上传的分块预检结果获得
         upload_id = preupload["upload_id"]
         for offset in chunk_offset_list:
-            chunks_pending.insert(
-                0,
-                self._upload_chunk(
-                    page, offset, chunk_number, total_chunk_count, preupload
-                ),
-            )
+            chunks_pending.append((offset, chunk_number))
             chunk_number += 1
+
+        try:
+            threads = max(1, int(preupload.get("threads") or 1))
+        except (TypeError, ValueError):
+            threads = 1
 
         while chunks_pending:
             tasks = []
 
-            while len(tasks) < preupload["threads"] and len(chunks_pending) > 0:
-                tasks.append(create_task(chunks_pending.pop()))
-
-            result = await asyncio.gather(*tasks)
-
-            for r in result:
-                if not r["ok"]:
-                    chunks_pending.insert(
-                        0,
+            while len(tasks) < threads and chunks_pending:
+                offset, chunk_number = chunks_pending.pop(0)
+                tasks.append(
+                    create_task(
                         self._upload_chunk(
                             page,
-                            r["offset"],
-                            r["chunk_number"],
+                            offset,
+                            chunk_number,
                             total_chunk_count,
                             preupload,
-                        ),
+                        )
                     )
+                )
+
+            try:
+                await asyncio.gather(*tasks)
+            except BaseException:
+                for task in tasks:
+                    if not task.done():
+                        task.cancel()
+                await asyncio.gather(*tasks, return_exceptions=True)
+                raise
 
         data = await self._complete_page(page, total_chunk_count, preupload, upload_id)
 
@@ -1118,7 +1123,6 @@ class VideoUploader(AsyncEvent):
             "chunk_number": chunk_number,
             "total_chunk_count": total_chunk_count,
         }
-        self.dispatch(VideoUploaderEvents.PRE_CHUNK.value, chunk_event_callback_data)
         session = get_client()
 
         stream = open(page.path, "rb")
@@ -1129,13 +1133,6 @@ class VideoUploader(AsyncEvent):
         # 上传目标 URL
         preupload = self._switch_upload_endpoint(preupload, self.line)
         url = self._get_upload_url(preupload)
-
-        err_return = {
-            "ok": False,
-            "chunk_number": chunk_number,
-            "offset": offset,
-            "page": page,
-        }
 
         real_chunk_size = len(chunk)
 
@@ -1157,41 +1154,63 @@ class VideoUploader(AsyncEvent):
             "page": page,
         }
 
-        try:
-            resp = await session.request(
-                method="PUT",
-                url=url,
-                data=chunk,  # type: ignore
-                params=params,
-                headers={"x-upos-auth": preupload["auth"]},
-            )
-            if resp.code >= 400:
-                chunk_event_callback_data["info"] = f"Status {resp.code}"
-                self.dispatch(
-                    VideoUploaderEvents.CHUNK_FAILED.value,
-                    chunk_event_callback_data,
+        max_attempts = 3
+        retryable_statuses = {408, 429, 500, 502, 503, 504}
+
+        for attempt in range(1, max_attempts + 1):
+            attempt_data = {
+                **chunk_event_callback_data,
+                "attempt": attempt,
+                "max_attempts": max_attempts,
+            }
+            self.dispatch(VideoUploaderEvents.PRE_CHUNK.value, attempt_data)
+
+            status_code = None
+            try:
+                resp = await session.request(
+                    method="PUT",
+                    url=url,
+                    data=chunk,  # type: ignore
+                    params=params,
+                    headers={"x-upos-auth": preupload["auth"]},
                 )
-                return err_return
+                status_code = resp.code
+                if status_code >= 400:
+                    raise NetworkException(status_code, "上传视频分块失败")
 
-            data = resp.utf8_text()
+                data = resp.utf8_text()
+                if data != "MULTIPART_PUT_SUCCESS" and data != "":
+                    raise ApiException("分块上传响应异常")
 
-            if data != "MULTIPART_PUT_SUCCESS" and data != "":
-                chunk_event_callback_data["info"] = "分块上传失败"
                 self.dispatch(
-                    VideoUploaderEvents.CHUNK_FAILED.value,
-                    chunk_event_callback_data,
+                    VideoUploaderEvents.AFTER_CHUNK.value,
+                    attempt_data,
                 )
-                return err_return
+                return ok_return
+            except CancelledError:
+                raise
+            except Exception as err:
+                retryable = (
+                    not isinstance(err, NetworkException)
+                    or status_code in retryable_statuses
+                )
+                retrying = retryable and attempt < max_attempts
+                retry_delay = min(2 ** (attempt - 1), 8) if retrying else 0
+                failure_data = {
+                    **attempt_data,
+                    "info": str(err),
+                    "err": err,
+                    "status_code": status_code,
+                    "retrying": retrying,
+                    "retry_delay_seconds": retry_delay,
+                }
+                self.dispatch(VideoUploaderEvents.CHUNK_FAILED.value, failure_data)
 
-        except Exception as e:
-            chunk_event_callback_data["info"] = str(e)
-            self.dispatch(
-                VideoUploaderEvents.CHUNK_FAILED.value, chunk_event_callback_data
-            )
-            return err_return
+                if not retrying:
+                    raise
+                await asyncio.sleep(retry_delay)
 
-        self.dispatch(VideoUploaderEvents.AFTER_CHUNK.value, chunk_event_callback_data)
-        return ok_return
+        raise ApiException("分块上传重试耗尽")
 
     async def _complete_page(
         self, page: VideoUploaderPage, chunks: int, preupload: dict, upload_id: str

--- a/modules/bilibili_uploader.py
+++ b/modules/bilibili_uploader.py
@@ -191,6 +191,32 @@ def _bilibili_406_hint() -> str:
     )
 
 
+class _BilibiliChunkProgress:
+    def __init__(self):
+        self._completed = {}
+        self._totals = {}
+
+    def record(self, payload: Any) -> Optional[float]:
+        if not isinstance(payload, dict):
+            return None
+        page = payload.get("page")
+        chunk_number = payload.get("chunk_number")
+        total_chunk_count = payload.get("total_chunk_count")
+        if page is None or not isinstance(chunk_number, int):
+            return None
+        if not isinstance(total_chunk_count, int) or total_chunk_count <= 0:
+            return None
+
+        page_key = id(page)
+        self._totals[page_key] = total_chunk_count
+        self._completed.setdefault(page_key, set()).add(chunk_number)
+        completed = sum(len(chunks) for chunks in self._completed.values())
+        total = sum(self._totals.values())
+        if total <= 0:
+            return None
+        return min(95.0, completed / total * 95.0)
+
+
 class BilibiliUploader:
     """Bilibili uploader based on the internal SDK subset."""
 
@@ -277,8 +303,12 @@ class BilibiliUploader:
                 cover=cover_file_path,
             )
 
-            last_emitted_percent = 0.0
             last_emitted_text = ""
+            chunk_progress = _BilibiliChunkProgress()
+            page_positions = {
+                id(item): index for index, item in enumerate(uploader.pages, 1)
+            }
+            page_count = len(uploader.pages)
 
             def _emit_progress(text: str):
                 nonlocal last_emitted_text
@@ -295,88 +325,87 @@ class BilibiliUploader:
                 except Exception:
                     pass
 
-            def _to_float(value: Any) -> Optional[float]:
-                try:
-                    if value is None:
-                        return None
-                    return float(value)
-                except Exception:
-                    return None
+            def _page_label(data: Any) -> str:
+                page_obj = data.get("page") if isinstance(data, dict) else None
+                page_number = page_positions.get(id(page_obj), 1)
+                return f"第{page_number}/{page_count}P"
 
-            def _extract_progress_percent(payload: Any) -> Optional[float]:
-                if not isinstance(payload, dict):
-                    return None
-
-                candidates = []
-
-                for key in (
-                    "percent",
-                    "progress",
-                    "uploaded_percent",
-                    "upload_percent",
-                ):
-                    value = _to_float(payload.get(key))
-                    if value is None:
-                        continue
-                    if 0.0 <= value <= 1.0:
-                        value *= 100.0
-                    candidates.append(value)
-
-                total_keys = (
-                    "total_chunk_count",
-                    "chunk_count",
-                    "total_chunks",
-                    "chunks_total",
-                )
-                current_keys = (
-                    "chunk_number",
-                    "chunk_index",
-                    "uploaded_chunk_count",
-                    "uploaded_chunks",
-                    "chunk_id",
-                    "current_chunk",
-                )
-
-                totals = [_to_float(payload.get(k)) for k in total_keys]
-                currents = [_to_float(payload.get(k)) for k in current_keys]
-
-                for total in totals:
-                    if total is None or total <= 0:
-                        continue
-                    for current in currents:
-                        if current is None:
-                            continue
-                        candidates.append((current / total) * 100.0)
-                        candidates.append(((current + 1.0) / total) * 100.0)
-
-                normalized = [
-                    max(0.0, min(100.0, value))
-                    for value in candidates
-                    if value is not None
-                ]
-                if not normalized:
-                    return None
-
-                # 优先选择“略大于上一进度”的最小值，兼容 chunk 索引基数差异
-                forward = [value for value in normalized if value > (last_emitted_percent + 0.05)]
-                if forward:
-                    return min(forward)
-                return max(normalized)
+            def _event_error(data: Any) -> str:
+                err = data.get("err") if isinstance(data, dict) else data
+                return _compact_exception_text(str(err)) or "未知错误"
 
             @uploader.on(video_uploader.VideoUploaderEvents.AFTER_CHUNK.value)
             def on_after_chunk(data):
-                nonlocal last_emitted_percent
                 try:
-                    percent = _extract_progress_percent(data)
+                    percent = chunk_progress.record(data)
                     if percent is None:
                         _emit_progress("上传中...")
                         return
-                    if percent < last_emitted_percent:
-                        percent = last_emitted_percent
-                    last_emitted_percent = min(100.0, percent)
-                    _emit_progress(f"{last_emitted_percent:.1f}%")
+                    _emit_progress(f"{percent:.1f}%")
                 except Exception:
                     pass
+
+            @uploader.on(video_uploader.VideoUploaderEvents.CHUNK_FAILED.value)
+            def on_chunk_failed(data):
+                if not isinstance(data, dict):
+                    self.log("Bilibili 分块上传失败")
+                    return
+                chunk_number = int(data.get("chunk_number", 0)) + 1
+                total_chunks = data.get("total_chunk_count", "?")
+                attempt = data.get("attempt", "?")
+                max_attempts = data.get("max_attempts", "?")
+                info = _compact_exception_text(str(data.get("info") or "未知错误"))
+                if data.get("retrying"):
+                    delay = data.get("retry_delay_seconds", 0)
+                    self.log(
+                        f"Bilibili {_page_label(data)} 分块 {chunk_number}/{total_chunks} 上传失败，"
+                        f"尝试 {attempt}/{max_attempts}，{delay} 秒后重试：{info}"
+                    )
+                else:
+                    self.log(
+                        f"Bilibili {_page_label(data)} 分块 {chunk_number}/{total_chunks} 上传失败，"
+                        f"已停止重试（{attempt}/{max_attempts}）：{info}"
+                    )
+
+            @uploader.on(video_uploader.VideoUploaderEvents.PRE_PAGE_SUBMIT.value)
+            def on_pre_page_submit(data):
+                _emit_progress("95.0%")
+                self.log(f"Bilibili {_page_label(data)} 分块上传完成，正在提交分P")
+
+            @uploader.on(video_uploader.VideoUploaderEvents.AFTER_PAGE_SUBMIT.value)
+            def on_after_page_submit(data):
+                self.log(f"Bilibili {_page_label(data)} 分P提交成功")
+
+            @uploader.on(video_uploader.VideoUploaderEvents.PAGE_SUBMIT_FAILED.value)
+            def on_page_submit_failed(data):
+                self.log(f"Bilibili {_page_label(data)} 分P提交失败：{_event_error(data)}")
+
+            @uploader.on(video_uploader.VideoUploaderEvents.PRE_COVER.value)
+            def on_pre_cover(_data):
+                _emit_progress("96.0%")
+                self.log("开始上传Bilibili封面")
+
+            @uploader.on(video_uploader.VideoUploaderEvents.AFTER_COVER.value)
+            def on_after_cover(_data):
+                _emit_progress("98.0%")
+                self.log("Bilibili封面上传成功")
+
+            @uploader.on(video_uploader.VideoUploaderEvents.COVER_FAILED.value)
+            def on_cover_failed(data):
+                self.log(f"Bilibili封面上传失败：{_event_error(data)}")
+
+            @uploader.on(video_uploader.VideoUploaderEvents.PRE_SUBMIT.value)
+            def on_pre_submit(_data):
+                _emit_progress("99.0%")
+                self.log("视频和封面上传完成，正在提交Bilibili投稿")
+
+            @uploader.on(video_uploader.VideoUploaderEvents.AFTER_SUBMIT.value)
+            def on_after_submit(_data):
+                self.log("Bilibili投稿接口提交成功")
+
+            @uploader.on(video_uploader.VideoUploaderEvents.SUBMIT_FAILED.value)
+            def on_submit_failed(data):
+                self.log(f"Bilibili投稿提交失败：{_event_error(data)}")
 
             @uploader.on(video_uploader.VideoUploaderEvents.FAILED.value)
             def on_failed(data):
@@ -396,7 +425,6 @@ class BilibiliUploader:
                 with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
                     result = pool.submit(asyncio.run, uploader.start()).result()
 
-            last_emitted_percent = 100.0
             _emit_progress("100.0%")
             self.log(f"bilibili上传完成: {result}")
 

--- a/tests/test_bilibili_uploader.py
+++ b/tests/test_bilibili_uploader.py
@@ -1,0 +1,287 @@
+import asyncio
+import os
+import tempfile
+import unittest
+from unittest.mock import AsyncMock, Mock, patch
+
+from modules.bili_sdk.exceptions.NetworkException import NetworkException
+from modules.bili_sdk.utils.AsyncEvent import AsyncEvent
+from modules.bili_sdk.video_uploader import (
+    VideoUploader,
+    VideoUploaderEvents,
+    VideoUploaderPage,
+)
+from modules.bilibili_uploader import BilibiliUploader, _BilibiliChunkProgress
+
+
+class _FakeResponse:
+    def __init__(self, code=200, text="MULTIPART_PUT_SUCCESS"):
+        self.code = code
+        self._text = text
+
+    def utf8_text(self):
+        return self._text
+
+
+class BilibiliSdkChunkRetryTests(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.video_path = os.path.join(self.temp_dir.name, "video.mp4")
+        with open(self.video_path, "wb") as stream:
+            stream.write(b"abcdefgh")
+        self.page = VideoUploaderPage(self.video_path, "test")
+        self.uploader = object.__new__(VideoUploader)
+        AsyncEvent.__init__(self.uploader)
+        self.uploader.line = None
+        self.preupload = {
+            "endpoint": "//upload.example.com",
+            "upos_uri": "upos://bucket/video.mp4",
+            "upload_id": "upload-id",
+            "chunk_size": 8,
+            "auth": "auth",
+        }
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def test_chunk_retries_transient_failures_then_succeeds(self):
+        client = Mock()
+        client.request = AsyncMock(
+            side_effect=[
+                _FakeResponse(503),
+                _FakeResponse(503),
+                _FakeResponse(200),
+            ]
+        )
+        failures = []
+        successes = []
+        self.uploader.add_event_listener(
+            VideoUploaderEvents.CHUNK_FAILED.value, failures.append
+        )
+        self.uploader.add_event_listener(
+            VideoUploaderEvents.AFTER_CHUNK.value, successes.append
+        )
+
+        with patch(
+            "modules.bili_sdk.video_uploader.get_client", return_value=client
+        ), patch(
+            "modules.bili_sdk.video_uploader.asyncio.sleep", new=AsyncMock()
+        ) as sleep_mock:
+            result = asyncio.run(
+                self.uploader._upload_chunk(
+                    self.page, 0, 0, 1, dict(self.preupload)
+                )
+            )
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(client.request.await_count, 3)
+        self.assertEqual([item["attempt"] for item in failures], [1, 2])
+        self.assertEqual([item["retrying"] for item in failures], [True, True])
+        self.assertEqual([item["retry_delay_seconds"] for item in failures], [1, 2])
+        self.assertEqual(len(successes), 1)
+        self.assertEqual(sleep_mock.await_count, 2)
+
+    def test_chunk_stops_after_three_transient_failures(self):
+        client = Mock()
+        client.request = AsyncMock(return_value=_FakeResponse(503))
+        failures = []
+        self.uploader.add_event_listener(
+            VideoUploaderEvents.CHUNK_FAILED.value, failures.append
+        )
+
+        with patch(
+            "modules.bili_sdk.video_uploader.get_client", return_value=client
+        ), patch(
+            "modules.bili_sdk.video_uploader.asyncio.sleep", new=AsyncMock()
+        ):
+            with self.assertRaises(NetworkException):
+                asyncio.run(
+                    self.uploader._upload_chunk(
+                        self.page, 0, 0, 1, dict(self.preupload)
+                    )
+                )
+
+        self.assertEqual(client.request.await_count, 3)
+        self.assertEqual(len(failures), 3)
+        self.assertFalse(failures[-1]["retrying"])
+        self.assertEqual(failures[-1]["attempt"], 3)
+        self.assertEqual(failures[-1]["status_code"], 503)
+
+    def test_chunk_does_not_retry_client_error(self):
+        client = Mock()
+        client.request = AsyncMock(return_value=_FakeResponse(403))
+        failures = []
+        self.uploader.add_event_listener(
+            VideoUploaderEvents.CHUNK_FAILED.value, failures.append
+        )
+
+        with patch(
+            "modules.bili_sdk.video_uploader.get_client", return_value=client
+        ):
+            with self.assertRaises(NetworkException):
+                asyncio.run(
+                    self.uploader._upload_chunk(
+                        self.page, 0, 0, 1, dict(self.preupload)
+                    )
+                )
+
+        self.assertEqual(client.request.await_count, 1)
+        self.assertEqual(len(failures), 1)
+        self.assertFalse(failures[0]["retrying"])
+
+    def test_upload_page_uses_one_thread_when_preupload_returns_zero(self):
+        preupload = {
+            **self.preupload,
+            "chunk_size": 4,
+            "threads": 0,
+            "biz_id": 123,
+        }
+        self.uploader._preupload = AsyncMock(return_value=preupload)
+        self.uploader._upload_chunk = AsyncMock(return_value={"ok": True})
+        self.uploader._complete_page = AsyncMock(
+            return_value={"filename": "video", "cid": 123}
+        )
+
+        result = asyncio.run(self.uploader._upload_page(self.page))
+
+        self.assertEqual(result, {"filename": "video", "cid": 123})
+        self.assertEqual(self.uploader._upload_chunk.await_count, 2)
+        self.uploader._complete_page.assert_awaited_once()
+
+
+class BilibiliProgressTests(unittest.TestCase):
+    def test_progress_counts_unique_chunks_in_completion_order(self):
+        tracker = _BilibiliChunkProgress()
+        page = object()
+
+        first = tracker.record(
+            {"page": page, "chunk_number": 0, "total_chunk_count": 23}
+        )
+        duplicate = tracker.record(
+            {"page": page, "chunk_number": 0, "total_chunk_count": 23}
+        )
+        out_of_order = tracker.record(
+            {"page": page, "chunk_number": 22, "total_chunk_count": 23}
+        )
+
+        self.assertAlmostEqual(first, 95 / 23)
+        self.assertEqual(duplicate, first)
+        self.assertAlmostEqual(out_of_order, 2 * 95 / 23)
+
+        final = out_of_order
+        for chunk_number in range(1, 22):
+            final = tracker.record(
+                {
+                    "page": page,
+                    "chunk_number": chunk_number,
+                    "total_chunk_count": 23,
+                }
+            )
+        self.assertEqual(final, 95.0)
+
+    def test_upload_video_emits_stage_progress_and_retry_log(self):
+        progress = []
+        logger = Mock()
+
+        class FakePage:
+            def __init__(self, path, title):
+                self.path = path
+                self.title = title
+
+        class FakeUploader(AsyncEvent):
+            def __init__(self, pages, meta, credential, cover):
+                super().__init__()
+                self.pages = pages
+
+            async def start(self):
+                page = self.pages[0]
+                self.dispatch(
+                    VideoUploaderEvents.CHUNK_FAILED.value,
+                    {
+                        "page": page,
+                        "chunk_number": 0,
+                        "total_chunk_count": 3,
+                        "attempt": 1,
+                        "max_attempts": 3,
+                        "retrying": True,
+                        "retry_delay_seconds": 1,
+                        "info": "Status 503",
+                    },
+                )
+                for chunk_number in (0, 0, 2, 1):
+                    self.dispatch(
+                        VideoUploaderEvents.AFTER_CHUNK.value,
+                        {
+                            "page": page,
+                            "chunk_number": chunk_number,
+                            "total_chunk_count": 3,
+                        },
+                    )
+                self.dispatch(
+                    VideoUploaderEvents.PRE_PAGE_SUBMIT.value, {"page": page}
+                )
+                self.dispatch(
+                    VideoUploaderEvents.AFTER_PAGE_SUBMIT.value, {"page": page}
+                )
+                self.dispatch(VideoUploaderEvents.PRE_COVER.value, None)
+                self.dispatch(VideoUploaderEvents.AFTER_COVER.value, {"url": "cover"})
+                self.dispatch(VideoUploaderEvents.PRE_SUBMIT.value, {})
+                self.dispatch(
+                    VideoUploaderEvents.AFTER_SUBMIT.value,
+                    {"bvid": "BV1test", "aid": 1},
+                )
+                return {"bvid": "BV1test", "aid": 1}
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            video_path = os.path.join(temp_dir, "video.mp4")
+            cover_path = os.path.join(temp_dir, "cover.jpg")
+            for path in (video_path, cover_path):
+                with open(path, "wb") as stream:
+                    stream.write(b"test")
+
+            with patch(
+                "modules.bilibili_uploader.setup_task_logger", return_value=logger
+            ), patch(
+                "modules.bilibili_uploader.configure_bilibili_runtime"
+            ), patch(
+                "modules.bilibili_uploader.load_credential_from_file",
+                return_value=object(),
+            ), patch(
+                "modules.bilibili_uploader.validate_credential_remote",
+                return_value=(True, "ok"),
+            ), patch(
+                "modules.bilibili_uploader.video_uploader.VideoMeta",
+                return_value=object(),
+            ), patch(
+                "modules.bilibili_uploader.video_uploader.VideoUploaderPage",
+                FakePage,
+            ), patch(
+                "modules.bilibili_uploader.video_uploader.VideoUploader",
+                FakeUploader,
+            ):
+                success, result = BilibiliUploader("cookies.json").upload_video(
+                    video_path,
+                    cover_path,
+                    "标题",
+                    "简介",
+                    ["标签"],
+                    21,
+                    youtube_url="https://www.youtube.com/watch?v=test",
+                    task_id="test-task",
+                    progress_callback=progress.append,
+                )
+
+        self.assertTrue(success)
+        self.assertEqual(result["bvid"], "BV1test")
+        self.assertEqual(
+            progress,
+            ["0.0%", "31.7%", "63.3%", "95.0%", "96.0%", "98.0%", "99.0%", "100.0%"],
+        )
+        log_messages = [call.args[0] for call in logger.info.call_args_list]
+        self.assertTrue(any("尝试 1/3，1 秒后重试" in item for item in log_messages))
+        self.assertTrue(any("正在提交分P" in item for item in log_messages))
+        self.assertTrue(any("正在提交Bilibili投稿" in item for item in log_messages))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- replace unbounded failed-chunk requeueing with at most 3 upload attempts and exponential backoff
- propagate permanent chunk failures so tasks exit instead of remaining stuck near 95.7%
- calculate progress from unique completed chunks and reserve 95–99% for page submission, cover upload, and final submission
- add task logs for chunk retries and each post-upload stage
- add regression tests for retry exhaustion, non-retryable errors, invalid thread counts, out-of-order chunks, duplicate events, and stage progress

## Testing

- `python -m pytest tests/test_bilibili_uploader.py tests/test_bilibili_runtime.py tests/test_cookie_path_resolution.py tests/test_platform_metadata_limits.py -q` — 29 passed
- `python -m pytest tests/ -q` — 276 passed, 10 subtests passed

Related to #87. This PR addresses the separate Bilibili upload-stall feedback and does not change the AcFun `400011` handling or task cancellation flow.