### PR TITLE
fix(edit-task): 修复上传按钮被隐藏 action 字段抢占导致不触发上传

### DIFF
--- a/app.py
+++ b/app.py
@@ -1832,7 +1832,12 @@ def edit_task(task_id):
         return redirect(url_for('tasks'))
     
     if request.method == 'POST':
-        action = request.form.get('action', 'save_metadata').strip().lower()
+        # 主表单的隐藏字段已改名 default_action（避免与上传按钮的同名 action 冲突）。
+        # 这里优先取显式提交的 action（如 force_upload），回退到 default_action（save_metadata）。
+        _submitted_actions = [a for a in request.form.getlist('action') if a]
+        action = (_submitted_actions[0]
+                  if _submitted_actions
+                  else request.form.get('default_action', 'save_metadata')).strip().lower()
         redirect_target = url_for('edit_task', task_id=task_id)
 
         if action == 'replace_cover':

--- a/app.py
+++ b/app.py
@@ -1821,6 +1821,23 @@ def manual_review():
     
     return render_template('manual_review.html', tasks=review_tasks)
 
+def _resolve_edit_task_action(form):
+    """从多值同名 action 表单中解析实际要执行的动作。
+
+    优先级：force_upload > 其它显式提交的 action > default_action（save_metadata）。
+    升级前已打开/被缓存的旧页面会同时提交 action=save_metadata 与 action=force_upload，
+    二者按 DOM 顺序提交后 Werkzeug 仍保留两个值；这里显式优先识别 force_upload，
+    避免点击「上传到 Bilibili」却只走保存。
+    """
+    _submitted = [a.strip().lower() for a in form.getlist('action') if a and a.strip()]
+    if 'force_upload' in _submitted:
+        return 'force_upload'
+    if _submitted:
+        return _submitted[0]
+    _default = form.get('default_action') or 'save_metadata'
+    return (_default or 'save_metadata').strip().lower()
+
+
 @app.route('/tasks/<task_id>/edit', methods=['GET', 'POST'])
 @login_required
 def edit_task(task_id):
@@ -1833,11 +1850,8 @@ def edit_task(task_id):
     
     if request.method == 'POST':
         # 主表单的隐藏字段已改名 default_action（避免与上传按钮的同名 action 冲突）。
-        # 这里优先取显式提交的 action（如 force_upload），回退到 default_action（save_metadata）。
-        _submitted_actions = [a for a in request.form.getlist('action') if a]
-        action = (_submitted_actions[0]
-                  if _submitted_actions
-                  else request.form.get('default_action', 'save_metadata')).strip().lower()
+        # 多值同名 action 时显式优先匹配 force_upload（而非取 DOM 顺序第一个）。
+        action = _resolve_edit_task_action(request.form)
         redirect_target = url_for('edit_task', task_id=task_id)
 
         if action == 'replace_cover':

--- a/templates/edit_task.html
+++ b/templates/edit_task.html
@@ -173,7 +173,7 @@
             <!-- 右侧编辑表单 -->
             <div class="col-md-8">
                 <form method="post" action="{{ url_for('edit_task', task_id=task.id) }}" id="task-edit-form">
-                    <input type="hidden" name="action" value="save_metadata">
+                    <input type="hidden" name="default_action" value="save_metadata">
                     <div class="card mb-4">
                         <div class="card-header">
                             编辑视频信息

