### PR TITLE
docs(settings): 在 YouTube Cookies 段增加 Netscape cookies.txt 引导

### DIFF
--- a/templates/settings.html
+++ b/templates/settings.html
@@ -499,6 +499,9 @@
                                                         </div>
                                                     </div>
                                                     <div class="col-12">
+                                                        <p class="help-text mb-0">可上传由浏览器插件（如 “Get cookies.txt LOCALLY”）导出的 Netscape 格式 <code>cookies.txt</code>；CookieCloud 为可选项，仅用于会员专享 / 私享视频及降低限流，日常搬运并非必须。<code>YOUTUBE_COOKIES_PATH</code> 指向的文件即上文“YouTube Cookies 文件路径”（默认 <code>cookies/yt_cookies.txt</code>）。</p>
+                                                    </div>
+                                                    <div class="col-12">
                                                         <label class="checkbox-label">
                                                             <input type="checkbox" name="YOUTUBE_PROXY_ENABLED" {% if config.get('YOUTUBE_PROXY_ENABLED', False) %}checked{% endif %}>
                                                             启用代理下载


### PR DESCRIPTION
## 关联 Issue
Closes #100

## 问题
用户不知道如何配置 YouTube Cookie。UI 里唯一被明确标注的路径是 CookieCloud 卡片；而「YouTube Cookies」段落里的「上传新的 Cookies 文件」入口不明显，也没有说明支持/需要 Netscape 格式 `cookies.txt`。

## 修复
在「YouTube Cookies」卡片内「上传新的 Cookies 文件」下方增加一段引导说明：
- 可上传由浏览器插件（如 “Get cookies.txt LOCALLY”）导出的 Netscape 格式 `cookies.txt`；
- CookieCloud 为可选项，仅用于会员专享 / 私享视频及降低限流，日常搬运并非必须；
- 明确 `YOUTUBE_COOKIES_PATH` 指向的文件即上文“YouTube Cookies 文件路径”（默认 `cookies/yt_cookies.txt`）。

## 影响范围
仅新增说明文本，不改变任何逻辑或表单字段。
