### PR TITLE
Support BILIBILI_PROXY and BILIBILI_TIMEOUT env vars for bilibili upload network config

### DIFF
--- a/modules/bilibili_runtime.py
+++ b/modules/bilibili_runtime.py
@@ -23,6 +23,22 @@ def configure_bilibili_runtime() -> bool:
         impersonate = os.environ.get("BILIBILI_IMPERSONATE", "chrome131").strip()
         if impersonate:
             request_settings.set("impersonate", impersonate)
+
+        proxy = os.environ.get("BILIBILI_PROXY", "").strip()
+        if proxy:
+            request_settings.set_proxy(proxy)
+            logger.info("Bilibili SDK 代理已设置为: %s", proxy)
+
+        timeout_env = os.environ.get("BILIBILI_TIMEOUT", "").strip()
+        if timeout_env:
+            try:
+                timeout_val = float(timeout_env)
+                if timeout_val > 0:
+                    request_settings.set_timeout(timeout_val)
+                    logger.info("Bilibili SDK 超时已设置为: %s 秒", timeout_val)
+            except ValueError:
+                pass
+
         _INITIALIZED = True
         _LAST_ERROR = None
         return True


### PR DESCRIPTION
Add `BILIBILI_PROXY` and `BILIBILI_TIMEOUT` environment variable support to `configure_bilibili_runtime()` so users can route Bilibili upload traffic through a proxy or adjust request timeouts without changing system proxy settings.

The Bilibili SDK uses curl_cffi for HTTP requests which does not respect system HTTP_PROXY. This is especially important for users outside mainland China where Bilibili's UPOS upload CDN is unreachable directly, or for users whose ISPs block curl_cffi's TLS fingerprint impersonation.

See [#87 (comment)](https://github.com/fqscfqj/Y2A-Auto/issues/87#issuecomment-5042730907) for the reported case.