--- a/tests/test_edit_task_upload_action.py
+++ b/tests/test_edit_task_upload_action.py
@@ -1,0 +1,67 @@
+"""
+回归测试：编辑任务页「上传」按钮必须真正触发上传，而非被隐藏的
+save_metadata 字段抢占（同名 action 字段冲突）。
+
+根因：主表单内存在两个同名为 action 的字段——隐藏字段
+value="save_metadata"（始终提交）与上传按钮 value="force_upload"。
+点击上传时二者同时提交，Werkzeug 的 request.form.get('action') 只取
+表单源码中第一个出现的（隐藏的 save_metadata），导致 force_upload 分支
+永不触发，点「上传」实际只走保存。
+
+修复：隐藏字段改名 default_action；app.py 改用 getlist('action') 优先取
+force_upload，回退到 default_action。本测试看守这个条件不回归。
+"""
+import pathlib
+import re
+import unittest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+TEMPLATE = REPO_ROOT / "templates" / "edit_task.html"
+
+
+class EditTaskUploadActionRegressionTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.html = TEMPLATE.read_text(encoding="utf-8")
+
+    def _main_form_block(self):
+        # 截取主编辑表单（id=task-edit-form）的片段，用于精确断言
+        m = re.search(
+            r'<form method="post" action="\{\{ url_for\(.edit_task[^>]*'
+            r'id="task-edit-form"[^>]*>.*?</form>',
+            self.html, re.DOTALL)
+        self.assertIsNotNone(m, "找不到主编辑表单 task-edit-form")
+        return m.group(0)
+
+    def test_hidden_save_metadata_field_renamed_to_default_action(self):
+        self.assertIn(
+            'name="default_action" value="save_metadata"',
+            self.html,
+            "主表单的隐藏保存字段应改名为 default_action，避免与上传按钮同名冲突",
+        )
+
+    def test_no_conflicting_hidden_action_save_metadata_in_main_form(self):
+        main_form = self._main_form_block()
+        self.assertNotIn(
+            'name="action" value="save_metadata"',
+            main_form,
+            "主表单内不应再存在 name=action value=save_metadata 的隐藏字段"
+            "（否则会与上传按钮同名，再次抢占 action）",
+        )
+
+    def test_upload_button_still_carries_action_force_upload(self):
+        main_form = self._main_form_block()
+        self.assertIn(
+            'name="action" value="force_upload"',
+            main_form,
+            "上传按钮必须保留 name=action value=force_upload，否则无法触发上传",
+        )
+
+    def test_cover_actions_preserved(self):
+        # 封面替换/恢复是各自独立的表单，其 name=action 不应被误改
+        self.assertIn('name="action" value="replace_cover"', self.html)
+        self.assertIn('name="action" value="restore_cover"', self.html)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_edit_task_upload_action_route.py
+++ b/tests/test_edit_task_upload_action_route.py
@@ -13,14 +13,34 @@ CI 环境已安装 Flask 等依赖，可直接运行；本地若缺少依赖则�
 import unittest
 from unittest.mock import patch, MagicMock
 
+# 仅当缺失的是明确的外部依赖（Flask 生态）时跳过测试；
+# 项目内部模块（app / modules.*）的导入错误属于真实回归，必须让测试失败，
+# 否则会出现「绿了但没覆盖」的假阳性（reviewer 已复现：注入项目内部 ImportError
+# 会让整组路由测试被标记为 skipped）。
+_EXTERNAL_DEPS = {
+    'flask', 'werkzeug', 'wtforms', 'markupsafe',
+    'itsdangerous', 'jinja2', 'click', 'blinker',
+}
+
+
+def _missing_external_dep(exc):
+    name = getattr(exc, 'name', None)
+    if name is None:
+        return False
+    return name.split('.')[0] in _EXTERNAL_DEPS
+
+
 try:
     import app as web_app
     from werkzeug.datastructures import MultiDict
     _HAS_APP = True
-except ImportError:
-    # 仅依赖缺失（如本地未装 Flask / 项目依赖）时跳过；
-    # 应用自身语法 / 初始化等其它错误应让测试失败，避免“绿了但没覆盖”的假阳性。
-    _HAS_APP = False
+except ImportError as e:
+    if _missing_external_dep(e):
+        # 外部依赖缺失：CI 环境之外无法运行，跳过
+        _HAS_APP = False
+    else:
+        # 项目内部模块缺失：真实回归，重新抛出让测试失败
+        raise
 
 
 @unittest.skipUnless(_HAS_APP, "app 依赖未安装，CI 环境可运行")

--- a/tests/test_edit_task_upload_action_route.py
+++ b/tests/test_edit_task_upload_action_route.py
@@ -15,8 +15,11 @@ from unittest.mock import patch, MagicMock
 
 try:
     import app as web_app
+    from werkzeug.datastructures import MultiDict
     _HAS_APP = True
-except Exception:  # 依赖缺失（如本地未装 Flask）时跳过，避免影响其它测试
+except ImportError:
+    # 仅依赖缺失（如本地未装 Flask / 项目依赖）时跳过；
+    # 应用自身语法 / 初始化等其它错误应让测试失败，避免“绿了但没覆盖”的假阳性。
     _HAS_APP = False
 
 
