### PR TITLE
fix(settings): 始终绑定提交监听器并保护模态框调用

### DIFF
--- a/templates/settings.html
+++ b/templates/settings.html
@@ -2938,7 +2938,7 @@ document.addEventListener('DOMContentLoaded', function () {
             });
     };
 
-    if (settingsForm && saveProgressModal) {
+    if (settingsForm) {
         settingsForm.addEventListener('submit', function (event) {
             if (event.defaultPrevented) {
                 return;
@@ -2984,7 +2984,9 @@ document.addEventListener('DOMContentLoaded', function () {
                 detail: '如果缺少 FFmpeg，这里会显示下载进度。',
                 percent: null
             });
-            saveProgressModal.show();
+            if (saveProgressModal) {
+                saveProgressModal.show();
+            }
 
             fetch(settingsForm.action || window.location.pathname, {
                 method: 'POST',


### PR DESCRIPTION
## 关联 Issue
Closes #99

## 问题
提交监听器仅在进度模态框实例创建成功时才绑定：
```js
if (settingsForm && saveProgressModal) {
    settingsForm.addEventListener('submit', ...);
}
```
若 `bootstrap` 未定义或模态框 DOM 缺失，`saveProgressModal` 为 `null`，监听器永不绑定，保存功能完全静默失效，且无任何报错反馈。

## 修复
- 改为 `if (settingsForm) { ... }` 始终绑定提交监听器。
- 将 `saveProgressModal.show()` 包一层 `if (saveProgressModal) { ... }`（其余模态框辅助函数 `setSettingsSaveModalClosable` / `forceHideSettingsSaveModal` 已自带空值保护），确保即使模态框不可用，`fetch` 仍能发出、保存仍能完成。

## 影响范围
仅修改 `templates/settings.html` 的监听器绑定与模态框调用；不改变正常路径下的行为。
