### PR TITLE
fix: video ext whitelist + configurable CPU preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,8 @@ python app.py
 ### 视频转码与维护
 
 - `VIDEO_ENCODER`：`auto` / `cpu` / `nvidia` / `intel` / `amd`
+- `VIDEO_CPU_PRESET`：常规 CPU/libx264 转码 preset，默认 `medium`
+- `VIDEO_CPU_PRESET_HD`：1440p+ 且超过 10 分钟时使用的 preset，默认 `veryfast`
 - `VIDEO_CUSTOM_PARAMS_ENABLED` / `VIDEO_CUSTOM_PARAMS`：自定义 FFmpeg 参数
 - `MAX_CONCURRENT_TASKS`：最大并发任务数，默认 `2`
 - `MAX_CONCURRENT_UPLOADS`：最大并发上传数，默认 `1`
@@ -312,6 +314,8 @@ python app.py
   "SPEECH_RECOGNITION_PROVIDER": "whisper",
   "VAD_ENABLED": true,
   "VIDEO_ENCODER": "auto",
+  "VIDEO_CPU_PRESET": "medium",
+  "VIDEO_CPU_PRESET_HD": "veryfast",
   "FFMPEG_AUTO_DOWNLOAD": true,
   "MAX_CONCURRENT_TASKS": 2,
   "MAX_CONCURRENT_UPLOADS": 1

--- a/modules/config_manager.py
+++ b/modules/config_manager.py
@@ -18,6 +18,12 @@ _YOUTUBE_DOWNLOAD_QUALITY_MODES = ('highest', 'manual')
 _YOUTUBE_DOWNLOAD_MAX_HEIGHT_VALUES = ('2160', '1440', '1080', '720', '480', '360')
 _YOUTUBE_DOWNLOAD_QUALITY_MODE_DEFAULT = 'highest'
 _YOUTUBE_DOWNLOAD_MAX_HEIGHT_DEFAULT = '1080'
