### PR TITLE
fix(monitor): 支持多关键词 OR 搜索，避免整串 AND 导致 0 结果

### DIFF
--- a/modules/youtube_monitor.py
+++ b/modules/youtube_monitor.py
@@ -1093,10 +1093,14 @@ class YouTubeMonitor:
 
         if failed_keywords:
             logger.warning(f"多关键词搜索中有 {len(failed_keywords)} 个关键词失败（已跳过并继续其余）：{failed_keywords}")
-            logger.warning("注意：多关键词会线性增加 search.list 配额消耗（每关键词 1 次请求）。")
+        # 多关键词会线性增加 search.list 配额消耗（每关键词 1 次请求），无论是否失败都提示
+        if len(batch_results) > 1:
+            logger.warning(f"多关键词 OR 搜索共 {len(batch_results)} 个关键词，将线性增加 search.list 配额消耗（每关键词 1 次请求）。")
 
         # 公平合并：round-robin 交错各关键词候选，去重后截断，
         # 确保每个关键词至少有机会进入最终候选集，避免前面的热门关键词占满名额。
+        # 每次成功 append 后立即检查预算并跳出，避免单轮内越过 total_budget（≤50），
+        # 否则会向 videos.list 传入超过 50 个 ID 而触发 400。
         total_budget = min(config['max_results'] * 2, 50)
         video_ids = []
         seen = set()
@@ -1105,6 +1109,7 @@ class YouTubeMonitor:
             active = list(iterators)
             while active and len(video_ids) < total_budget:
                 still_active = []
+                budget_reached = False
                 for it in active:
                     try:
                         vid = next(it)
@@ -1113,11 +1118,14 @@ class YouTubeMonitor:
                     if vid not in seen:
                         seen.add(vid)
                         video_ids.append(vid)
+                        if len(video_ids) >= total_budget:
+                            budget_reached = True
+                            break  # 立即跳出内层，停止本轮其余关键词
                     # 该批仍有剩余则保留，继续顺序轮转（即便本批本轮贡献为重复项）
                     still_active.append(it)
                 active = still_active
-                if len(video_ids) >= total_budget:
-                    break
+                if budget_reached:
+                    break  # 跳出外层 while
         logger.info(f"多关键词合并后候选 {len(video_ids)} 个（预算 {total_budget}，来源批次 {len(batch_results)}）")
         
         if not video_ids:

--- a/modules/youtube_monitor.py
+++ b/modules/youtube_monitor.py
@@ -1069,26 +1069,56 @@ class YouTubeMonitor:
             # 无关键词则按空查询搜索（返回热门视频），保持原有行为
             search_batches = [dict(search_params)]
 
-        all_video_ids = []
+        # 多关键词 OR 搜索：逐个关键词请求，并在每个 batch 外层单独容错，
+        # 单个关键词失败不影响其他关键词与整轮监控。
+        batch_results = []  # 每个关键词的 videoId 列表
+        failed_keywords = []
         for idx, sp in enumerate(search_batches, 1):
-            logger.debug(f"准备执行搜索请求({idx}/{len(search_batches)})，参数: {sp}")
-            search_request = self.youtube.search().list(**sp)
-            search_response = self._execute_with_retry(search_request, 'search.list')
+            kw_label = sp.get('q') or f'batch{idx}'
+            try:
+                logger.debug(f"准备执行搜索请求({idx}/{len(search_batches)})，参数: {sp}")
+                search_request = self.youtube.search().list(**sp)
+                search_response = self._execute_with_retry(search_request, 'search.list')
+            except Exception as e:
+                # 单批失败只跳过该关键词，继续处理其余关键词
+                logger.error(f"关键词搜索失败，跳过该关键词继续其他：q={kw_label}, 错误: {e}")
+                failed_keywords.append(kw_label)
+                continue
             if not search_response or 'items' not in search_response:
-                logger.error(f"搜索响应异常: {search_response}")
+                logger.error(f"搜索响应异常（关键词: {kw_label}）：{search_response}")
+                failed_keywords.append(kw_label)
                 continue
             ids = [item['id']['videoId'] for item in search_response['items'] if 'id' in item and 'videoId' in item['id']]
-            all_video_ids.extend(ids)
+            batch_results.append(ids)
 
-        # 去重并限制数量
+        if failed_keywords:
+            logger.warning(f"多关键词搜索中有 {len(failed_keywords)} 个关键词失败（已跳过并继续其余）：{failed_keywords}")
+            logger.warning("注意：多关键词会线性增加 search.list 配额消耗（每关键词 1 次请求）。")
+
+        # 公平合并：round-robin 交错各关键词候选，去重后截断，
+        # 确保每个关键词至少有机会进入最终候选集，避免前面的热门关键词占满名额。
+        total_budget = min(config['max_results'] * 2, 50)
         video_ids = []
         seen = set()