@@ -57,7 +60,10 @@ class EditTaskForceUploadMultiValueRouteTests(unittest.TestCase):
         try:
             resp = self.client.post(
                 '/tasks/1/edit',
-                data=[('action', 'save_metadata'), ('action', 'force_upload')],
+                # Werkzeug 3.1 的 _iter_data() 要求 data.items() 存在，
+                # plain list 会在请求发出前抛 AttributeError → 必须用 MultiDict
+                # 保留 action 的 DOM 顺序（save_metadata 在前，force_upload 在后）。
+                data=MultiDict([('action', 'save_metadata'), ('action', 'force_upload')]),
             )
         finally:
             for p in patchers:
@@ -78,7 +84,7 @@ class EditTaskForceUploadMultiValueRouteTests(unittest.TestCase):
         try:
             resp = self.client.post(
                 '/tasks/1/edit',
-                data=[('action', 'save_metadata')],
+                data=MultiDict([('action', 'save_metadata')]),
             )
         finally:
             for p in patchers:

--- a/tests/test_edit_task_upload_action_route.py
+++ b/tests/test_edit_task_upload_action_route.py
@@ -1,0 +1,96 @@
+"""
+回归测试：编辑任务页「上传到 Bilibili」按钮在提交多值同名 action
+（action=save_metadata&action=force_upload，旧缓存页面会出现）时，必须真正
+触发上传，而非被 save_metadata 抢占只走保存。
+
+这是 app.py 内 `_resolve_edit_task_action` 路由级行为的覆盖：直接打到
+/tasks/<id>/edit 端点，用重复的表单字段模拟旧页面的多值提交，断言 force_upload
+优先被选中（重定向到 manual_review 并触发后台上传），而非回退到 save_metadata
+（重定向回编辑页）。
+
+CI 环境已安装 Flask 等依赖，可直接运行；本地若缺少依赖则自动跳过。
+"""
+import unittest
+from unittest.mock import patch, MagicMock
+
+try:
+    import app as web_app
+    _HAS_APP = True
+except Exception:  # 依赖缺失（如本地未装 Flask）时跳过，避免影响其它测试
+    _HAS_APP = False
+
+
+@unittest.skipUnless(_HAS_APP, "app 依赖未安装，CI 环境可运行")
+class EditTaskForceUploadMultiValueRouteTests(unittest.TestCase):
+    def setUp(self):
+        web_app.app.config['TESTING'] = True
+        web_app.app.config['WTF_CSRF_ENABLED'] = False
+        self.client = web_app.app.test_client()
+
+    def _fake_task(self, status):
+        return {
+            'task_id': '1',
+            'status': status,
+            'upload_target': 'bilibili',
+            'video_title_translated': '',
+            'description_translated': '',
+            'tags_generated': '[]',
+            'selected_partition_id_bilibili': '123',
+        }
+
+    def _patch_stack(self, task_status):
+        """统一打桩：绕过登录（load_config 返回空，password_protection 不启用）、
+        任务读取与后台上传，使路由可走到 force_upload 分支。"""
+        return (
+            patch.object(web_app, 'get_task', return_value=self._fake_task(task_status)),
+            patch.object(web_app, '_start_background_force_upload', lambda *a, **k: None),
+            patch.object(web_app, 'update_task', MagicMock()),
+            patch.object(web_app, 'load_config', return_value={}),
+            patch.object(web_app, '_missing_upload_partition_labels', lambda *a, **k: []),
+        )
+
+    def test_multivalue_action_prioritizes_force_upload(self):
+        # 旧缓存页面会同时提交两个 action，按 DOM 顺序第一个是 save_metadata
+        patchers = self._patch_stack(web_app.TASK_STATES['DOWNLOADED'])
+        for p in patchers:
+            p.start()
+        try:
+            resp = self.client.post(
+                '/tasks/1/edit',
+                data=[('action', 'save_metadata'), ('action', 'force_upload')],
+            )
+        finally:
+            for p in patchers:
+                p.stop()
+
+        # force_upload 分支重定向到 manual_review 并启动后台上传
+        self.assertIn(resp.status_code, (302, 303))
+        location = resp.headers.get('Location', '')
+        self.assertIn('manual_review', location,
+                      "多值 action 含 force_upload 时应走上传分支（重定向 manual_review），"
+                      f"实际 Location={location}")
+
+    def test_single_save_metadata_redirects_back_to_edit(self):
+        # 单独提交 save_metadata 时应只保存，重定向回编辑页（非 manual_review）
+        patchers = self._patch_stack(web_app.TASK_STATES['DOWNLOADED'])
+        for p in patchers:
+            p.start()
+        try:
+            resp = self.client.post(
+                '/tasks/1/edit',
+                data=[('action', 'save_metadata')],
+            )
+        finally:
+            for p in patchers:
+                p.stop()
+
+        self.assertIn(resp.status_code, (302, 303))
+        location = resp.headers.get('Location', '')
+        self.assertNotIn('manual_review', location,
+                         "仅提交 save_metadata 不应触发上传分支")
+        self.assertIn('/tasks/1/edit', location,
+                      "仅保存时应重定向回编辑页")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_edit_task_upload_action_route.py
+++ b/tests/test_edit_task_upload_action_route.py
@@ -8,42 +8,23 @@
 优先被选中（重定向到 manual_review 并触发后台上传），而非回退到 save_metadata
 （重定向回编辑页）。
 
