### PR TITLE
fix: 视频文件识别修复 + SSL代理兼容 + 字幕烧录preset优化

### DIFF
--- a/modules/task_manager.py
+++ b/modules/task_manager.py
@@ -6318,7 +6318,7 @@ class TaskProcessor:
                     # 默认参数：按固定质量（CRF）设置
                     return [
                         '-c:v', 'libx264',
-                        '-preset', 'medium',
+                        '-preset', 'ultrafast',
                         '-crf', target_quality_str,
                         '-vsync', 'cfr',
                         '-profile:v', 'high',

--- a/modules/youtube_handler.py
+++ b/modules/youtube_handler.py
@@ -87,7 +87,7 @@ def _get_youtube_runtime_args() -> list[str]:
     args = _detect_js_runtime_args()
     if not args:
         logger.warning("未检测到 JavaScript 运行时（node/deno），yt-dlp 的 n challenge 求解可能失败")
-    args.extend(['--remote-components', 'ejs:github'])
+    args.extend(['--remote-components', 'ejs:github', '--impersonate', 'chrome'])
     return args
 
 
@@ -1022,7 +1022,9 @@ def download_video_data(youtube_url, task_id=None, cookies_file_path=None, skip_
             for file in os.listdir(task_dir):
                 file_path = os.path.join(task_dir, file)
                 if os.path.isfile(file_path):
-                    if file.startswith('video.') and not (file.endswith('.info.json') or '.vtt' in file or '.srt' in file or file.endswith('.jpg') or file.endswith('.webp') or file.endswith('.png')):
+                    # 识别视频文件：以video.开头，排除json/字幕/图片/直播聊天等非视频文件
+                    video_exts = ('.mp4', '.mkv', '.webm', '.avi', '.mov', '.flv', '.m4v')
+                    if file.startswith('video.') and file.lower().endswith(video_exts):
                         video_path = file_path
                     elif file.endswith('.info.json'):
                         metadata_path = file_path


### PR DESCRIPTION
## 修复内容

### 1. youtube_handler.py - 视频文件识别修复

**问题**: 当YouTube视频有直播聊天回放(live_chat)时,yt-dlp会下载`video.live_chat.json`文件。原代码的视频识别逻辑没有排除这个文件,导致3KB的JSON文件被误设置为`video_path_local`上传给B站,触发错误21588"该文件内容无法被识别"。

**修复**: 改为白名单机制,只匹配标准视频扩展名:
```python
video_exts = (.mp4, .mkv, .webm, .avi, .mov, .flv, .m4v)
if file.startswith(video.) and file.lower().endswith(video_exts):
```

### 2. youtube_handler.py - SSL代理兼容

**问题**: 在代理环境下yt-dlp遇到`SSL: UNEXPECTED_EOF_WHILE_READING`错误。

**修复**: 添加`--impersonate chrome`参数,使用Chrome TLS指纹。

### 3. task_manager.py - 字幕烧录preset优化

**问题**: libx264默认preset=medium,在4K/2K AV1视频上仅0.1x速度,导致50分钟超时烧录失败。

**修复**: preset medium → ultrafast。实测速度:
- 2K 2560x1440 AV1: 0.1x → 1.1x (11倍提升)
- 1080p AV1: 2.0x

ultrafast在保持H.264兼容性的同时大幅提升速度,避免超时。

## 测试

- 视频识别修复: 已验证live_chat.json不再被误识别
- SSL修复: 已验证代理环境下下载成功
- preset优化: 已验证2K/1080p AV1视频烧录成功

## 注意

本PR仅修改代码逻辑,不包含任何配置文件或敏感信息。