-        for vid in all_video_ids:
-            if vid not in seen:
-                seen.add(vid)
-                video_ids.append(vid)
-            if len(video_ids) >= min(config['max_results'] * 2, 50):
-                break
+        if batch_results:
+            iterators = [iter(ids) for ids in batch_results]
+            active = list(iterators)
+            while active and len(video_ids) < total_budget:
+                still_active = []
+                for it in active:
+                    try:
+                        vid = next(it)
+                    except StopIteration:
+                        continue
+                    if vid not in seen:
+                        seen.add(vid)
+                        video_ids.append(vid)
+                    # 该批仍有剩余则保留，继续顺序轮转（即便本批本轮贡献为重复项）
+                    still_active.append(it)
+                active = still_active
+                if len(video_ids) >= total_budget:
+                    break
+        logger.info(f"多关键词合并后候选 {len(video_ids)} 个（预算 {total_budget}，来源批次 {len(batch_results)}）")
         
         if not video_ids:
             return []

--- a/modules/youtube_monitor.py
+++ b/modules/youtube_monitor.py
@@ -16,6 +16,7 @@ from googleapiclient.http import DEFAULT_HTTP_TIMEOUT_SEC
 import httplib2
 import threading
 import time
+import re
 from urllib.parse import quote, urlsplit
 from apscheduler.schedulers.background import BackgroundScheduler
 from logging.handlers import RotatingFileHandler
@@ -1048,16 +1049,25 @@ class YouTubeMonitor:
         if published_before:
             search_params['publishedBefore'] = published_before
         
-        # 添加关键词搜索
-        if config['keywords']:
-            search_params['q'] = config['keywords']
-        
         # 添加分类过滤
         if config['category_id'] and config['category_id'] != '0':
             search_params['videoCategoryId'] = config['category_id']
-        
-        # 不再按 videoDuration 分批搜索，统一一次搜索后在详情阶段精确分类
-        search_batches = [dict(search_params)]
+
+        # 添加关键词搜索：支持多关键词 OR 搜索。
+        # 多个关键词可用逗号/分号/空格/换行分隔，每个关键词单独发起一次搜索请求，
+        # 最后合并并去重，实现“任一关键词匹配即搬运”的语义（原先是整串 AND 搜索）。
+        raw_kw = (config.get('keywords') or '').strip()
+        keywords_list = [k for k in re.split(r'[\s,;，；\n]+', raw_kw) if k] if raw_kw else []
+        if keywords_list:
+            search_batches = []
+            for kw in keywords_list:
+                sp = dict(search_params)
+                sp['q'] = kw
+                search_batches.append(sp)
+            logger.info(f"多关键词 OR 搜索，共 {len(keywords_list)} 个: {keywords_list}")
+        else:
+            # 无关键词则按空查询搜索（返回热门视频），保持原有行为
+            search_batches = [dict(search_params)]
 
         all_video_ids = []
         for idx, sp in enumerate(search_batches, 1):


### PR DESCRIPTION
## 关联 Issue
Closes #111

## 问题
多关键词监控被 YouTube Data API 当作整串 AND 搜索（`q` 参数语义），导致几乎永远搜不到视频（0 结果）。

## 修复
`modules/youtube_monitor.py` 的 `_fetch_search_videos()`：
- 新增 top-level `import re`。
- 将 `config['keywords']` 按 `[\s,;，；\n]+` 拆分为多个关键词，每个关键词单独发起一次 `search.list` 请求，最后合并 `video_id` 并去重，实现「任一关键词匹配即搬运」的 OR 语义。
- 无关键词时退化为空查询（返回热门视频），保持原有行为。

## 验证
同一多关键词配置，修复后从 0 视频变为命中约 40 视频（筛选后约 20 进队列）。

> 注：本 PR 仅修复关键词 OR 语义（Issue #111）。时间窗口尊重 `time_period` 的修复（Issue #112）在独立 PR 中提交，二者互不耦合。

---

## 评审意见修复（reviewer change request）
针对评审提出的阻塞问题，已追加提交修复：

1. **公平合并（修复阻塞点）**：多关键词结果不再按关键词顺序拼接后全局截断。改为 **round-robin 交错**各关键词候选、去重后截断到 `min(max_results*2, 50)`，确保每个关键词至少有机会进入最终候选集，真正实现可靠的 OR（而非退化为优先匹配首个关键词）。
2. **单批容错**：每个关键词的 `search.list` 单独 `try/except`，失败时记录失败关键词并跳过，继续处理其余关键词与整轮监控（任意单批异常不再终止整轮）。
3. **配额提示**：新增日志明确「多关键词会线性增加 `search.list` 配额消耗（每关键词 1 次请求）」；建议在监控 UI/说明中向用户提示该点。

> 单关键词 / 无关键词场景仍走原行为，round-robin 退化为顺序取满，等价原有逻辑。

---

## 评审二次修复（第二轮 change request）
针对第二轮评审指出的阻塞边界问题，已追加提交修复：

1. **防止越过 50 ID 上限（阻塞）**：原实现仅在外层 while 每轮开始时检查预算，内层仍会遍历本轮所有活跃 iterator，可能从 48 追加到 52 再退出，导致 `videos.list` 收到超过 50 个 ID 而 400。现改为**每次成功 `append` 后立即检查 `total_budget` 并 break 内层 + 外层**，保证 `video_ids` 长度 ≤ `min(max_results*2, 50)`（≤50），且跳出后不再处理本轮其余 iterator。已用多场景模拟验证：4 关键词 / budget=50、3 关键词、7 关键词等均严格 ≤ 预算、无重复。
2. **配额提示位置（非阻塞）**：配额提示从无失败分支移出，改为多关键词（`batch_results > 1`）即记录，正常成功路径也会打印，提醒线性增加 `search.list` 配额。
