### PR TITLE
fix(settings): CookieCloud 开启但字段为空时给出非阻断提示

### DIFF
--- a/app.py
+++ b/app.py
@@ -953,6 +953,23 @@ def _perform_settings_save(form_data: dict, uploads: dict, operation_id: str | N
             youtube_monitor.stop_all_schedules()
             logger.info("YouTube API密钥未配置，已跳过监控系统初始化")
 
+        # Issue 101: 非阻断提示——CookieCloud 已启用时，逐项检查服务地址/UUID/密码是否缺失
+        if str(updated_config.get('COOKIECLOUD_ENABLED', False)).lower() in ('true', '1', 'on'):
+            _cookiecloud_missing = []
+            if not str(updated_config.get('COOKIECLOUD_SERVER_URL', '') or '').strip():
+                _cookiecloud_missing.append('服务地址')
+            if not str(updated_config.get('COOKIECLOUD_UUID', '') or '').strip():
+                _cookiecloud_missing.append('UUID')
+            if not str(updated_config.get('COOKIECLOUD_PASSWORD', '') or '').strip():
+                _cookiecloud_missing.append('密码')
+            if _cookiecloud_missing:
+                _append_settings_message(
+                    messages, 'warning',
+                    f'CookieCloud 已启用，但以下必填项为空：{"、".join(_cookiecloud_missing)}。'
+                    'CookieCloud 需要服务地址、UUID、密码三者均非空才能正常同步，'
+                    '请补全后保存，或暂时关闭 CookieCloud。'
+                )
+
         _append_settings_message(messages, 'success', '配置已成功保存')
         final_level = 'warning' if any(msg['category'] in ('warning', 'danger') for msg in messages) else 'success'
         final_stage = 'warning' if final_level == 'warning' else 'completed'


### PR DESCRIPTION
## 关联 Issue
Closes #101

## 问题
`COOKIECLOUD_ENABLED=true` 但服务地址 / UUID 为空时，保存仍能成功（后端不校验这些字段），卡片显示「已启用」却不会真正拉取 Cookie，用户易误以为被锁死为必填。

## 修复
在 `_perform_settings_save` 中，当检测到 CookieCloud 已启用但「服务地址」与「UUID」均为空时，追加一条**非阻断**的 warning 提示（不影响保存成功），明确告知不会真正拉取 Cookie，并建议填写或关闭。

## 影响范围
仅新增一条 warning 消息；保存流程与成功判定不受影响（warning 仅会改变最终提示的色调，符合现有 `final_level` 逻辑）。
