### PR TITLE
fix(monitor): 搜索窗口尊重 time_period 配置，去掉动态 1 天分支

### DIFF
--- a/modules/youtube_monitor.py
+++ b/modules/youtube_monitor.py
@@ -982,14 +982,10 @@ class YouTubeMonitor:
                         logger.info("最新跟进模式：首次运行，仅从当前时间开始跟进新发布的视频")
                 else:
                     # 其他模式或全局检索：使用配置的时间段
-                    if config.get('channel_mode') == 'latest':
-                        # 保持原有行为：对于非频道监控的'latest'，按调度间隔*2估算窗口
-                        interval_hours = config.get('schedule_interval', 120) / 60 * 2
-                        days = max(1, interval_hours / 24)  # 至少1天
-                        logger.info(f"使用动态时间段: 最近 {days:.1f} 天（基于调度间隔 {config.get('schedule_interval', 120)} 分钟）")
-                    else:
-                        days = config.get('time_period', 7)
-                        logger.info(f"使用时间段: 最近 {days} 天")
+                    # 统一使用配置的时间段（time_period，默认7天）作为搜索窗口，
+                    # 避免动态1天窗口漏掉稍早发布的视频；配合任务去重不会重复建任务。
+                    days = max(config.get('time_period', 7), 1)
+                    logger.info(f"使用时间段: 最近 {days} 天（time_period 配置）")
                     published_after = (datetime.utcnow() - timedelta(days=days)).strftime('%Y-%m-%dT%H:%M:%SZ')
             
             # 如果指定了频道，优先使用频道搜索


### PR DESCRIPTION
## 关联 Issue
Closes #112

## 问题
监控时间窗口在 `channel_mode == 'latest'` 分支被写死为动态的「最近 1 天」（按调度间隔估算），完全忽略了 `time_period` 配置（默认 7 天），导致更早发布的视频永远搜不到。

## 修复
`modules/youtube_monitor.py` 的 `_fetch_search_videos()`：
- 去掉 `channel_mode == 'latest'` 的动态 1 天分支，统一为 `days = max(config.get('time_period', 7), 1)`，使搜索窗口真正尊重 `time_period` 配置。
- 配合任务去重（`monitor_history` / 已有任务跳过），扩大窗口不会重复建任务，仅多消耗少量 API 额度。

## 验证
设 `time_period = 7`、调度间隔 45 分钟时，日志由 `使用动态时间段: 最近 1.0 天` 变为 `使用时间段: 最近 7 天（time_period 配置）`。

> 注：本 PR 仅修复时间窗口尊重 `time_period`（Issue #112）。多关键词 OR 搜索（Issue #111）在独立 PR 中提交，二者互不耦合。
