### PR TITLE
fix(task): 上传成功后立即删除本地文件，避免磁盘被大视频撑爆

### DIFF
--- a/modules/task_manager.py
+++ b/modules/task_manager.py
@@ -8041,6 +8041,15 @@ class TaskProcessor:
                     status=TASK_STATES['COMPLETED'],
                     acfun_upload_response=json.dumps(result, ensure_ascii=False)
                 )
+                # 单平台(AcFun)上传成功后立即删除本地文件，腾出磁盘空间，
+                # 避免大视频长期占用磁盘导致后续任务因 No space left on device 失败。
+                # 双平台(both)场景由 B 站上传分支（最后平台）统一删除，这里不重复删。
+                try:
+                    if _get_task_upload_target(task) == UPLOAD_TARGET_ACFUN:
+                        delete_task_files(task_id)
+                        task_logger.info(f"AcFun 上传完成，已删除本地文件释放空间: {task_id}")
+                except Exception as _e:
+                    task_logger.warning(f"上传后删除本地文件失败（不影响已完成的 AcFun 上传）: {_e}")
             else:
                 task_logger.error(f"视频上传失败: {result}")
                 update_task(
@@ -8293,6 +8302,18 @@ class TaskProcessor:
                     bilibili_upload_response=json.dumps(result, ensure_ascii=False),
                     upload_progress=None
                 )
+                # 上传到 B 站成功后立即删除本地文件，腾出磁盘空间，
+                # 避免大视频（如 CS2 比赛直播流，单条可达十余 GB）长期占用磁盘，
+                # 导致后续任务因「No space left on device」而失败。
+                # - bilibili 单平台：此处即为最后平台，直接删除；
+                # - both 双平台：AcFun 已先上传完成，B 站为最后平台，同样删除；
+                # - acfun 单平台：不会进入本分支，由 AcFun 分支处理。
+                try:
+                    if _get_task_upload_target(task) != UPLOAD_TARGET_ACFUN:
+                        delete_task_files(task_id)
+                        task_logger.info(f"bilibili 上传完成，已删除本地文件释放空间: {task_id}")
+                except Exception as _e:
+                    task_logger.warning(f"上传后删除本地文件失败（不影响已完成的 B 站上传）: {_e}")
             else:
                 task_logger.error(f"bilibili上传失败: {result}")
                 update_task(


### PR DESCRIPTION
## 概述

Closes #115

Y2A 当前在视频上传到 B 站（或 AcFun）成功后**不会自动清理本地文件**，仅依赖默认关闭的 `DOWNLOAD_CLEANUP_*` 定时任务或手动 `delete_task()`。对于 CS2 比赛直播流之类的大视频（单条约十余 GB），下载目录 `downloads/<task_id>` 会长期占用磁盘，多个任务累积后极易触发 `No space left on device`，导致后续任务下载/上传失败。

本 PR 在上传成功后**立即删除本地任务目录**，腾出磁盘空间。

## 修改内容

文件：`modules/task_manager.py`

- **B 站上传成功分支**（`_do_upload_to_bilibili`）：成功后调用 `delete_task_files(task_id)`。
  - `bilibili` 单平台：此处即为最后平台，直接删除；
  - `both` 双平台：AcFun 已先上传完成，B 站为最后平台，同样删除；
  - `acfun` 单平台：不会进入本分支，由 AcFun 分支处理。
- **AcFun 上传成功分支**（`_do_upload_to_acfun`）：成功后仅当目标为 `acfun` 单平台时调用 `delete_task_files(task_id)`；`both` 场景交由 B 站分支（最后平台）统一删除，避免重复删除。

## 安全性

- 删除走既有 `delete_task_files(task_id)`，其内部先用 `_get_task_download_dir_real(task_id)` 对 `task_id` 做 UUID 格式与真实路径校验，**杜绝路径穿越**，只会删除 `downloads/<task_id>` 目录。
- 删除包裹在独立 `try/except` 中：即使删除失败也只记 warning，**不影响已完成的上传状态**。

## 行为对照

| 上传目标 | 删除时机 |
| --- | --- |
| `bilibili` | B 站上传成功后 |
| `acfun` | AcFun 上传成功后 |
| `both` | AcFun → B 站，B 站（最后平台）上传成功后 |