-CI 环境已安装 Flask 等依赖，可直接运行；本地若缺少依赖则自动跳过。
+CI 环境已安装全部依赖，导入即硬依赖、不做跳过。
+
+导入策略（根因修复）：直接 import app 与 MultiDict，**不包裹任何 try/except 跳过**。
+任何导入错误——无论项目内部模块（app / modules.*）还是外部依赖——都代表真实回归，
+必须让测试失败，否则会出现「绿了但没覆盖」的假阳性（reviewer 曾复现：注入项目内部
+ImportError 会让整组路由测试被标记为 skipped）。原先基于白名单区分「外部依赖缺失
+vs 内部模块缺失」的做法既误分类普通 ImportError，又漏掉 flask_cors / Pillow /
+APScheduler / requests / googleapiclient / Cryptodome 等，维护成本高且仍可能假绿。
+统一改为「导入即硬依赖」后，缺依赖时测试直接报错，问题暴露得更早、更可靠。
 """
 import unittest
 from unittest.mock import patch, MagicMock
 
-# 仅当缺失的是明确的外部依赖（Flask 生态）时跳过测试；
-# 项目内部模块（app / modules.*）的导入错误属于真实回归，必须让测试失败，
-# 否则会出现「绿了但没覆盖」的假阳性（reviewer 已复现：注入项目内部 ImportError
-# 会让整组路由测试被标记为 skipped）。
-_EXTERNAL_DEPS = {
-    'flask', 'werkzeug', 'wtforms', 'markupsafe',
-    'itsdangerous', 'jinja2', 'click', 'blinker',
-}
+import app as web_app
+from werkzeug.datastructures import MultiDict
 
 
-def _missing_external_dep(exc):
-    name = getattr(exc, 'name', None)
-    if name is None:
-        return False
-    return name.split('.')[0] in _EXTERNAL_DEPS
-
-
-try:
-    import app as web_app
-    from werkzeug.datastructures import MultiDict
-    _HAS_APP = True
-except ImportError as e:
-    if _missing_external_dep(e):
-        # 外部依赖缺失：CI 环境之外无法运行，跳过
-        _HAS_APP = False
-    else:
-        # 项目内部模块缺失：真实回归，重新抛出让测试失败
-        raise
-
-
-@unittest.skipUnless(_HAS_APP, "app 依赖未安装，CI 环境可运行")
 class EditTaskForceUploadMultiValueRouteTests(unittest.TestCase):
     def setUp(self):
         web_app.app.config['TESTING'] = True


### PR DESCRIPTION
## 关联
Closes #123

## 问题
编辑任务页主表单存在两个同名为 `action` 的字段：
- 隐藏字段 `value="save_metadata"`（始终随表单提交）；
- 上传按钮 `value="force_upload"`。

点击「上传到 Bilibili/双平台/AcFun」时二者同时提交，Werkzeug 的 `request.form.get('action')` 只取表单源码中**第一个**出现的（隐藏的 `save_metadata`），导致 `force_upload` 分支永不触发——点「上传」实际只走保存，任务停在 `READY_FOR_UPLOAD`，后台无上传动作，用户无报错提示、极易误以为已发布。

## 修复
- `templates/edit_task.html`：将隐藏字段 `name="action"` 改为 `name="default_action"`，消除同名冲突（仅按钮保留 `action`）。
- `app.py`：`edit_task` 改用 `request.form.getlist('action')` 优先取 `force_upload`，回退到 `save_metadata`，进一步增强健壮性，避免任何同源提交歧义。

## 测试建议
在处于可上传状态的任务编辑页点击「上传到 Bilibili/双平台/AcFun」，任务应进入 `UPLOADING` 并最终 `COMPLETED`；点击「保存修改」仍走原有保存逻辑。