+_VIDEO_CPU_PRESETS = (
+    'ultrafast', 'superfast', 'veryfast', 'faster', 'fast',
+    'medium', 'slow', 'slower', 'veryslow',
+)
+_VIDEO_CPU_PRESET_DEFAULT = 'medium'
+_VIDEO_CPU_PRESET_HD_DEFAULT = 'veryfast'
 
 # 默认配置
 DEFAULT_CONFIG = {
@@ -146,6 +152,8 @@ DEFAULT_CONFIG = {
     "STUCK_TASK_CHECK_INTERVAL_SECONDS": 300,  # 自动扫描并恢复卡住任务的时间间隔（秒）
     # 视频转码相关（硬编默认输出 HEVC/H.265，CPU 保持 H.264）
     "VIDEO_ENCODER": "auto",  # auto/cpu/nvidia/intel/amd - 自动检测或指定编码器
+    "VIDEO_CPU_PRESET": _VIDEO_CPU_PRESET_DEFAULT,  # 常规 CPU/libx264 转码 preset
+    "VIDEO_CPU_PRESET_HD": _VIDEO_CPU_PRESET_HD_DEFAULT,  # 1440p+ 且超过 10 分钟时使用
     "VIDEO_CUSTOM_PARAMS_ENABLED": False,  # 是否启用自定义转码参数
     "VIDEO_CUSTOM_PARAMS": "",  # 自定义 FFmpeg 视频编码参数（启用自定义参数时使用）
     # 语音识别（无字幕转写）
@@ -234,6 +242,14 @@ def normalize_youtube_download_max_height(value):
     return normalized
 
 
+def normalize_video_cpu_preset(value, default=_VIDEO_CPU_PRESET_DEFAULT):
+    fallback = str(default or _VIDEO_CPU_PRESET_DEFAULT).strip().lower()
+    if fallback not in _VIDEO_CPU_PRESETS:
+        fallback = _VIDEO_CPU_PRESET_DEFAULT
+    normalized = str(value or fallback).strip().lower()
+    return normalized if normalized in _VIDEO_CPU_PRESETS else fallback
+
+
 def normalize_login_session_timeout_minutes(value):
     try:
         normalized = int(str(value).strip())
@@ -293,6 +309,18 @@ def load_config():
                     config['VIDEO_ENCODER'] = 'auto'
                     encoder_changed = True
 
+                cpu_preset_before = config.get('VIDEO_CPU_PRESET')
+                config['VIDEO_CPU_PRESET'] = normalize_video_cpu_preset(
+                    cpu_preset_before, _VIDEO_CPU_PRESET_DEFAULT
+                )
+                cpu_preset_changed = config['VIDEO_CPU_PRESET'] != cpu_preset_before
+
+                cpu_preset_hd_before = config.get('VIDEO_CPU_PRESET_HD')
+                config['VIDEO_CPU_PRESET_HD'] = normalize_video_cpu_preset(
+                    cpu_preset_hd_before, _VIDEO_CPU_PRESET_HD_DEFAULT
+                )
+                cpu_preset_hd_changed = config['VIDEO_CPU_PRESET_HD'] != cpu_preset_hd_before
+
                 upload_target_before = config.get('UPLOAD_TARGET_DEFAULT')
                 upload_target_normalized = str(upload_target_before or 'acfun').strip().lower()
                 if upload_target_normalized not in ('acfun', 'bilibili', 'both'):
@@ -339,6 +367,8 @@ def load_config():
                 if (
                     missing_keys
                     or encoder_changed
+                    or cpu_preset_changed
+                    or cpu_preset_hd_changed
                     or upload_target_changed
                     or quality_mode_changed
                     or quality_height_changed
@@ -420,6 +450,14 @@ def update_config(new_config):
                 else:
                     logger.warning("无效的视频编码器配置值，已回退为 auto")
                     current_config[key] = 'auto'
+            elif key == 'VIDEO_CPU_PRESET':
+                current_config[key] = normalize_video_cpu_preset(
+                    new_config[key], _VIDEO_CPU_PRESET_DEFAULT
+                )
+            elif key == 'VIDEO_CPU_PRESET_HD':
+                current_config[key] = normalize_video_cpu_preset(
+                    new_config[key], _VIDEO_CPU_PRESET_HD_DEFAULT
+                )
             elif key == 'UPLOAD_TARGET_DEFAULT':
                 target = str(new_config[key]).strip().lower()
                 current_config[key] = target if target in ('acfun', 'bilibili', 'both') else 'acfun'

--- a/modules/task_manager.py
+++ b/modules/task_manager.py
@@ -23,6 +23,7 @@ from apscheduler.schedulers.base import SchedulerNotRunningError
 import queue
 from .utils import get_app_root_dir, get_app_subdir
 from .ffmpeg_manager import get_ffmpeg_path, get_ffprobe_path
+from .config_manager import normalize_video_cpu_preset
 from .notifications import (
     EVENT_TASK_ADDED,
     EVENT_TASK_COMPLETED,
@@ -6315,13 +6316,17 @@ class TaskProcessor:
                 def build_cpu_params():
                     if custom_video_params:
                         return list(custom_video_params)
-                    # 可配置preset,默认medium;高分辨率/预计超时用更快preset
-                    cpu_preset = (self.config.get('VIDEO_CPU_PRESET', 'medium')
-                                  or 'medium').strip() or 'medium'
-                    # 高分辨率(>=1440p)且视频较长时,自动用更快preset避免超时
-                    if cpu_preset == 'medium' and input_height >= 1440 and video_duration and video_duration > 600:
-                        cpu_preset = self.config.get('VIDEO_CPU_PRESET_HD', 'veryfast') or 'veryfast'
-                        task_logger.info(f"检测到{input_height}p长视频,CPU preset自动调整为{cpu_preset}")
+                    cpu_preset = normalize_video_cpu_preset(
+                        self.config.get('VIDEO_CPU_PRESET'), 'medium'
+                    )
+                    # 1440p+ 且超过 10 分钟时使用独立的快速 preset，避免字幕烧录超时。
+                    if input_height >= 1440 and video_duration and video_duration > 600:
+                        cpu_preset = normalize_video_cpu_preset(
+                            self.config.get('VIDEO_CPU_PRESET_HD'), 'veryfast'
+                        )
+                        task_logger.info(
+                            f"检测到 {input_height}p 长视频，CPU preset 自动调整为 {cpu_preset}"
+                        )
                     # 默认参数：按固定质量（CRF）设置
                     return [
                         '-c:v', 'libx264',

--- a/modules/task_manager.py
+++ b/modules/task_manager.py
@@ -6315,10 +6315,17 @@ class TaskProcessor:
                 def build_cpu_params():
                     if custom_video_params:
                         return list(custom_video_params)
+                    # 可配置preset,默认medium;高分辨率/预计超时用更快preset
+                    cpu_preset = (self.config.get('VIDEO_CPU_PRESET', 'medium')
+                                  or 'medium').strip() or 'medium'
+                    # 高分辨率(>=1440p)且视频较长时,自动用更快preset避免超时
+                    if cpu_preset == 'medium' and input_height >= 1440 and video_duration and video_duration > 600:
+                        cpu_preset = self.config.get('VIDEO_CPU_PRESET_HD', 'veryfast') or 'veryfast'
+                        task_logger.info(f"检测到{input_height}p长视频,CPU preset自动调整为{cpu_preset}")
                     # 默认参数：按固定质量（CRF）设置
                     return [
                         '-c:v', 'libx264',
-                        '-preset', 'medium',
+                        '-preset', cpu_preset,
                         '-crf', target_quality_str,
                         '-vsync', 'cfr',
                         '-profile:v', 'high',

--- a/modules/youtube_handler.py
+++ b/modules/youtube_handler.py
@@ -1019,10 +1019,12 @@ def download_video_data(youtube_url, task_id=None, cookies_file_path=None, skip_
             subtitles_paths = []
             
             # 查找实际的视频文件与封面
+            # 识别视频文件：以video.开头，匹配标准视频扩展名，排除info/json/字幕/图片
+            video_exts = {'.mp4', '.mkv', '.webm', '.avi', '.mov', '.flv', '.m4v'}
             for file in os.listdir(task_dir):
                 file_path = os.path.join(task_dir, file)
                 if os.path.isfile(file_path):
-                    if file.startswith('video.') and not (file.endswith('.info.json') or '.vtt' in file or '.srt' in file or file.endswith('.jpg') or file.endswith('.webp') or file.endswith('.png')):
+                    if file.startswith('video.') and file.lower().endswith(tuple(video_exts)):
                         video_path = file_path
                     elif file.endswith('.info.json'):
                         metadata_path = file_path

--- a/modules/youtube_handler.py
+++ b/modules/youtube_handler.py
@@ -34,6 +34,7 @@ _YOUTUBE_USER_AGENT = (
 )
 _INTERNAL_YT_DLP_FLAG = '--y2a-internal-yt-dlp'
 _YT_DLP_UNAVAILABLE_MESSAGE = '本地 yt-dlp 不可用，请重新安装依赖或重新下载完整便携包。'
+_VIDEO_OUTPUT_EXTENSIONS = frozenset({'.mp4', '.mkv', '.webm', '.avi', '.mov', '.flv', '.m4v'})
 
 
 class YtDlpUnavailableError(RuntimeError):
@@ -44,6 +45,12 @@ def _format_unexpected_download_error(exc: Exception) -> str:
     if isinstance(exc, YtDlpUnavailableError):
         return str(exc)
     return f"下载过程中发生未预期的错误: {exc}"
+
+
+def _is_video_output_file(filename: str) -> bool:
+    """判断 yt-dlp 产物是否为可上传的视频文件。"""
+    name = str(filename or '')
+    return name.startswith('video.') and Path(name).suffix.lower() in _VIDEO_OUTPUT_EXTENSIONS
 
 # 项目根目录，使用工具函数以兼容开发环境和 PyInstaller 打包环境，并使用 realpath 解析符号链接
 _BASE_DIR = os.path.realpath(get_app_root_dir())
@@ -1019,12 +1026,11 @@ def download_video_data(youtube_url, task_id=None, cookies_file_path=None, skip_
             subtitles_paths = []
             
             # 查找实际的视频文件与封面
-            # 识别视频文件：以video.开头，匹配标准视频扩展名，排除info/json/字幕/图片
-            video_exts = {'.mp4', '.mkv', '.webm', '.avi', '.mov', '.flv', '.m4v'}
+            # 识别视频文件，排除 info/json/字幕/图片/直播聊天等产物。
             for file in os.listdir(task_dir):
                 file_path = os.path.join(task_dir, file)
                 if os.path.isfile(file_path):
-                    if file.startswith('video.') and file.lower().endswith(tuple(video_exts)):
+                    if _is_video_output_file(file):
                         video_path = file_path
                     elif file.endswith('.info.json'):
                         metadata_path = file_path

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -300,6 +300,31 @@
                                                         </label>
                                                     </div>
                                                 </div>
+                                                {% set x264_presets = ['ultrafast', 'superfast', 'veryfast', 'faster', 'fast', 'medium', 'slow', 'slower', 'veryslow'] %}
+                                                <div class="row g-3 mt-2">
+                                                    <div class="col-md-6">
+                                                        <div class="form-group">
+                                                            <label for="video-cpu-preset" class="form-label">CPU 转码 preset</label>
+                                                            <select id="video-cpu-preset" name="VIDEO_CPU_PRESET" class="form-select">
+                                                                {% for preset in x264_presets %}
+                                                                <option value="{{ preset }}" {% if config.get('VIDEO_CPU_PRESET', 'medium') == preset %}selected{% endif %}>{{ preset }}</option>
+                                                                {% endfor %}
+                                                            </select>
+                                                            <p class="help-text mb-0">常规 CPU/libx264 字幕烧录使用，默认 medium。</p>
+                                                        </div>
+                                                    </div>
+                                                    <div class="col-md-6">
+                                                        <div class="form-group">
+                                                            <label for="video-cpu-preset-hd" class="form-label">高分辨率长视频 preset</label>
+                                                            <select id="video-cpu-preset-hd" name="VIDEO_CPU_PRESET_HD" class="form-select">
+                                                                {% for preset in x264_presets %}
+                                                                <option value="{{ preset }}" {% if config.get('VIDEO_CPU_PRESET_HD', 'veryfast') == preset %}selected{% endif %}>{{ preset }}</option>
+                                                                {% endfor %}
+                                                            </select>
+                                                            <p class="help-text mb-0">1440p 及以上且超过 10 分钟时使用，默认 veryfast。</p>
+                                                        </div>
+                                                    </div>
+                                                </div>
                                                 <div class="row g-3 mt-2" id="custom-params-section">
                                                     <div class="col-12">
                                                         <div class="form-group">

--- a/tests/test_video_cpu_preset_config.py
+++ b/tests/test_video_cpu_preset_config.py
@@ -1,0 +1,19 @@
+import unittest
+
+from modules.config_manager import DEFAULT_CONFIG, normalize_video_cpu_preset
+
+
+class VideoCpuPresetConfigTests(unittest.TestCase):
+    def test_defaults_are_registered_for_persistence(self):
+        self.assertEqual(DEFAULT_CONFIG['VIDEO_CPU_PRESET'], 'medium')
+        self.assertEqual(DEFAULT_CONFIG['VIDEO_CPU_PRESET_HD'], 'veryfast')
+
+    def test_normalizes_supported_preset(self):
+        self.assertEqual(normalize_video_cpu_preset('  FAST  '), 'fast')
+
+    def test_invalid_preset_uses_requested_fallback(self):
+        self.assertEqual(normalize_video_cpu_preset('invalid', 'veryfast'), 'veryfast')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_video_ext_detection.py
+++ b/tests/test_video_ext_detection.py
@@ -1,0 +1,41 @@
+"""回归测试:任务目录同时存在video.mp4/video.live_chat.json/字幕/封面时,
+必须稳定选择video.mp4而非live_chat.json"""
+import os, tempfile, shutil, unittest
+from pathlib import Path
+
+class TestVideoExtDetection(unittest.TestCase):
+    def test_live_chat_json_not_treated_as_video(self):
+        """video.live_chat.json (3KB) 不应被识别为视频"""
+        with tempfile.TemporaryDirectory() as tmp:
+            # 创建模拟文件
+            task_dir = Path(tmp)
+            (task_dir / 'video.mp4').write_bytes(b'\x00' * 1024 * 1024)  # 1MB视频
+            (task_dir / 'video.live_chat.json').write_bytes(b'{}')
+            (task_dir / 'video.en.srt').write_text('1\n00:00:00 --> 00:00:01\ntest')
+            (task_dir / 'video.webp').write_bytes(b'\x00' * 1024)  # 封面
+            
+            # 模拟find_video_in_task_dir逻辑
+            video_exts = {'.mp4', '.mkv', '.webm', '.avi', '.mov', '.flv', '.m4v'}
+            video_candidates = [p for p in task_dir.glob('video.*')
+                                if p.suffix.lower() in video_exts and p.name != 'video.mp4' and '.info' not in p.name]
+            # 主视频
+            main_video = task_dir / 'video.mp4'
+            self.assertTrue(main_video.exists())
+            # live_chat.json不在视频候选中
+            chat_file = task_dir / 'video.live_chat.json'
+            self.assertNotIn(chat_file.suffix.lower(), video_exts)
+            self.assertEqual(len(video_candidates), 0, "不应有额外视频候选(live_chat.json不是视频)")
+    
+    def test_video_ext_whitelist(self):
+        """白名单只包含标准视频扩展名"""
+        video_exts = {'.mp4', '.mkv', '.webm', '.avi', '.mov', '.flv', '.m4v'}
+        self.assertIn('.mp4', video_exts)
+        self.assertIn('.mkv', video_exts)
+        self.assertNotIn('.json', video_exts)
+        self.assertNotIn('.srt', video_exts)
+        self.assertNotIn('.vtt', video_exts)
+        self.assertNotIn('.webp', video_exts)
+        self.assertNotIn('.jpg', video_exts)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_video_ext_detection.py
+++ b/tests/test_video_ext_detection.py
@@ -1,41 +1,29 @@
-"""回归测试:任务目录同时存在video.mp4/video.live_chat.json/字幕/封面时,
-必须稳定选择video.mp4而非live_chat.json"""
-import os, tempfile, shutil, unittest
-from pathlib import Path
+"""YouTube 下载产物识别回归测试。"""
+
+import unittest
+
+from modules.youtube_handler import _is_video_output_file
+
 
 class TestVideoExtDetection(unittest.TestCase):
-    def test_live_chat_json_not_treated_as_video(self):
-        """video.live_chat.json (3KB) 不应被识别为视频"""
-        with tempfile.TemporaryDirectory() as tmp:
-            # 创建模拟文件
-            task_dir = Path(tmp)
-            (task_dir / 'video.mp4').write_bytes(b'\x00' * 1024 * 1024)  # 1MB视频
-            (task_dir / 'video.live_chat.json').write_bytes(b'{}')
-            (task_dir / 'video.en.srt').write_text('1\n00:00:00 --> 00:00:01\ntest')
-            (task_dir / 'video.webp').write_bytes(b'\x00' * 1024)  # 封面
-            
-            # 模拟find_video_in_task_dir逻辑
-            video_exts = {'.mp4', '.mkv', '.webm', '.avi', '.mov', '.flv', '.m4v'}
-            video_candidates = [p for p in task_dir.glob('video.*')
-                                if p.suffix.lower() in video_exts and p.name != 'video.mp4' and '.info' not in p.name]
-            # 主视频
-            main_video = task_dir / 'video.mp4'
-            self.assertTrue(main_video.exists())
-            # live_chat.json不在视频候选中
-            chat_file = task_dir / 'video.live_chat.json'
-            self.assertNotIn(chat_file.suffix.lower(), video_exts)
-            self.assertEqual(len(video_candidates), 0, "不应有额外视频候选(live_chat.json不是视频)")
-    
-    def test_video_ext_whitelist(self):
-        """白名单只包含标准视频扩展名"""
-        video_exts = {'.mp4', '.mkv', '.webm', '.avi', '.mov', '.flv', '.m4v'}
-        self.assertIn('.mp4', video_exts)
-        self.assertIn('.mkv', video_exts)
-        self.assertNotIn('.json', video_exts)
-        self.assertNotIn('.srt', video_exts)
-        self.assertNotIn('.vtt', video_exts)
-        self.assertNotIn('.webp', video_exts)
-        self.assertNotIn('.jpg', video_exts)
+    def test_accepts_supported_video_outputs(self):
+        for filename in ('video.mp4', 'video.MKV', 'video.f399.webm', 'video.mov'):
+            with self.subTest(filename=filename):
+                self.assertTrue(_is_video_output_file(filename))
+
+    def test_rejects_live_chat_and_other_sidecar_files(self):
+        for filename in (
+            'video.live_chat.json',
+            'video.info.json',
+            'video.en.srt',
+            'video.zh.vtt',
+            'video.webp',
+            'video.jpg',
+            'cover.mp4',
+        ):
+            with self.subTest(filename=filename):
+                self.assertFalse(_is_video_output_file(filename))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Addresses reviewer feedback from PR #91:

1. **youtube_handler.py**: video ext whitelist (.mp4/.mkv/.webm/.avi/.mov/.flv/.m4v) to exclude video.live_chat.json which caused error 21588 on Bilibili upload.

2. **task_manager.py**: configurable `VIDEO_CPU_PRESET` (default medium). For 1440p+ videos longer than 10 minutes, automatically uses faster preset (configurable via `VIDEO_CPU_PRESET_HD`, default veryfast) to avoid timeout. Does NOT change default preset globally - per reviewer request.

3. **tests/**: regression test for video extension detection.

Does NOT add unconditional --impersonate chrome (per reviewer feedback - should be config option or retry strategy).
Does NOT change global default preset to ultrafast (per reviewer feedback - would increase file size).