### PR TITLE
fix(monitor): add persistent Search Queries quota guard

### DIFF
--- a/modules/config_manager.py
+++ b/modules/config_manager.py
@@ -147,6 +147,11 @@ DEFAULT_CONFIG = {
     "SUBTITLE_QC_THRESHOLD": 0.60,  # 通过阈值（0-1），仅作为 AI 复核分数下限（质量优先）
     "SUBTITLE_QC_SAMPLE_MAX_ITEMS": 80,  # AI 抽样条目上限（实际会按边界程度自适应收缩）
     "SUBTITLE_QC_MAX_CHARS": 9000,  # AI 送检最大字符数上限（实际会按边界程度自适应收缩）
+
+    # 监控配速：每轮 search 次数上限（每次 search 消耗 YouTube Data API 100 配额单位，
+    # 免费额度 10000/天）。多关键词 OR 搜索时按天轮流挑选，结合每天仅跑一次，可避免
+    # 高频调度在一天内把配额打满（429 quotaExceeded）。
+    "MONITOR_SEARCHES_PER_RUN": 2,
     # 并发控制配置
     "MAX_CONCURRENT_TASKS": 2,  # 最大并发任务数
     "MAX_CONCURRENT_UPLOADS": 1,  # 最大并发上传数

--- a/modules/youtube_monitor.py
+++ b/modules/youtube_monitor.py
@@ -1096,6 +1096,17 @@ class YouTubeMonitor:
             logger.warning("今日 search 配额已耗尽（当日熔断），跳过本轮搜索（将于次日太平洋时间重置）")
             return []
 
+        # 双重闸门：全局桶有余额时，仍可能因「本配置当日公平份额」已耗尽而无法发起请求。
+        # 此时同样跳过整轮、不推进游标（否则会出现「无搜索却推进游标」的空转，
+        # 即全局剩余 48、本配置份额为 0 时游标仍 +1 的经典竞态）。
+        if not self._config_share_remaining(config['id']):
+            self._last_fetch_quota_skipped = True
+            logger.warning(
+                f"配置 {config.get('name', config['id'])} 当日 search 配额份额已耗尽，"
+                "跳过本轮（不推进关键词游标，将于次日太平洋时间重置）"
+            )
+            return []
+
         # 预算通过后才构造 search 批次；仅在「关键词数 > 每轮上限」时推进轮转游标，
         # 保证高频调度下轮流覆盖全部关键词、且游标不会在熔断期空推进。
         if keywords_list:
@@ -1498,22 +1509,53 @@ class YouTubeMonitor:
             raise
 
     def _http_error_quota_reason(self, e: HttpError) -> Optional[str]:
-        """从 Google API HttpError 中提取结构化错误 reason。
+        """从 Google API HttpError 中提取结构化错误 reason（类型安全）。
 
         429 既可能是「当日配额耗尽」（quotaExceeded / dailyLimitExceeded），也可能是
         「短时窗口速率限制」（rateLimitExceeded）。二者处理完全不同：前者要触发当日
-        熔断、后者只需重试。只有结构化 reason 能可靠区分，故优先解析
-        `e.error_details`（googleapiclient 由响应 JSON 的 error.errors[] 反序列化而来），
-        解析不到时再退化到错误文本匹配。
+        熔断、后者只需重试。只有结构化 reason 能可靠区分，故优先解析错误中的 reason。
+
+        googleapiclient 在不同响应形态下，`error_details` 可能是：
+          - list[dict]（含 error.errors[]，最常见，字段缺 reason 时退文本）；
+          - str（仅 error.message 时，googleapiclient 把 error_details 设为字符串，
+            此时 `for d in details` 会遍历字符、用 `.get` 会 AttributeError —— 必须类型判定）；
+          - dict（整段 error 对象）。
+        为避免对字符串形态崩溃，先归一化成一个「错误对象列表」再逐个取 reason；
+        仍取不到时退化到 `e.content` 原始 JSON 与错误文本匹配。
         """
-        details = getattr(e, 'error_details', None)
-        if details:
-            for d in details:
-                r = (d or {}).get('reason')
+        raw = getattr(e, 'error_details', None)
+        err_objs: list = []
+        if isinstance(raw, list):
+            err_objs = raw
+        elif isinstance(raw, dict):
+            err_objs = raw.get('errors') or [raw]
+        elif isinstance(raw, str):
+            # 某些版本/场景会把 error_details 反序列化为字符串形式的 JSON
+            try:
+                parsed = json.loads(raw)
+                if isinstance(parsed, list):
+                    err_objs = parsed
+                elif isinstance(parsed, dict):
+                    err_objs = parsed.get('errors') or [parsed]
+            except (ValueError, TypeError):
+                err_objs = []
+        for d in err_objs:
+            if isinstance(d, dict):
+                r = d.get('reason')
                 if r:
                     return r
-        # error_details 缺 reason 字段（如只有 message）或不存在时，退化到错误文本抓 reason。
-        # 容忍 JSON 引号包裹（"reason":"quotaExceeded"）与非引号纯文本（reason: rateLimitExceeded）。
+        # error_details 无 reason 或形态异常时，尝试从原始响应体 e.content 解析
+        content = getattr(e, 'content', None)
+        if isinstance(content, (bytes, bytearray)):
+            try:
+                parsed = json.loads(content.decode('utf-8', 'replace'))
+                if isinstance(parsed, dict):
+                    for d in (parsed.get('error', {}).get('errors') or []):
+                        if isinstance(d, dict) and d.get('reason'):
+                            return d['reason']
+            except (ValueError, TypeError):
+                pass
+        # 最后退化到错误文本抓 reason（容忍 JSON 引号包裹与非引号纯文本）
         m = re.search(r'\breason["\']?\s*:\s*["\']?([A-Za-z_]+)', str(e))
         if m:
             return m.group(1)
@@ -2122,28 +2164,43 @@ class YouTubeMonitor:
             f"当日 search 配额熔断持久化失败（本进程已 fail-closed 停止发请求）：{last_err}"
         )
 
-    def _monitor_search_config_count(self):
-        """返回启用且「真正消费 search.list」的 auto 配置数（公平份额分母）。
+    def _is_search_consumer(self, c: Dict[str, Any]) -> bool:
+        """判断一个监控配置是否「实际消费 search.list」配额。
 
-        只有会发起 search.list 的配置才计入分母：有关键词（多关键词 OR 搜索）或
-        指定了频道（频道内搜索）的启用 auto 配置。playlist / latest / historical
-        等走 playlistItems.list / videos.list 的模式不消耗 search 配额，绝不能计入
-        （旧实现把它们算进分母，导致 search 配置被过度限流——根因之一）。
+        与 `_fetch_trending_videos` 的分流逻辑保持一致（权威谓词，单一来源）：
+        - 未启用 → 不消费；
+        - 有 `channel_ids` 且 `channel_mode == 'search'` → 走 `_fetch_channel_search_videos`（search.list）；
+        - 有 `channel_ids` 但 `channel_mode` 非 search（latest/historical）→ 走 playlist 模式，不消费 search；
+        - 无 `channel_ids`（普通关键词/全局检索）→ 走 `_fetch_search_videos`（search.list）。
+
+        因此「真正消费 search」的配置 = 启用 且 （无 channel_ids 或 channel_mode=='search'）。
+        注意：manual 配置同样会经由 `_fetch_trending_videos` 消费 search，故**不排除 manual**——
+        否则手动运行可先吃满全局桶、饿死自动配置（reviewer 指出的真实抢占场景）。
+        """
+        if not c.get('enabled'):
+            return False
+        channel_ids = (c.get('channel_ids') or '')
+        if isinstance(channel_ids, str) and channel_ids.strip():
+            return c.get('channel_mode') == 'search'
+        return True
+
+    def _per_config_share(self) -> int:
+        """返回单个 search 消费者当天的公平份额上限（budget // 消费者数，最少 1）。"""
+        count = max(1, self._monitor_search_config_count() or 1)
+        return max(1, self._MONITOR_DAILY_SEARCH_BUDGET // count)
+
+    def _monitor_search_config_count(self):
+        """返回「真正消费 search.list」的启用配置数（任意 schedule_type）。
+
+        这是公平份额分母。谓词来自 `_is_search_consumer`（与分流逻辑同源），
+        因此频道搜索配置（channel_ids + channel_mode=='search'）、普通关键词配置、手动运行
+        的搜索配置都会被正确计入；playlist/latest/historical 频道配置不计入。
         """
         try:
             configs = self.get_monitor_configs()
         except Exception:
             return 0
-        n = 0
-        for c in configs:
-            if not c.get('enabled'):
-                continue
-            if c.get('schedule_type') != 'auto':
-                continue
-            if (c.get('keywords') and str(c.get('keywords')).strip()) or \
-               (c.get('channel_id') and str(c.get('channel_id')).strip()):
-                n += 1
-        return n
+        return sum(1 for c in configs if self._is_search_consumer(c))
 
     def _try_consume_quota(self, n=1, config_id=None):
         """原子扣减 n 次 search 配额。
@@ -2169,8 +2226,7 @@ class YouTubeMonitor:
             return False
         share = None
         if config_id is not None:
-            search_cfg_count = max(1, self._monitor_search_config_count() or 1)
-            share = max(1, self._MONITOR_DAILY_SEARCH_BUDGET // search_cfg_count)
+            share = self._per_config_share()
         with sqlite3.connect(self.db_path, timeout=30) as conn:
             conn.execute(
                 'INSERT INTO monitor_quota_budget (quota_date, used) VALUES (?, 0) '
@@ -2205,6 +2261,28 @@ class YouTubeMonitor:
                     return False
             conn.commit()
         return True
+
+    def _config_share_remaining(self, config_id) -> bool:
+        """判断某配置当日是否仍有「公平份额」余额（不扣减）。
+
+        用于在发起真实请求前预检：当全局桶尚有余额、但本配置当日份额已耗尽时，
+        不应推进关键词轮转游标也不发起请求（避免「空推进游标」——见 _fetch_search_videos）。
+        """
+        if getattr(self, '_quota_depleted_day', None) == self._quota_day_str():
+            return False
+        share = self._per_config_share()
+        day = self._quota_day_str()
+        self._quota_reset_tables()
+        try:
+            with sqlite3.connect(self.db_path, timeout=30) as conn:
+                row = conn.execute(
+                    'SELECT used FROM monitor_quota_usage WHERE config_id = ? AND quota_date = ?',
+                    (config_id, day),
+                ).fetchone()
+            used = row[0] if row else 0
+        except Exception:
+            return True  # 读不到时保守放行，由 _try_consume_quota 兜底拦截
+        return used < share
 
     def _next_keyword_rotation_start(self, config_id, keyword_count, max_searches):
         """返回本轮关键词轮转起始下标，并原子推进游标（每轮推进，跨重启保持）。

--- a/modules/youtube_monitor.py
+++ b/modules/youtube_monitor.py
@@ -379,7 +379,7 @@ class YouTubeMonitor:
             
             for config in configs:
                 if config['enabled'] and config['schedule_type'] == 'auto':
-                    self._schedule_monitor(config['id'], self._monitor_schedule_interval_minutes())
+                    self._schedule_monitor(config['id'], self._resolve_schedule_interval_minutes(config))
                     restored_schedules += 1
             
             if restored_schedules > 0:
@@ -627,10 +627,10 @@ class YouTubeMonitor:
             # 保存配置到文件
             self._save_config_to_file(config_id, config_data)
             
-            # 如果是自动调度，添加到调度器（统一走每日预算节拍）
+            # 如果是自动调度，添加到调度器（尊重用户配置的间隔，配额由共享每日预算兜底）
             if config_data.get('schedule_type') == 'auto':
-                interval = self._monitor_schedule_interval_minutes()
-                logger.info(f"配置 {config_id} 启用自动调度，间隔: {interval}分钟（按天轮流模式）")
+                interval = self._resolve_schedule_interval_minutes(config_data)
+                logger.info(f"配置 {config_id} 启用自动调度，间隔: {interval}分钟")
                 self._schedule_monitor(config_id, interval)
             
             return config_id
@@ -1090,6 +1090,17 @@ class YouTubeMonitor:
 
         # 多关键词 OR 搜索：逐个关键词请求，并在每个 batch 外层单独容错，
         # 单个关键词失败不影响其他关键词与整轮监控。
+        # 跨配置共享的每日配额预算：限制今天实际发出的 search 次数，避免多配置/高频调度打满配额。
+        planned_searches = len(search_batches)
+        allowed_searches = self._consume_quota_budget(planned_searches)
+        if allowed_searches < planned_searches:
+            logger.warning(
+                f"每日跨配置 search 预算不足（已用 {self._quota_used}/{self._MONITOR_DAILY_SEARCH_BUDGET}），"
+                f"本轮仅执行 {allowed_searches}/{planned_searches} 个关键词搜索，其余跳过"
+            )
+            search_batches = search_batches[:allowed_searches]
+        if not search_batches:
+            logger.warning("每日跨配置 search 预算已耗尽，本轮监控跳过所有搜索（配额将在次日 UTC 重置）")
         batch_results = []  # 每个关键词的 videoId 列表
         failed_keywords = []
         for idx, sp in enumerate(search_batches, 1):
@@ -1257,7 +1268,12 @@ class YouTubeMonitor:
                 search_params['publishedBefore'] = published_before
             
             logger.info(f"在频道 {channel_id} 内搜索关键词: {keywords}")
-            
+
+            # 计入跨配置共享的每日 search 预算（频道内搜索每次消耗 1 次 search.list）
+            if self._consume_quota_budget(1) < 1:
+                logger.warning(f"每日跨配置 search 预算已耗尽，跳过频道 {channel_id} 的搜索（配额将在次日 UTC 重置）")
+                return []
+
             # 执行搜索（带重试）
             logger.debug(f"准备执行频道搜索请求，YouTube API 对象: {type(self.youtube)}")
             # 清理 None 值，避免 API 报错
@@ -1863,32 +1879,80 @@ class YouTubeMonitor:
             )
             conn.commit()
     
-    def _monitor_schedule_interval_minutes(self):
-        """统一调度间隔（配额预算节拍，单一策略来源）。
+    # YouTube Data API 免费配额：10000 单位/天，一次 search.list 消耗 100 单位。
+    # 多个监控配置共享同一个 API key 的每日配额，因此用一个跨配置共享的
+    # 「每日 search 次数」令牌桶统一兜底，避免高频调度 + 多配置把配额打满（429 quotaExceeded）。
+    _MONITOR_DAILY_QUOTA_UNITS = 10000
+    _MONITOR_QUOTA_PER_SEARCH = 100
+    # 实际可用 search 次数 = 配额 / 单次消耗，再留 5% 余量防边界 429
+    _MONITOR_DAILY_SEARCH_BUDGET = int(_MONITOR_DAILY_QUOTA_UNITS / _MONITOR_QUOTA_PER_SEARCH * 0.95)  # 95 次/天
 
-        YouTube Data API 免费配额仅 10000 单位/天，一次 search 消耗 100 单位。
-        配额预算按「每天」分摊：无论用户在配置里填多少分钟，实际调度统一为每天
-        一次（1440 分钟），配合 _fetch_search_videos 内「按天轮流选关键词」实现
-        均匀分布，避免高频调度 + 多关键词把每日配额打满（429 quotaExceeded）。
+    def _resolve_schedule_interval_minutes(self, config):
+        """返回该配置的调度间隔（分钟），尊重用户在设置页填写的 schedule_interval。
 
-        所有调度入口（启动 start_all_schedules / 恢复 _restart_restored_schedules /
-        新建 / 编辑 _update_schedule）都必须走这里，不能各自用 config['schedule_interval']，
-        否则会绕过每日预算。
+        之前无条件强制 1440（每日一次）属于行为回归：UI 仍允许 1–43200 并显示旧间隔，
+        但系统忽略了它，导致用户设的间隔不生效。这里恢复「尊重用户配置」的语义。
+
+        配额安全不再靠强制每日调度来保证，而是统一交由跨配置共享的每日 search 令牌桶
+        （见 _consume_quota_budget）兜底：无论调度多频繁，每天实际发出的 search 请求
+        总量被限制在 _MONITOR_DAILY_SEARCH_BUDGET 以内，且立即检查（start_all_schedules
+        的 15s 触发）也计入同一预算，不会绕过。
+
+        为安全与调度资源考虑，间隔下限 1 分钟、上限 1440 分钟（每日一次）：
+        低于每日的更高频对抓取新视频意义有限；超过每日无实际意义。
         """
-        return 1440
+        raw = config.get('schedule_interval')
+        try:
+            iv = int(raw)
+        except (TypeError, ValueError):
+            iv = 120
+        iv = max(1, min(iv, 1440))
+        return iv
+
+    def _quota_budget_remaining(self):
+        """返回今日跨配置共享的 search 预算剩余次数（自动按 UTC 日重置）。"""
+        today = datetime.utcnow().strftime('%Y-%m-%d')
+        if not hasattr(self, '_quota_date') or self._quota_date != today:
+            self._quota_date = today
+            self._quota_used = 0
+        return max(0, self._MONITOR_DAILY_SEARCH_BUDGET - self._quota_used)
+
+    def _consume_quota_budget(self, searches):
+        """尝试从跨配置共享的每日 search 预算中扣减 searches 次请求。
+
+        返回实际可执行的 search 次数（受今日预算上限约束，不会超过 searches）。
+        立即检查与定时运行都走同一份 _fetch_search_videos，因此都会计入本预算。
+        """
+        today = datetime.utcnow().strftime('%Y-%m-%d')
+        if not hasattr(self, '_quota_date') or self._quota_date != today:
+            self._quota_date = today
+            self._quota_used = 0
+        remaining = max(0, self._MONITOR_DAILY_SEARCH_BUDGET - self._quota_used)
+        allowed = min(searches, remaining)
+        self._quota_used += allowed
+        return allowed
 
     def _resolve_monitor_searches_per_run(self):
-        """从全局应用配置读取每轮 search 次数上限，并做非整数校验。
+        """从全局应用配置读取每轮 search 次数上限，并做严格校验。
 
         MONITOR_SEARCHES_PER_RUN 属于全局应用配置（config_manager.DEFAULT_CONFIG），
         而传入 _fetch_search_videos 的是 monitor DB 记录，上面没有该字段；若直接用
         config.get(...) 会恒为默认值 2 而从未真正生效。这里显式从全局配置读取并校验。
+
+        校验规则：必须为正整数，且受上限约束（默认上限 10），避免过大值一次性把
+        跨配置每日配额预算打满。非法或越界值回退到默认值 2。
         """
         try:
             raw = (load_config() or {}).get('MONITOR_SEARCHES_PER_RUN')
             if raw is None or raw == '':
                 return 2
-            return max(int(raw), 1)
+            val = int(raw)
+            if val < 1:
+                val = 1
+            if val > 10:
+                logger.warning("MONITOR_SEARCHES_PER_RUN 超过上限 10，已截断为 10")
+                val = 10
+            return val
         except (TypeError, ValueError):
             logger.warning("MONITOR_SEARCHES_PER_RUN 非整数，回退到默认值 2")
             return 2
@@ -1925,9 +1989,9 @@ class YouTubeMonitor:
         # 移除现有任务
         self._remove_schedule(config_id)
         
-        # 如果是自动调度，重新添加（统一走每日预算节拍）
+        # 如果是自动调度，重新添加（尊重用户配置的间隔，配额由共享每日预算兜底）
         if config_data.get('schedule_type') == 'auto' and config_data.get('enabled'):
-            self._schedule_monitor(config_id, self._monitor_schedule_interval_minutes())
+            self._schedule_monitor(config_id, self._resolve_schedule_interval_minutes(config_data))
     
     def _remove_schedule(self, config_id):
         """移除调度任务"""
@@ -2024,8 +2088,13 @@ class YouTubeMonitor:
             logger.error(f"清除所有监控历史记录失败: {str(e)}")
             return False, f"清除历史记录失败: {str(e)}"
     
-    def start_all_schedules(self):
-        """启动所有自动调度的监控任务"""
+    def start_all_schedules(self, immediate=True):
+        """启动所有自动调度的监控任务。
+
+        immediate=True 时，对「此前不存在对应定时任务」的配置额外安排一次 15s 后的立即检查；
+        对已有定时任务（例如设置保存触发的重启）不再重复安排，避免每次保存都触发一次立即运行
+        从而绕过每日配额预算。该立即检查同样走 _fetch_search_videos，会计入跨配置每日预算。
+        """
         logger.info("开始启动所有自动调度的监控任务")
         
         configs = self.get_monitor_configs()
@@ -2034,24 +2103,26 @@ class YouTubeMonitor:
         logger.info(f"找到 {len(auto_configs)} 个启用的自动调度配置")
         
         for config in auto_configs:
-            # 统一走每日预算节拍（所有调度入口一致，避免高频调度打满配额）
-            run_interval = self._monitor_schedule_interval_minutes()
-            logger.info(f"启动调度: {config['name']} (ID: {config['id']}), 间隔: {run_interval}分钟（按天轮流模式）")
+            # 尊重用户配置的调度间隔（而非强制每日），配额安全由共享每日预算兜底
+            job_existed = self.scheduler.get_job(f"monitor_{config['id']}") is not None
+            run_interval = self._resolve_schedule_interval_minutes(config)
+            logger.info(f"启动调度: {config['name']} (ID: {config['id']}), 间隔: {run_interval}分钟")
             self._schedule_monitor(config['id'], run_interval)
-            # 启动/重启后立即触发一次检查，避免首次检查被推到一整个间隔之后
-            try:
-                self.scheduler.add_job(
-                    func=self.run_monitor,
-                    trigger='date',
-                    run_date=datetime.now() + timedelta(seconds=15),
-                    args=[config['id']],
-                    id=f"monitor_immediate_{config['id']}",
-                    replace_existing=True,
-                    misfire_grace_time=600,
-                )
-                logger.info(f"已安排启动后立即检查: {config['name']} (ID: {config['id']})")
-            except Exception as e:
-                logger.error(f"安排启动后立即检查失败: {str(e)}")
+            # 仅当定时任务此前不存在时才安排「启动后立即检查」，避免每次保存都绕过每日预算
+            if immediate and not job_existed:
+                try:
+                    self.scheduler.add_job(
+                        func=self.run_monitor,
+                        trigger='date',
+                        run_date=datetime.now() + timedelta(seconds=15),
+                        args=[config['id']],
+                        id=f"monitor_immediate_{config['id']}",
+                        replace_existing=True,
+                        misfire_grace_time=600,
+                    )
+                    logger.info(f"已安排启动后立即检查: {config['name']} (ID: {config['id']})")
+                except Exception as e:
+                    logger.error(f"安排启动后立即检查失败: {str(e)}")
         
         if not self.scheduler.running:
             self.scheduler.start()

--- a/modules/youtube_monitor.py
+++ b/modules/youtube_monitor.py
@@ -1108,13 +1108,19 @@ class YouTubeMonitor:
 
         # 多关键词 OR 搜索：逐个关键词请求，并在每个 batch 外层单独容错，
         # 单个关键词失败不影响其他关键词与整轮监控。
-        # 跨配置共享的每日配额预算：每个实际 search.list 请求（含重试的每次 attempt）
-        # 都从共享预算原子扣减（SQLite 持久化，按 America/Los_Angeles 配额日重置）；
-        # 预算或该配置公平份额耗尽时，剩余关键词整轮跳过，并记录为明确的
+        # 跨配置共享的单一全局每日令牌桶：每个实际 search.list 请求（含重试的每次
+        # attempt）都原子扣减（SQLite 持久化，按 America/Los_Angeles 配额日重置）；
+        # 预算耗尽或远端 429 当日熔断时，剩余关键词整轮跳过，并记录为明确的
         # 「预算跳过」状态而非正常「0 结果」。
+        # 集中式当日熔断：今日配额已耗尽（远端 429 触发或预算用尽）则直接跳过整轮搜索，
+        # 不再发出任何 search.list（多关键词与频道搜索后续入口共用同一持久化状态）。
+        if self._quota_budget_remaining() <= 0:
+            self._last_fetch_quota_skipped = True
+            logger.warning("今日 search 配额已耗尽（当日熔断），跳过本轮搜索（将于次日太平洋时间重置）")
+            return []
+
         batch_results = []  # 每个关键词的 videoId 列表
         failed_keywords = []
-        budget_exhausted = False
         for idx, sp in enumerate(search_batches, 1):
             kw_label = sp.get('q') or f'batch{idx}'
             try:
@@ -1122,13 +1128,14 @@ class YouTubeMonitor:
                 search_request = self.youtube.search().list(**sp)
                 search_response = self._execute_with_retry(
                     search_request, 'search.list',
-                    quota_consumer=lambda: self._try_consume_quota(config['id'], 1),
+                    quota_consumer=lambda: self._try_consume_quota(1),
                 )
             except QuotaBudgetExhausted:
-                budget_exhausted = True
+                # 今日全局配额已耗尽（预算用尽或远端 429 当日熔断）：
+                # 停止当前及剩余关键词，不再发出任何 search.list。
                 self._last_fetch_quota_skipped = True
                 logger.warning(
-                    f"每日 search 配额预算或本配置公平份额已耗尽，关键词 {kw_label} 及剩余关键词跳过"
+                    f"今日 search 配额已耗尽，关键词 {kw_label} 及剩余关键词跳过"
                     "（配额将在次日太平洋时间重置）"
                 )
                 failed_keywords.append(f"{kw_label}(预算跳过)")
@@ -1293,8 +1300,16 @@ class YouTubeMonitor:
             
             logger.info(f"在频道 {channel_id} 内搜索关键词: {keywords}")
 
-            # 计入跨配置共享的每日 search 预算：每个实际 attempt（含重试）都原子扣减，
-            # 预算/该配置公平份额耗尽时静默跳过，并记录为明确的「预算跳过」状态。
+            # 集中式当日熔断：今日配额耗尽则直接跳过该频道搜索，不再发请求。
+            if self._quota_budget_remaining() <= 0:
+                self._last_fetch_quota_skipped = True
+                logger.warning(
+                    f"今日 search 配额已耗尽（当日熔断），跳过频道 {channel_id} 的搜索"
+                    "（将于次日太平洋时间重置）"
+                )
+                return []
+            # 计入跨配置共享的每日 search 预算（单一全局令牌桶）：每个实际 attempt 原子扣减，
+            # 配额耗尽时由 _execute_with_retry 触发当日熔断并抛出 QuotaBudgetExhausted。
             logger.debug(f"准备执行频道搜索请求，YouTube API 对象: {type(self.youtube)}")
             # 清理 None 值，避免 API 报错
             search_params = {k: v for k, v in search_params.items() if v is not None}
@@ -1302,12 +1317,13 @@ class YouTubeMonitor:
             try:
                 search_response = self._execute_with_retry(
                     search_request, f'search.list (channel {channel_id})',
-                    quota_consumer=lambda: self._try_consume_quota(config['id'], 1),
+                    quota_consumer=lambda: self._try_consume_quota(1),
                 )
             except QuotaBudgetExhausted:
+                # 今日全局配额已耗尽：停止该频道搜索（当日熔断，后续频道/轮次一并停）。
                 self._last_fetch_quota_skipped = True
                 logger.warning(
-                    f"每日 search 配额预算或本配置公平份额已耗尽，跳过频道 {channel_id} 的搜索"
+                    f"今日 search 配额已耗尽，跳过频道 {channel_id} 的搜索"
                     "（配额将在次日太平洋时间重置）"
                 )
                 return []
@@ -1487,23 +1503,23 @@ class YouTubeMonitor:
         last_exception: Optional[Exception] = None
         while attempt < max_attempts:
             if quota_consumer is not None and not quota_consumer():
+                # 本地预算预测不足：当日不应再发请求
                 raise QuotaBudgetExhausted(description)
             try:
                 return request.execute()
             except HttpError as e:
-                # 对于5xx或已知可重试错误进行重试
                 resp = getattr(e, 'resp', None)
-                if resp is not None:
-                    status = getattr(resp, 'status', None)
-                else:
-                    status = None
+                status = getattr(resp, 'status', None) if resp is not None else None
+                msg = str(e).lower()
                 if status and 500 <= status < 600:
                     last_exception = e
-                elif status == 429:
-                    # 429 / quotaExceeded / rate limit：当日配额受限，静默跳过、不再重试，
-                    # 避免继续烧配额（issue 明确要求 429 当日跳过）。
-                    logger.warning(f"调用 {description} 触发 429/配额限制，当日跳过（不再重试）: {e}")
-                    raise
+                elif status == 429 or 'quotaexceeded' in msg:
+                    # 429 / quotaExceeded：远端当日配额真的受限。
+                    # 触发集中式当日熔断（持久化 + 内存标志），抛出 QuotaBudgetExhausted，
+                    # 上层据此停止当前及后续所有 search 请求，不再重试、不再烧配额。
+                    logger.warning(f"调用 {description} 触发 429/配额限制，标记今日配额耗尽并当日熔断: {e}")
+                    self._mark_quota_depleted_today()
+                    raise QuotaBudgetExhausted(description)
                 else:
                     raise
             except ssl.SSLError as e:
@@ -1963,8 +1979,11 @@ class YouTubeMonitor:
             from zoneinfo import ZoneInfo
             return datetime.now(ZoneInfo(self._QUOTA_TZ_NAME)).strftime('%Y-%m-%d')
         except Exception:
-            # 极少数无系统 tzdata 的环境：退化为 UTC-7（近似洛杉矶时间）
-            return (datetime.utcnow() - timedelta(hours=7)).strftime('%Y-%m-%d')
+            # 无 IANA tzdata 的环境：安全回退到 UTC 日（datetime.utcnow()）。
+            # 这只会让配额日比 PT 日早 7/8h 重置（保守侧：边界可能多一次重置），
+            # 绝不会像固定 UTC-7 那样在冬令时（实际 UTC-8）算错日期导致提前释放。
+            # 生产环境应在 requirements 中安装 tzdata，使 ZoneInfo(America/Los_Angeles) 始终可用。
+            return datetime.utcnow().strftime('%Y-%m-%d')
 
     def _quota_reset_tables(self):
         """惰性创建配额/轮转相关表（幂等）。"""
@@ -1975,14 +1994,6 @@ class YouTubeMonitor:
                 'CREATE TABLE IF NOT EXISTS monitor_quota_budget ('
                 '  quota_date TEXT PRIMARY KEY,'
                 '  used INTEGER NOT NULL'
-                ')'
-            )
-            conn.execute(
-                'CREATE TABLE IF NOT EXISTS monitor_quota_usage ('
-                '  config_id INTEGER NOT NULL,'
-                '  quota_date TEXT NOT NULL,'
-                '  used INTEGER NOT NULL,'
-                '  PRIMARY KEY (config_id, quota_date)'
                 ')'
             )
             conn.execute(
@@ -2006,58 +2017,47 @@ class YouTubeMonitor:
         used = row[0] if row else 0
         return max(0, self._MONITOR_DAILY_SEARCH_BUDGET - used)
 
-    def _consume_quota_budget(self, searches):
-        """（兼容入口）从跨配置共享的每日 search 预算中原子扣减，返回实际可执行次数。
+    def _mark_quota_depleted_today(self):
+        """标记今日配额已耗尽（持久化 + 内存标志）。
 
-        基于 SQLite 条件更新实现跨线程 / 跨进程原子性：逐次 UPDATE 且仅当
-        `used < budget` 时生效，避免不同 APScheduler 线程在边界同时超额。
+        一旦 YouTube 返回 429 / quotaExceeded，当天不应再发任何 search.list——
+        把全局预算置满，使后续一切 _try_consume_quota 直接失败，实现「当日熔断」。
+
+        这是**单一控制点**：多关键词搜索、频道搜索、后续所有调度轮次共用同一份
+        持久化状态，不再依赖分散在各处的 try/except 去「猜」是否该停。旧实现把 429
+        往上抛、再被通用异常分支当成普通关键词失败并 continue，导致第一个关键词 429
+        后第二个仍会真实发请求——根因就是缺少这个集中式熔断。
         """
         self._quota_reset_tables()
         day = self._quota_day_str()
-        granted = 0
-        with sqlite3.connect(self.db_path, timeout=30) as conn:
-            conn.execute(
-                'INSERT INTO monitor_quota_budget (quota_date, used) VALUES (?, 0) '
-                'ON CONFLICT(quota_date) DO NOTHING', (day,)
-            )
-            for _ in range(int(searches)):
-                cur = conn.execute(
-                    'UPDATE monitor_quota_budget SET used = used + 1 '
-                    'WHERE quota_date = ? AND used < ?',
-                    (day, self._MONITOR_DAILY_SEARCH_BUDGET),
-                )
-                if cur.rowcount != 1:
-                    break
-                granted += 1
-            conn.commit()
-        return granted
-
-    def _monitor_config_quota_share(self):
-        """返回每个启用自动调度配置的每日公平份额（预算均分，最少 1 次）。
-
-        防止「先到先得」的高频配置吃光整个预算、持续饿死后面的配置：
-        每个配置每天最多使用自己的份额，预算因此按配置数公平分配。
-        """
         try:
-            configs = self.get_monitor_configs()
-            auto_count = len([
-                c for c in configs
-                if c.get('enabled') and c.get('schedule_type') == 'auto'
-            ])
+            with sqlite3.connect(self.db_path, timeout=30) as conn:
+                conn.execute(
+                    'INSERT INTO monitor_quota_budget (quota_date, used) '
+                    'VALUES (?, ?) ON CONFLICT(quota_date) DO UPDATE SET used = ?',
+                    (day, self._MONITOR_DAILY_SEARCH_BUDGET, self._MONITOR_DAILY_SEARCH_BUDGET),
+                )
         except Exception:
-            auto_count = 0
-        return max(1, self._MONITOR_DAILY_SEARCH_BUDGET // (auto_count or 1))
+            pass
+        self._last_fetch_quota_skipped = True
 
-    def _try_consume_quota(self, config_id, n=1):
-        """原子扣减 n 次 search 配额（全局共享预算 + 该配置当日公平份额）。
+    def _try_consume_quota(self, n=1):
+        """原子扣减 n 次 search 配额（单一全局每日令牌桶，跨配置共享）。
 
-        返回 True 表示扣减成功；False 表示全局预算或该配置份额已耗尽。
-        条件 UPDATE 为单语句原子操作，跨线程 / 跨进程安全；
-        配置份额不足时回滚全局扣减，把额度让给其它配置。
+        返回 True 表示扣减成功；False 表示今日全局预算已耗尽。
+
+        设计取舍（根因修复，替代旧的「每配置公平份额」模型）：
+        - 旧模型把 playlist / latest / historical 等非 search 配置也算进分母、手动配置
+          可先吃光、auto 过多时靠后配置长期拿不到——三种情况都会饿死或过度限流。
+        - 改为**单一全局令牌桶**后，所有真正消费 search.list 的配置（auto 或 manual）
+          共享同一天 95 次额度，先到先得；轮转游标（_next_keyword_rotation_start）保证
+          高频调度下关键词也轮流覆盖，不会因「先到先得」而长期饿死某个配置。
+        - 单语句条件 UPDATE（used + n <= budget）跨线程 / 跨进程原子，不会超额。
+        - 当日熔断（_mark_quota_depleted_today 把 used 置满）后此处自然返回 False，
+          所有 search 入口（含频道搜索）统一短路。
         """
         self._quota_reset_tables()
         day = self._quota_day_str()
-        share = self._monitor_config_quota_share()
         with sqlite3.connect(self.db_path, timeout=30) as conn:
             conn.execute(
                 'INSERT INTO monitor_quota_budget (quota_date, used) VALUES (?, 0) '
@@ -2069,51 +2069,43 @@ class YouTubeMonitor:
                 (n, day, n, self._MONITOR_DAILY_SEARCH_BUDGET),
             )
             if cur.rowcount != 1:
-                return False  # 全局预算已耗尽
-            conn.execute(
-                'INSERT INTO monitor_quota_usage (config_id, quota_date, used) '
-                'VALUES (?, ?, 0) ON CONFLICT(config_id, quota_date) DO NOTHING',
-                (config_id, day),
-            )
-            cur2 = conn.execute(
-                'UPDATE monitor_quota_usage SET used = used + ? '
-                'WHERE config_id = ? AND quota_date = ? AND used + ? <= ?',
-                (n, config_id, day, n, share),
-            )
-            if cur2.rowcount != 1:
-                # 该配置当日份额用尽：回滚全局扣减，公平让位给其它配置
-                conn.execute(
-                    'UPDATE monitor_quota_budget SET used = MAX(0, used - ?) '
-                    'WHERE quota_date = ?', (n, day)
-                )
-                conn.commit()
-                return False
+                return False  # 今日全局预算已耗尽
             conn.commit()
         return True
 
     def _next_keyword_rotation_start(self, config_id, keyword_count, max_searches):
-        """返回本轮关键词轮转起始下标，并持久化推进游标（每轮推进，跨重启保持）。
+        """返回本轮关键词轮转起始下标，并原子推进游标（每轮推进，跨重启保持）。
 
-        旧实现按「UTC 日期」算起点，高频调度（如每小时一轮）会在整天重复同一组
-        关键词、其余关键词一次也不搜；改为每轮推进并落库后，高频模式也能轮流覆盖
-        全部关键词。
+        高频调度下轮流覆盖全部关键词，避免整天重复同一组。
+
+        并发安全：用显式 `BEGIN IMMEDIATE` 写事务锁包裹 SELECT + UPDATE，
+        保证「读到旧游标 → 计算 → 写回新游标」是原子操作，消除并发线程 / 进程
+        读到同一旧游标、写回同一 next 值的竞态（旧实现 SELECT 与 UPSERT 分离，
+        并发验证中 100 次调用只产生 50 个不同起点）。
         """
         self._quota_reset_tables()
+        now = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
         with sqlite3.connect(self.db_path, timeout=30) as conn:
-            row = conn.execute(
-                'SELECT cursor_index FROM monitor_keyword_cursor WHERE config_id = ?',
-                (config_id,),
-            ).fetchone()
-            start = (row[0] % keyword_count) if row else 0
-            next_cursor = (start + max_searches) % keyword_count
-            conn.execute(
-                'INSERT INTO monitor_keyword_cursor (config_id, cursor_index, updated_at) '
-                'VALUES (?, ?, ?) '
-                'ON CONFLICT(config_id) DO UPDATE SET '
-                '  cursor_index = excluded.cursor_index, updated_at = excluded.updated_at',
-                (config_id, next_cursor, datetime.now().strftime('%Y-%m-%d %H:%M:%S')),
-            )
-            conn.commit()
+            conn.isolation_level = None  # 手动控制事务
+            conn.execute('BEGIN IMMEDIATE')  # 写锁：独占到 COMMIT/ROLLBACK
+            try:
+                row = conn.execute(
+                    'SELECT cursor_index FROM monitor_keyword_cursor WHERE config_id = ?',
+                    (config_id,),
+                ).fetchone()
+                start = (row[0] % keyword_count) if row else 0
+                next_cursor = (start + max_searches) % keyword_count
+                conn.execute(
+                    'INSERT INTO monitor_keyword_cursor (config_id, cursor_index, updated_at) '
+                    'VALUES (?, ?, ?) '
+                    'ON CONFLICT(config_id) DO UPDATE SET '
+                    '  cursor_index = excluded.cursor_index, updated_at = excluded.updated_at',
+                    (config_id, next_cursor, now),
+                )
+                conn.execute('COMMIT')
+            except Exception:
+                conn.execute('ROLLBACK')
+                raise
         return start
 
     def _resolve_monitor_searches_per_run(self):

--- a/modules/youtube_monitor.py
+++ b/modules/youtube_monitor.py
@@ -1055,12 +1055,32 @@ class YouTubeMonitor:
         raw_kw = (config.get('keywords') or '').strip()
         keywords_list = [k for k in re.split(r'[\s,;，；\n]+', raw_kw) if k] if raw_kw else []
         if keywords_list:
+            # 配速（节流）：YouTube Data API 免费配额仅 10000 单位/天，一次 search 消耗
+            # 100 单位。多关键词 OR 搜索（每个关键词单独 search）在高频调度下极易把每日
+            # 配额打满（429 quotaExceeded），导致后续监控全部 0 结果。
+            # 策略：每轮最多只发 MONITOR_SEARCHES_PER_RUN 次 search（默认 2），
+            # 并按「当天日期」在全部关键词里轮流挑选，使配额均匀分摊到各关键词、
+            # 且相邻多天能覆盖不同关键词，而非每轮把所有关键词都搜一遍。
+            max_searches = max(int(config.get('MONITOR_SEARCHES_PER_RUN', 2)), 1)
+            day_index = (datetime.utcnow() - datetime(1970, 1, 1)).days  # 按 UTC 天轮换
+            if len(keywords_list) > max_searches:
+                start = (day_index * max_searches) % len(keywords_list)
+                selected = []
+                for i in range(max_searches):
+                    selected.append(keywords_list[(start + i) % len(keywords_list)])
+                logger.info(
+                    f"配速：关键词共 {len(keywords_list)} 个，仅本轮搜索 {max_searches} 个"
+                    f"（按天轮流，起始下标 {start}）：{selected}"
+                )
+            else:
+                selected = keywords_list
+                logger.info(f"多关键词 OR 搜索，共 {len(keywords_list)} 个: {keywords_list}")
+
             search_batches = []
-            for kw in keywords_list:
+            for kw in selected:
                 sp = dict(search_params)
                 sp['q'] = kw
                 search_batches.append(sp)
-            logger.info(f"多关键词 OR 搜索，共 {len(keywords_list)} 个: {keywords_list}")
         else:
             # 无关键词则按空查询搜索（返回热门视频），保持原有行为
             search_batches = [dict(search_params)]
@@ -1981,8 +2001,26 @@ class YouTubeMonitor:
         logger.info(f"找到 {len(auto_configs)} 个启用的自动调度配置")
         
         for config in auto_configs:
-            logger.info(f"启动调度: {config['name']} (ID: {config['id']}), 间隔: {config['schedule_interval']}分钟")
-            self._schedule_monitor(config['id'], config['schedule_interval'])
+            # 按天轮流模式：无论 DB 中配置何种间隔，统一以每天（1440 分钟）跑一次，
+            # 配合 _fetch_search_videos 内「按天轮流挑选关键词」实现均匀分布，避免
+            # 高频调度 + 多关键词把每日 search 配额打满（429 quotaExceeded）。
+            run_interval = 1440
+            logger.info(f"启动调度: {config['name']} (ID: {config['id']}), 间隔: {run_interval}分钟（按天轮流模式）")
+            self._schedule_monitor(config['id'], run_interval)
+            # 启动/重启后立即触发一次检查，避免首次检查被推到一整个间隔之后
+            try:
+                self.scheduler.add_job(
+                    func=self.run_monitor,
+                    trigger='date',
+                    run_date=datetime.now() + timedelta(seconds=15),
+                    args=[config['id']],
+                    id=f"monitor_immediate_{config['id']}",
+                    replace_existing=True,
+                    misfire_grace_time=600,
+                )
+                logger.info(f"已安排启动后立即检查: {config['name']} (ID: {config['id']})")
+            except Exception as e:
+                logger.error(f"安排启动后立即检查失败: {str(e)}")
         
         if not self.scheduler.running:
             self.scheduler.start()

--- a/modules/youtube_monitor.py
+++ b/modules/youtube_monitor.py
@@ -132,6 +132,10 @@ class YouTubeMonitor:
         self._last_fetch_had_errors = False
         self._api_proxy_enabled = False
         self._last_api_init_error: Optional[str] = None
+        # 配额相关运行态（惰性创建，这里显式初始化避免访问时 AttributeError）
+        self._last_fetch_quota_skipped = False
+        self._quota_depleted_day = None
+        self._quota_tables_ready = False
         self._init_database()
         self._init_youtube_api()
         
@@ -1081,6 +1085,20 @@ class YouTubeMonitor:
             # MONITOR_SEARCHES_PER_RUN 是「全局应用配置」，monitor DB 记录上并无此字段；
             # 必须从全局配置显式读取（带非整数校验），否则会恒为默认值 2 而失效。
             max_searches = self._resolve_monitor_searches_per_run()
+        else:
+            max_searches = 0
+
+        # 集中式当日熔断（单一控制点）：今日配额耗尽则直接跳过整轮搜索，
+        # 不再发出任何 search.list（多关键词与频道搜索后续入口共用同一持久化状态）。
+        # 必须在轮转游标推进之前——熔断期间每轮高频调度都不应空推进游标（P2 修复）。
+        if self._quota_budget_remaining() <= 0:
+            self._last_fetch_quota_skipped = True
+            logger.warning("今日 search 配额已耗尽（当日熔断），跳过本轮搜索（将于次日太平洋时间重置）")
+            return []
+
+        # 预算通过后才构造 search 批次；仅在「关键词数 > 每轮上限」时推进轮转游标，
+        # 保证高频调度下轮流覆盖全部关键词、且游标不会在熔断期空推进。
+        if keywords_list:
             if len(keywords_list) > max_searches:
                 # 持久化轮转游标：每轮推进（而非按 UTC 天选词），高频调度也能轮流
                 # 覆盖全部关键词，避免整天只重复同一组关键词、其余关键词一次也不搜。
@@ -1106,19 +1124,6 @@ class YouTubeMonitor:
             # 无关键词则按空查询搜索（返回热门视频），保持原有行为
             search_batches = [dict(search_params)]
 
-        # 多关键词 OR 搜索：逐个关键词请求，并在每个 batch 外层单独容错，
-        # 单个关键词失败不影响其他关键词与整轮监控。
-        # 跨配置共享的单一全局每日令牌桶：每个实际 search.list 请求（含重试的每次
-        # attempt）都原子扣减（SQLite 持久化，按 America/Los_Angeles 配额日重置）；
-        # 预算耗尽或远端 429 当日熔断时，剩余关键词整轮跳过，并记录为明确的
-        # 「预算跳过」状态而非正常「0 结果」。
-        # 集中式当日熔断：今日配额已耗尽（远端 429 触发或预算用尽）则直接跳过整轮搜索，
-        # 不再发出任何 search.list（多关键词与频道搜索后续入口共用同一持久化状态）。
-        if self._quota_budget_remaining() <= 0:
-            self._last_fetch_quota_skipped = True
-            logger.warning("今日 search 配额已耗尽（当日熔断），跳过本轮搜索（将于次日太平洋时间重置）")
-            return []
-
         batch_results = []  # 每个关键词的 videoId 列表
         failed_keywords = []
         for idx, sp in enumerate(search_batches, 1):
@@ -1128,7 +1133,8 @@ class YouTubeMonitor:
                 search_request = self.youtube.search().list(**sp)
                 search_response = self._execute_with_retry(
                     search_request, 'search.list',
-                    quota_consumer=lambda: self._try_consume_quota(1),
+                    quota_consumer=lambda: self._try_consume_quota(1, config['id']),
+                    operation_type='search',
                 )
             except QuotaBudgetExhausted:
                 # 今日全局配额已耗尽（预算用尽或远端 429 当日熔断）：
@@ -1317,7 +1323,8 @@ class YouTubeMonitor:
             try:
                 search_response = self._execute_with_retry(
                     search_request, f'search.list (channel {channel_id})',
-                    quota_consumer=lambda: self._try_consume_quota(1),
+                    quota_consumer=lambda: self._try_consume_quota(1, config['id']),
+                    operation_type='search',
                 )
             except QuotaBudgetExhausted:
                 # 今日全局配额已耗尽：停止该频道搜索（当日熔断，后续频道/轮次一并停）。
@@ -1490,14 +1497,49 @@ class YouTubeMonitor:
             # 向上抛出让上层决定是否继续以及是否更新last_run_time
             raise
 
-    def _execute_with_retry(self, request: Any, description: str, max_attempts: int = 3, backoff_seconds: float = 1.0, quota_consumer: Optional[Any] = None) -> Any:
+    def _http_error_quota_reason(self, e: HttpError) -> Optional[str]:
+        """从 Google API HttpError 中提取结构化错误 reason。
+
+        429 既可能是「当日配额耗尽」（quotaExceeded / dailyLimitExceeded），也可能是
+        「短时窗口速率限制」（rateLimitExceeded）。二者处理完全不同：前者要触发当日
+        熔断、后者只需重试。只有结构化 reason 能可靠区分，故优先解析
+        `e.error_details`（googleapiclient 由响应 JSON 的 error.errors[] 反序列化而来），
+        解析不到时再退化到错误文本匹配。
+        """
+        details = getattr(e, 'error_details', None)
+        if details:
+            for d in details:
+                r = (d or {}).get('reason')
+                if r:
+                    return r
+        # error_details 缺 reason 字段（如只有 message）或不存在时，退化到错误文本抓 reason。
+        # 容忍 JSON 引号包裹（"reason":"quotaExceeded"）与非引号纯文本（reason: rateLimitExceeded）。
+        m = re.search(r'\breason["\']?\s*:\s*["\']?([A-Za-z_]+)', str(e))
+        if m:
+            return m.group(1)
+        return None
+
+    def _execute_with_retry(self, request: Any, description: str, max_attempts: int = 3,
+                            backoff_seconds: float = 1.0, quota_consumer: Optional[Any] = None,
+                            operation_type: str = 'other') -> Any:
         """对YouTube API请求执行带重试的调用，用于处理临时性网络/SSL问题。
 
         quota_consumer: 可选可调用对象，在**每次实际 attempt 前**调用一次；
-        返回 False 表示当日配额预算 / 该配置公平份额已耗尽，立即以
-        QuotaBudgetExhausted 中止（不再发起请求、不再重试）。
-        重试的每次 attempt 都是一次真实 API 请求，因此每次 attempt 都扣减配额
-        （修复“重试绕过每日预算”的回归）。
+            返回 False 表示当日配额预算 / 该配置公平份额已耗尽，立即以
+            QuotaBudgetExhausted 中止（不再发起请求、不再重试）。
+            重试的每次 attempt 都是一次真实 API 请求，因此每次 attempt 都扣减配额。
+
+        operation_type: 'search' 表示 search.list 类操作（消耗每日 search 配额，且
+            需要在「当日配额耗尽」reason 时触发集中式熔断）；'other' 表示 videos.list /
+            channels.list / playlistItems.list 等（使用不同配额维度，即便触发配额错误
+            也**不**熔断 search 预算，仅向上抛出交由调用方处理）。
+
+        配额熔断的精确触发条件（仅对 search 操作）：
+            - HTTP 429 且 reason ∈ {quotaExceeded, dailyLimitExceeded} → 当日配额真的耗尽
+              → 持久化熔断 + 抛 QuotaBudgetExhausted（停止当前及后续所有 search）。
+            - reason == rateLimitExceeded（短时速率限制）→ 可重试，**不**熔断
+              （否则一次短时限流就会误杀当天所有 search）。
+            - 其它 429 / 5xx → 按原逻辑退避重试。
         """
         attempt = 0
         last_exception: Optional[Exception] = None
@@ -1510,16 +1552,29 @@ class YouTubeMonitor:
             except HttpError as e:
                 resp = getattr(e, 'resp', None)
                 status = getattr(resp, 'status', None) if resp is not None else None
-                msg = str(e).lower()
-                if status and 500 <= status < 600:
+                reason = self._http_error_quota_reason(e)
+                daily_quota_error = reason in ('quotaExceeded', 'dailyLimitExceeded')
+                if daily_quota_error:
+                    if operation_type == 'search':
+                        # 明确的当日配额耗尽：触发集中式当日熔断（持久化 + 内存标志），
+                        # 上层据此停止当前及后续所有 search 请求，不再重试、不再烧配额。
+                        logger.warning(
+                            f"调用 {description} 触发当日配额耗尽({reason})，"
+                            f"标记今日 search 配额耗尽并当日熔断: {e}"
+                        )
+                        self._mark_quota_depleted_today()
+                        raise QuotaBudgetExhausted(description)
+                    # 非 search 操作（videos.list 等）的配额错误：不熔断 search 预算，
+                    # 直接抛出交由上层处理（其配额维度与 search 无关）。
+                    logger.warning(
+                        f"调用 {description} 触发配额错误({reason})，非 search 操作不熔断 search 预算: {e}"
+                    )
+                    raise
+                elif status == 429 or reason == 'rateLimitExceeded':
+                    # 短时速率限制：可重试，不触发当日熔断（避免误杀全天 search）
                     last_exception = e
-                elif status == 429 or 'quotaexceeded' in msg:
-                    # 429 / quotaExceeded：远端当日配额真的受限。
-                    # 触发集中式当日熔断（持久化 + 内存标志），抛出 QuotaBudgetExhausted，
-                    # 上层据此停止当前及后续所有 search 请求，不再重试、不再烧配额。
-                    logger.warning(f"调用 {description} 触发 429/配额限制，标记今日配额耗尽并当日熔断: {e}")
-                    self._mark_quota_depleted_today()
-                    raise QuotaBudgetExhausted(description)
+                elif status and 500 <= status < 600:
+                    last_exception = e
                 else:
                     raise
             except ssl.SSLError as e:
@@ -1979,11 +2034,12 @@ class YouTubeMonitor:
             from zoneinfo import ZoneInfo
             return datetime.now(ZoneInfo(self._QUOTA_TZ_NAME)).strftime('%Y-%m-%d')
         except Exception:
-            # 无 IANA tzdata 的环境：安全回退到 UTC 日（datetime.utcnow()）。
-            # 这只会让配额日比 PT 日早 7/8h 重置（保守侧：边界可能多一次重置），
-            # 绝不会像固定 UTC-7 那样在冬令时（实际 UTC-8）算错日期导致提前释放。
-            # 生产环境应在 requirements 中安装 tzdata，使 ZoneInfo(America/Los_Angeles) 始终可用。
-            return datetime.utcnow().strftime('%Y-%m-%d')
+            # 无 IANA tzdata 的环境：保守回退到固定 UTC-8（太平洋标准时间，不含 DST）。
+            # PT 为 UTC-7（夏令时）或 UTC-8（冬令时）。固定 UTC-8 的边界与冬令时一致、
+            # 比夏令时晚 1 小时——因此配额日边界**绝不会早于**真实 PT 日，最坏只是比
+            # 真实 PT 日最多晚 1 小时重置（延迟而非提前，安全侧，不会提前放出第二批额度）。
+            # 生产环境仍应在 requirements 中安装 tzdata 使 ZoneInfo 始终可用。
+            return (datetime.utcnow() - timedelta(hours=8)).strftime('%Y-%m-%d')
 
     def _quota_reset_tables(self):
         """惰性创建配额/轮转相关表（幂等）。"""
@@ -1997,6 +2053,14 @@ class YouTubeMonitor:
                 ')'
             )
             conn.execute(
+                'CREATE TABLE IF NOT EXISTS monitor_quota_usage ('
+                '  config_id INTEGER NOT NULL,'
+                '  quota_date TEXT NOT NULL,'
+                '  used INTEGER NOT NULL,'
+                '  PRIMARY KEY (config_id, quota_date)'
+                ')'
+            )
+            conn.execute(
                 'CREATE TABLE IF NOT EXISTS monitor_keyword_cursor ('
                 '  config_id INTEGER PRIMARY KEY,'
                 '  cursor_index INTEGER NOT NULL,'
@@ -2007,7 +2071,15 @@ class YouTubeMonitor:
         self._quota_tables_ready = True
 
     def _quota_budget_remaining(self):
-        """返回今日跨配置共享的 search 预算剩余次数（SQLite 持久化，按 PT 配额日重置）。"""
+        """返回今日跨配置共享的 search 预算剩余次数（SQLite 持久化，按 PT 配额日重置）。
+
+        若当日已触发熔断（持久化或内存 fail-closed 标志），直接返回 0，确保即便
+        持久化写入失败，本进程也不会继续发请求（绝不提前释放额度）。
+        """
+        # 内存熔断标志（持久化失败时的 fail-closed 兜底）：与当日配额日绑定，
+        # 跨日自动失效（新一天 _quota_day_str 变化后标志不匹配，重新读 DB）。
+        if getattr(self, '_quota_depleted_day', None) == self._quota_day_str():
+            return 0
         self._quota_reset_tables()
         day = self._quota_day_str()
         with sqlite3.connect(self.db_path) as conn:
@@ -2018,51 +2090,93 @@ class YouTubeMonitor:
         return max(0, self._MONITOR_DAILY_SEARCH_BUDGET - used)
 
     def _mark_quota_depleted_today(self):
-        """标记今日配额已耗尽（持久化 + 内存标志）。
+        """标记今日配额已耗尽（持久化 + 内存 fail-closed 标志）。
 
-        一旦 YouTube 返回 429 / quotaExceeded，当天不应再发任何 search.list——
-        把全局预算置满，使后续一切 _try_consume_quota 直接失败，实现「当日熔断」。
+        一旦 YouTube 返回当日配额耗尽 reason（quotaExceeded / dailyLimitExceeded），
+        当天不应再发任何 search.list——把全局预算置满，使后续一切 _try_consume_quota
+        直接失败，实现「当日熔断」。
 
-        这是**单一控制点**：多关键词搜索、频道搜索、后续所有调度轮次共用同一份
-        持久化状态，不再依赖分散在各处的 try/except 去「猜」是否该停。旧实现把 429
-        往上抛、再被通用异常分支当成普通关键词失败并 continue，导致第一个关键词 429
-        后第二个仍会真实发请求——根因就是缺少这个集中式熔断。
+        持久化失败时**绝不静默吞掉**：先设置内存标志（本进程立即 fail-closed 停发），
+        再对 DB 写入重试 3 次；全部失败则记 CRITICAL 日志。这样即使进程/磁盘异常，
+        当前实例也不会在熔断状态下继续烧配额，下一轮/另一进程读到持久化状态后也同样停。
         """
         self._quota_reset_tables()
         day = self._quota_day_str()
-        try:
-            with sqlite3.connect(self.db_path, timeout=30) as conn:
-                conn.execute(
-                    'INSERT INTO monitor_quota_budget (quota_date, used) '
-                    'VALUES (?, ?) ON CONFLICT(quota_date) DO UPDATE SET used = ?',
-                    (day, self._MONITOR_DAILY_SEARCH_BUDGET, self._MONITOR_DAILY_SEARCH_BUDGET),
-                )
-        except Exception:
-            pass
+        # 先置内存标志：即便随后 DB 写入失败，本进程也停止发请求（fail-closed）
+        self._quota_depleted_day = day
         self._last_fetch_quota_skipped = True
+        last_err = None
+        for attempt_i in range(3):
+            try:
+                with sqlite3.connect(self.db_path, timeout=30) as conn:
+                    conn.execute(
+                        'INSERT INTO monitor_quota_budget (quota_date, used) '
+                        'VALUES (?, ?) ON CONFLICT(quota_date) DO UPDATE SET used = ?',
+                        (day, self._MONITOR_DAILY_SEARCH_BUDGET, self._MONITOR_DAILY_SEARCH_BUDGET),
+                    )
+                return
+            except Exception as ex:
+                last_err = ex
+                time.sleep(0.05 * (attempt_i + 1))
+        logger.critical(
+            f"当日 search 配额熔断持久化失败（本进程已 fail-closed 停止发请求）：{last_err}"
+        )
 
-    def _try_consume_quota(self, n=1):
-        """原子扣减 n 次 search 配额（单一全局每日令牌桶，跨配置共享）。
+    def _monitor_search_config_count(self):
+        """返回启用且「真正消费 search.list」的 auto 配置数（公平份额分母）。
 
-        返回 True 表示扣减成功；False 表示今日全局预算已耗尽。
+        只有会发起 search.list 的配置才计入分母：有关键词（多关键词 OR 搜索）或
+        指定了频道（频道内搜索）的启用 auto 配置。playlist / latest / historical
+        等走 playlistItems.list / videos.list 的模式不消耗 search 配额，绝不能计入
+        （旧实现把它们算进分母，导致 search 配置被过度限流——根因之一）。
+        """
+        try:
+            configs = self.get_monitor_configs()
+        except Exception:
+            return 0
+        n = 0
+        for c in configs:
+            if not c.get('enabled'):
+                continue
+            if c.get('schedule_type') != 'auto':
+                continue
+            if (c.get('keywords') and str(c.get('keywords')).strip()) or \
+               (c.get('channel_id') and str(c.get('channel_id')).strip()):
+                n += 1
+        return n
 
-        设计取舍（根因修复，替代旧的「每配置公平份额」模型）：
-        - 旧模型把 playlist / latest / historical 等非 search 配置也算进分母、手动配置
-          可先吃光、auto 过多时靠后配置长期拿不到——三种情况都会饿死或过度限流。
-        - 改为**单一全局令牌桶**后，所有真正消费 search.list 的配置（auto 或 manual）
-          共享同一天 95 次额度，先到先得；轮转游标（_next_keyword_rotation_start）保证
-          高频调度下关键词也轮流覆盖，不会因「先到先得」而长期饿死某个配置。
-        - 单语句条件 UPDATE（used + n <= budget）跨线程 / 跨进程原子，不会超额。
-        - 当日熔断（_mark_quota_depleted_today 把 used 置满）后此处自然返回 False，
-          所有 search 入口（含频道搜索）统一短路。
+    def _try_consume_quota(self, n=1, config_id=None):
+        """原子扣减 n 次 search 配额。
+
+        双层限流，既防超额又防单配置饿死其它配置（根因修复）：
+        1. **全局硬上限**：所有 search 消费者（auto / manual）共享一天 95 次，
+           单语句条件 UPDATE（used + n <= budget）跨线程 / 跨进程原子，绝不超过日配额。
+        2. **每配置公平份额**：在全局桶之上，对指定 config_id 施加
+           `budget / 搜索配置数`（最少 1 次）的当日上限。任一配置当天最多用掉自己
+           的份额，无法先吃光全局桶——高频/手动配置因此不会饿死低频配置。
+           - 配置份额耗尽时回滚本次全局扣减，把额度让给其它配置（公平，不浪费）。
+           - 全局桶耗尽时直接返回 False（不回滚——额度已被其它配置合法占用）。
+           - 未传 config_id（历史兼容调用）仅受全局桶约束。
+
+        返回 True 表示扣减成功；False 表示今日配额（全局或本配置份额）已耗尽。
+        当日熔断（_mark_quota_depleted_today 把 used 置满）后此处自然返回 False。
         """
         self._quota_reset_tables()
         day = self._quota_day_str()
+        # 纵深防御：若当日已 fail-closed 熔断（持久化失败时的内存兜底），直接拒绝，
+        # 不依赖 DB 读取（DB 写入失败时读到的仍是旧余额，会误放行）。
+        if getattr(self, '_quota_depleted_day', None) == day:
+            return False
+        share = None
+        if config_id is not None:
+            search_cfg_count = max(1, self._monitor_search_config_count() or 1)
+            share = max(1, self._MONITOR_DAILY_SEARCH_BUDGET // search_cfg_count)
         with sqlite3.connect(self.db_path, timeout=30) as conn:
             conn.execute(
                 'INSERT INTO monitor_quota_budget (quota_date, used) VALUES (?, 0) '
                 'ON CONFLICT(quota_date) DO NOTHING', (day,)
             )
+            # 全局硬上限
             cur = conn.execute(
                 'UPDATE monitor_quota_budget SET used = used + ? '
                 'WHERE quota_date = ? AND used + ? <= ?',
@@ -2070,6 +2184,25 @@ class YouTubeMonitor:
             )
             if cur.rowcount != 1:
                 return False  # 今日全局预算已耗尽
+            if share is not None:
+                conn.execute(
+                    'INSERT INTO monitor_quota_usage (config_id, quota_date, used) '
+                    'VALUES (?, ?, 0) ON CONFLICT(config_id, quota_date) DO NOTHING',
+                    (config_id, day),
+                )
+                cur2 = conn.execute(
+                    'UPDATE monitor_quota_usage SET used = used + ? '
+                    'WHERE config_id = ? AND quota_date = ? AND used + ? <= ?',
+                    (n, config_id, day, n, share),
+                )
+                if cur2.rowcount != 1:
+                    # 本配置当日公平份额耗尽：回滚本次全局扣减，让出额度给其它配置
+                    conn.execute(
+                        'UPDATE monitor_quota_budget SET used = MAX(0, used - ?) '
+                        'WHERE quota_date = ?', (n, day)
+                    )
+                    conn.commit()
+                    return False
             conn.commit()
         return True
 

--- a/modules/youtube_monitor.py
+++ b/modules/youtube_monitor.py
@@ -24,6 +24,10 @@ from modules.task_manager import add_task
 from .config_manager import load_config
 from .utils import get_app_subdir
 
+class QuotaBudgetExhausted(Exception):
+    """当日跨配置 search 配额预算（或该配置公平份额）已耗尽，本轮搜索跳过。"""
+
+
 def setup_youtube_monitor_logger():
     """设置YouTube监控专用日志"""
     logger = logging.getLogger('Y2A-Auto.YouTube-Monitor')
@@ -853,7 +857,13 @@ class YouTubeMonitor:
         if not config:
             logger.error(f"监控配置不存在: {config_id}")
             return False, "监控配置不存在"
-        
+
+        # 执行入口复核配置状态：配置在 15s 立即任务触发前被禁用/删除时，
+        # 不得再发 API 请求或写历史（配合 _remove_schedule 取消立即任务双保险）。
+        if not config.get('enabled', True):
+            logger.info(f"监控配置已禁用，跳过执行: {config.get('name', config_id)} (ID: {config_id})")
+            return False, "监控配置已禁用，跳过执行"
+
         logger.info(f"执行监控配置: {config['name']} (ID: {config_id})")
         logger.info(f"监控类型: {config.get('monitor_type', 'youtube_search')}, "
                    f"频道模式: {config.get('channel_mode', 'latest')}")
@@ -861,8 +871,9 @@ class YouTubeMonitor:
         try:
             # 获取视频
             logger.info("开始获取视频数据...")
-            # 每次运行前重置错误标记
+            # 每次运行前重置错误标记与预算跳过标记
             self._last_fetch_had_errors = False
+            self._last_fetch_quota_skipped = False
             videos = self._fetch_trending_videos(config)
             logger.info(f"获取到 {len(videos)} 个视频")
             
@@ -924,8 +935,13 @@ class YouTubeMonitor:
             else:
                 logger.warning("本次抓取存在错误，跳过更新last_run_time以避免漏掉新视频")
             
+            # 预算跳过是明确的独立状态（区别于正常“0 结果”），并入完成消息
+            quota_note = (
+                "（部分搜索因配额预算耗尽被跳过，配额将在次日太平洋时间重置）"
+                if getattr(self, '_last_fetch_quota_skipped', False) else ""
+            )
             logger.info(f"监控任务完成 - 配置: {config['name']}, "
-                       f"处理新视频: {processed_count}, 添加到任务队列: {added_count}")
+                       f"处理新视频: {processed_count}, 添加到任务队列: {added_count}{quota_note}")
             
             # 更新历史搬运进度（如果是历史模式）
             if config.get('channel_mode') == 'historical':
@@ -933,7 +949,7 @@ class YouTubeMonitor:
                 original_filtered = self._filter_videos(videos, config)
                 self._update_historical_progress(config_id, original_filtered, added_count)
             
-            return True, f"监控完成，处理了 {processed_count} 个新视频，添加了 {added_count} 个到任务队列"
+            return True, f"监控完成，处理了 {processed_count} 个新视频，添加了 {added_count} 个到任务队列{quota_note}"
             
         except Exception as e:
             logger.error(f"监控任务执行失败 - 配置: {config['name']} (ID: {config_id}), 错误: {str(e)}")
@@ -1065,15 +1081,17 @@ class YouTubeMonitor:
             # MONITOR_SEARCHES_PER_RUN 是「全局应用配置」，monitor DB 记录上并无此字段；
             # 必须从全局配置显式读取（带非整数校验），否则会恒为默认值 2 而失效。
             max_searches = self._resolve_monitor_searches_per_run()
-            day_index = (datetime.utcnow() - datetime(1970, 1, 1)).days  # 按 UTC 天轮换
             if len(keywords_list) > max_searches:
-                start = (day_index * max_searches) % len(keywords_list)
-                selected = []
-                for i in range(max_searches):
-                    selected.append(keywords_list[(start + i) % len(keywords_list)])
+                # 持久化轮转游标：每轮推进（而非按 UTC 天选词），高频调度也能轮流
+                # 覆盖全部关键词，避免整天只重复同一组关键词、其余关键词一次也不搜。
+                start = self._next_keyword_rotation_start(config['id'], len(keywords_list), max_searches)
+                selected = [
+                    keywords_list[(start + i) % len(keywords_list)]
+                    for i in range(max_searches)
+                ]
                 logger.info(
                     f"配速：关键词共 {len(keywords_list)} 个，仅本轮搜索 {max_searches} 个"
-                    f"（按天轮流，起始下标 {start}）：{selected}"
+                    f"（轮转游标起始下标 {start}）：{selected}"
                 )
             else:
                 selected = keywords_list
@@ -1090,25 +1108,31 @@ class YouTubeMonitor:
 
         # 多关键词 OR 搜索：逐个关键词请求，并在每个 batch 外层单独容错，
         # 单个关键词失败不影响其他关键词与整轮监控。
-        # 跨配置共享的每日配额预算：限制今天实际发出的 search 次数，避免多配置/高频调度打满配额。
-        planned_searches = len(search_batches)
-        allowed_searches = self._consume_quota_budget(planned_searches)
-        if allowed_searches < planned_searches:
-            logger.warning(
-                f"每日跨配置 search 预算不足（已用 {self._quota_used}/{self._MONITOR_DAILY_SEARCH_BUDGET}），"
-                f"本轮仅执行 {allowed_searches}/{planned_searches} 个关键词搜索，其余跳过"
-            )
-            search_batches = search_batches[:allowed_searches]
-        if not search_batches:
-            logger.warning("每日跨配置 search 预算已耗尽，本轮监控跳过所有搜索（配额将在次日 UTC 重置）")
+        # 跨配置共享的每日配额预算：每个实际 search.list 请求（含重试的每次 attempt）
+        # 都从共享预算原子扣减（SQLite 持久化，按 America/Los_Angeles 配额日重置）；
+        # 预算或该配置公平份额耗尽时，剩余关键词整轮跳过，并记录为明确的
+        # 「预算跳过」状态而非正常「0 结果」。
         batch_results = []  # 每个关键词的 videoId 列表
         failed_keywords = []
+        budget_exhausted = False
         for idx, sp in enumerate(search_batches, 1):
             kw_label = sp.get('q') or f'batch{idx}'
             try:
                 logger.debug(f"准备执行搜索请求({idx}/{len(search_batches)})，参数: {sp}")
                 search_request = self.youtube.search().list(**sp)
-                search_response = self._execute_with_retry(search_request, 'search.list')
+                search_response = self._execute_with_retry(
+                    search_request, 'search.list',
+                    quota_consumer=lambda: self._try_consume_quota(config['id'], 1),
+                )
+            except QuotaBudgetExhausted:
+                budget_exhausted = True
+                self._last_fetch_quota_skipped = True
+                logger.warning(
+                    f"每日 search 配额预算或本配置公平份额已耗尽，关键词 {kw_label} 及剩余关键词跳过"
+                    "（配额将在次日太平洋时间重置）"
+                )
+                failed_keywords.append(f"{kw_label}(预算跳过)")
+                break
             except Exception as e:
                 # 单批失败只跳过该关键词，继续处理其余关键词
                 logger.error(f"关键词搜索失败，跳过该关键词继续其他：q={kw_label}, 错误: {e}")
@@ -1122,7 +1146,7 @@ class YouTubeMonitor:
             batch_results.append(ids)
 
         if failed_keywords:
-            logger.warning(f"多关键词搜索中有 {len(failed_keywords)} 个关键词失败（已跳过并继续其余）：{failed_keywords}")
+            logger.warning(f"多关键词搜索中有 {len(failed_keywords)} 个关键词失败/跳过（已继续其余）：{failed_keywords}")
         # 多关键词会线性增加 search.list 配额消耗（每关键词 1 次请求），无论是否失败都提示
         if len(batch_results) > 1:
             logger.warning(f"多关键词 OR 搜索共 {len(batch_results)} 个关键词，将线性增加 search.list 配额消耗（每关键词 1 次请求）。")
@@ -1269,18 +1293,24 @@ class YouTubeMonitor:
             
             logger.info(f"在频道 {channel_id} 内搜索关键词: {keywords}")
 
-            # 计入跨配置共享的每日 search 预算（频道内搜索每次消耗 1 次 search.list）
-            if self._consume_quota_budget(1) < 1:
-                logger.warning(f"每日跨配置 search 预算已耗尽，跳过频道 {channel_id} 的搜索（配额将在次日 UTC 重置）")
-                return []
-
-            # 执行搜索（带重试）
+            # 计入跨配置共享的每日 search 预算：每个实际 attempt（含重试）都原子扣减，
+            # 预算/该配置公平份额耗尽时静默跳过，并记录为明确的「预算跳过」状态。
             logger.debug(f"准备执行频道搜索请求，YouTube API 对象: {type(self.youtube)}")
             # 清理 None 值，避免 API 报错
             search_params = {k: v for k, v in search_params.items() if v is not None}
             search_request = self.youtube.search().list(**search_params)
-            logger.debug(f"频道搜索请求已创建: {type(search_request)}")
-            search_response = self._execute_with_retry(search_request, f'search.list (channel {channel_id})')
+            try:
+                search_response = self._execute_with_retry(
+                    search_request, f'search.list (channel {channel_id})',
+                    quota_consumer=lambda: self._try_consume_quota(config['id'], 1),
+                )
+            except QuotaBudgetExhausted:
+                self._last_fetch_quota_skipped = True
+                logger.warning(
+                    f"每日 search 配额预算或本配置公平份额已耗尽，跳过频道 {channel_id} 的搜索"
+                    "（配额将在次日太平洋时间重置）"
+                )
+                return []
             
             # 添加调试日志 - 检查频道搜索响应
             logger.debug(f"频道搜索响应类型: {type(search_response)}, 值: {search_response}")
@@ -1444,11 +1474,20 @@ class YouTubeMonitor:
             # 向上抛出让上层决定是否继续以及是否更新last_run_time
             raise
 
-    def _execute_with_retry(self, request: Any, description: str, max_attempts: int = 3, backoff_seconds: float = 1.0) -> Any:
-        """对YouTube API请求执行带重试的调用，用于处理临时性网络/SSL问题"""
+    def _execute_with_retry(self, request: Any, description: str, max_attempts: int = 3, backoff_seconds: float = 1.0, quota_consumer: Optional[Any] = None) -> Any:
+        """对YouTube API请求执行带重试的调用，用于处理临时性网络/SSL问题。
+
+        quota_consumer: 可选可调用对象，在**每次实际 attempt 前**调用一次；
+        返回 False 表示当日配额预算 / 该配置公平份额已耗尽，立即以
+        QuotaBudgetExhausted 中止（不再发起请求、不再重试）。
+        重试的每次 attempt 都是一次真实 API 请求，因此每次 attempt 都扣减配额
+        （修复“重试绕过每日预算”的回归）。
+        """
         attempt = 0
         last_exception: Optional[Exception] = None
         while attempt < max_attempts:
+            if quota_consumer is not None and not quota_consumer():
+                raise QuotaBudgetExhausted(description)
             try:
                 return request.execute()
             except HttpError as e:
@@ -1460,12 +1499,13 @@ class YouTubeMonitor:
                     status = None
                 if status and 500 <= status < 600:
                     last_exception = e
+                elif status == 429:
+                    # 429 / quotaExceeded / rate limit：当日配额受限，静默跳过、不再重试，
+                    # 避免继续烧配额（issue 明确要求 429 当日跳过）。
+                    logger.warning(f"调用 {description} 触发 429/配额限制，当日跳过（不再重试）: {e}")
+                    raise
                 else:
-                    # 429或配额等错误也可适当重试
-                    if status in (429,):
-                        last_exception = e
-                    else:
-                        raise
+                    raise
             except ssl.SSLError as e:
                 # 记录并重试，同时尝试重建客户端
                 last_exception = e
@@ -1882,10 +1922,13 @@ class YouTubeMonitor:
     # YouTube Data API 免费配额：10000 单位/天，一次 search.list 消耗 100 单位。
     # 多个监控配置共享同一个 API key 的每日配额，因此用一个跨配置共享的
     # 「每日 search 次数」令牌桶统一兜底，避免高频调度 + 多配置把配额打满（429 quotaExceeded）。
+    # 官方配额按太平洋时间（America/Los_Angeles）0 点重置，见
+    # https://developers.google.com/youtube/v3/determine_quota_cost
     _MONITOR_DAILY_QUOTA_UNITS = 10000
     _MONITOR_QUOTA_PER_SEARCH = 100
     # 实际可用 search 次数 = 配额 / 单次消耗，再留 5% 余量防边界 429
     _MONITOR_DAILY_SEARCH_BUDGET = int(_MONITOR_DAILY_QUOTA_UNITS / _MONITOR_QUOTA_PER_SEARCH * 0.95)  # 95 次/天
+    _QUOTA_TZ_NAME = 'America/Los_Angeles'
 
     def _resolve_schedule_interval_minutes(self, config):
         """返回该配置的调度间隔（分钟），尊重用户在设置页填写的 schedule_interval。
@@ -1894,43 +1937,184 @@ class YouTubeMonitor:
         但系统忽略了它，导致用户设的间隔不生效。这里恢复「尊重用户配置」的语义。
 
         配额安全不再靠强制每日调度来保证，而是统一交由跨配置共享的每日 search 令牌桶
-        （见 _consume_quota_budget）兜底：无论调度多频繁，每天实际发出的 search 请求
+        （见 _try_consume_quota）兜底：无论调度多频繁，每天实际发出的 search 请求
         总量被限制在 _MONITOR_DAILY_SEARCH_BUDGET 以内，且立即检查（start_all_schedules
         的 15s 触发）也计入同一预算，不会绕过。
 
-        为安全与调度资源考虑，间隔下限 1 分钟、上限 1440 分钟（每日一次）：
-        低于每日的更高频对抓取新视频意义有限；超过每日无实际意义。
+        为安全与调度资源考虑，间隔下限 1 分钟、上限 43200 分钟（30 天），与设置页
+        声明（1–43200，最长 30 天）一致：用户配置每周/每月等长周期调度被真正尊重，
+        不再被静默截断成每日一次。
         """
         raw = config.get('schedule_interval')
         try:
             iv = int(raw)
         except (TypeError, ValueError):
             iv = 120
-        iv = max(1, min(iv, 1440))
+        iv = max(1, min(iv, 43200))
         return iv
 
+    def _quota_day_str(self):
+        """返回 YouTube 配额日（America/Los_Angeles 本地日期，与官方重置对齐）。
+
+        UTC 0 点比太平洋时间早约 7/8 小时，若按 UTC 日重置会提前放出第二天的额度，
+        导致边界多发一轮搜索；改用洛杉矶本地日期后与官方配额日一致。
+        """
+        try:
+            from zoneinfo import ZoneInfo
+            return datetime.now(ZoneInfo(self._QUOTA_TZ_NAME)).strftime('%Y-%m-%d')
+        except Exception:
+            # 极少数无系统 tzdata 的环境：退化为 UTC-7（近似洛杉矶时间）
+            return (datetime.utcnow() - timedelta(hours=7)).strftime('%Y-%m-%d')
+
+    def _quota_reset_tables(self):
+        """惰性创建配额/轮转相关表（幂等）。"""
+        if getattr(self, '_quota_tables_ready', False):
+            return
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                'CREATE TABLE IF NOT EXISTS monitor_quota_budget ('
+                '  quota_date TEXT PRIMARY KEY,'
+                '  used INTEGER NOT NULL'
+                ')'
+            )
+            conn.execute(
+                'CREATE TABLE IF NOT EXISTS monitor_quota_usage ('
+                '  config_id INTEGER NOT NULL,'
+                '  quota_date TEXT NOT NULL,'
+                '  used INTEGER NOT NULL,'
+                '  PRIMARY KEY (config_id, quota_date)'
+                ')'
+            )
+            conn.execute(
+                'CREATE TABLE IF NOT EXISTS monitor_keyword_cursor ('
+                '  config_id INTEGER PRIMARY KEY,'
+                '  cursor_index INTEGER NOT NULL,'
+                '  updated_at TEXT'
+                ')'
+            )
+            conn.commit()
+        self._quota_tables_ready = True
+
     def _quota_budget_remaining(self):
-        """返回今日跨配置共享的 search 预算剩余次数（自动按 UTC 日重置）。"""
-        today = datetime.utcnow().strftime('%Y-%m-%d')
-        if not hasattr(self, '_quota_date') or self._quota_date != today:
-            self._quota_date = today
-            self._quota_used = 0
-        return max(0, self._MONITOR_DAILY_SEARCH_BUDGET - self._quota_used)
+        """返回今日跨配置共享的 search 预算剩余次数（SQLite 持久化，按 PT 配额日重置）。"""
+        self._quota_reset_tables()
+        day = self._quota_day_str()
+        with sqlite3.connect(self.db_path) as conn:
+            row = conn.execute(
+                'SELECT used FROM monitor_quota_budget WHERE quota_date = ?', (day,)
+            ).fetchone()
+        used = row[0] if row else 0
+        return max(0, self._MONITOR_DAILY_SEARCH_BUDGET - used)
 
     def _consume_quota_budget(self, searches):
-        """尝试从跨配置共享的每日 search 预算中扣减 searches 次请求。
+        """（兼容入口）从跨配置共享的每日 search 预算中原子扣减，返回实际可执行次数。
 
-        返回实际可执行的 search 次数（受今日预算上限约束，不会超过 searches）。
-        立即检查与定时运行都走同一份 _fetch_search_videos，因此都会计入本预算。
+        基于 SQLite 条件更新实现跨线程 / 跨进程原子性：逐次 UPDATE 且仅当
+        `used < budget` 时生效，避免不同 APScheduler 线程在边界同时超额。
         """
-        today = datetime.utcnow().strftime('%Y-%m-%d')
-        if not hasattr(self, '_quota_date') or self._quota_date != today:
-            self._quota_date = today
-            self._quota_used = 0
-        remaining = max(0, self._MONITOR_DAILY_SEARCH_BUDGET - self._quota_used)
-        allowed = min(searches, remaining)
-        self._quota_used += allowed
-        return allowed
+        self._quota_reset_tables()
+        day = self._quota_day_str()
+        granted = 0
+        with sqlite3.connect(self.db_path, timeout=30) as conn:
+            conn.execute(
+                'INSERT INTO monitor_quota_budget (quota_date, used) VALUES (?, 0) '
+                'ON CONFLICT(quota_date) DO NOTHING', (day,)
+            )
+            for _ in range(int(searches)):
+                cur = conn.execute(
+                    'UPDATE monitor_quota_budget SET used = used + 1 '
+                    'WHERE quota_date = ? AND used < ?',
+                    (day, self._MONITOR_DAILY_SEARCH_BUDGET),
+                )
+                if cur.rowcount != 1:
+                    break
+                granted += 1
+            conn.commit()
+        return granted
+
+    def _monitor_config_quota_share(self):
+        """返回每个启用自动调度配置的每日公平份额（预算均分，最少 1 次）。
+
+        防止「先到先得」的高频配置吃光整个预算、持续饿死后面的配置：
+        每个配置每天最多使用自己的份额，预算因此按配置数公平分配。
+        """
+        try:
+            configs = self.get_monitor_configs()
+            auto_count = len([
+                c for c in configs
+                if c.get('enabled') and c.get('schedule_type') == 'auto'
+            ])
+        except Exception:
+            auto_count = 0
+        return max(1, self._MONITOR_DAILY_SEARCH_BUDGET // (auto_count or 1))
+
+    def _try_consume_quota(self, config_id, n=1):
+        """原子扣减 n 次 search 配额（全局共享预算 + 该配置当日公平份额）。
+
+        返回 True 表示扣减成功；False 表示全局预算或该配置份额已耗尽。
+        条件 UPDATE 为单语句原子操作，跨线程 / 跨进程安全；
+        配置份额不足时回滚全局扣减，把额度让给其它配置。
+        """
+        self._quota_reset_tables()
+        day = self._quota_day_str()
+        share = self._monitor_config_quota_share()
+        with sqlite3.connect(self.db_path, timeout=30) as conn:
+            conn.execute(
+                'INSERT INTO monitor_quota_budget (quota_date, used) VALUES (?, 0) '
+                'ON CONFLICT(quota_date) DO NOTHING', (day,)
+            )
+            cur = conn.execute(
+                'UPDATE monitor_quota_budget SET used = used + ? '
+                'WHERE quota_date = ? AND used + ? <= ?',
+                (n, day, n, self._MONITOR_DAILY_SEARCH_BUDGET),
+            )
+            if cur.rowcount != 1:
+                return False  # 全局预算已耗尽
+            conn.execute(
+                'INSERT INTO monitor_quota_usage (config_id, quota_date, used) '
+                'VALUES (?, ?, 0) ON CONFLICT(config_id, quota_date) DO NOTHING',
+                (config_id, day),
+            )
+            cur2 = conn.execute(
+                'UPDATE monitor_quota_usage SET used = used + ? '
+                'WHERE config_id = ? AND quota_date = ? AND used + ? <= ?',
+                (n, config_id, day, n, share),
+            )
+            if cur2.rowcount != 1:
+                # 该配置当日份额用尽：回滚全局扣减，公平让位给其它配置
+                conn.execute(
+                    'UPDATE monitor_quota_budget SET used = MAX(0, used - ?) '
+                    'WHERE quota_date = ?', (n, day)
+                )
+                conn.commit()
+                return False
+            conn.commit()
+        return True
+
+    def _next_keyword_rotation_start(self, config_id, keyword_count, max_searches):
+        """返回本轮关键词轮转起始下标，并持久化推进游标（每轮推进，跨重启保持）。
+
+        旧实现按「UTC 日期」算起点，高频调度（如每小时一轮）会在整天重复同一组
+        关键词、其余关键词一次也不搜；改为每轮推进并落库后，高频模式也能轮流覆盖
+        全部关键词。
+        """
+        self._quota_reset_tables()
+        with sqlite3.connect(self.db_path, timeout=30) as conn:
+            row = conn.execute(
+                'SELECT cursor_index FROM monitor_keyword_cursor WHERE config_id = ?',
+                (config_id,),
+            ).fetchone()
+            start = (row[0] % keyword_count) if row else 0
+            next_cursor = (start + max_searches) % keyword_count
+            conn.execute(
+                'INSERT INTO monitor_keyword_cursor (config_id, cursor_index, updated_at) '
+                'VALUES (?, ?, ?) '
+                'ON CONFLICT(config_id) DO UPDATE SET '
+                '  cursor_index = excluded.cursor_index, updated_at = excluded.updated_at',
+                (config_id, next_cursor, datetime.now().strftime('%Y-%m-%d %H:%M:%S')),
+            )
+            conn.commit()
+        return start
 
     def _resolve_monitor_searches_per_run(self):
         """从全局应用配置读取每轮 search 次数上限，并做严格校验。
@@ -1994,15 +2178,17 @@ class YouTubeMonitor:
             self._schedule_monitor(config_id, self._resolve_schedule_interval_minutes(config_data))
     
     def _remove_schedule(self, config_id):
-        """移除调度任务"""
+        """移除调度任务（含启动后立即检查任务）"""
         job_id = f"monitor_{config_id}"
-        
-        try:
-            if self.scheduler.get_job(job_id):
-                self.scheduler.remove_job(job_id)
-                logger.info(f"移除监控调度任务: {job_id}")
-        except Exception as e:
-            logger.error(f"移除调度任务失败: {str(e)}")
+        immediate_id = f"monitor_immediate_{config_id}"
+
+        for jid in (job_id, immediate_id):
+            try:
+                if self.scheduler.get_job(jid):
+                    self.scheduler.remove_job(jid)
+                    logger.info(f"移除监控调度任务: {jid}")
+            except Exception as e:
+                logger.error(f"移除调度任务失败: {jid}, 错误: {str(e)}")
     
     def get_monitor_history(self, config_id=None, limit=100):
         """获取监控历史记录"""

--- a/modules/youtube_monitor.py
+++ b/modules/youtube_monitor.py
@@ -379,7 +379,7 @@ class YouTubeMonitor:
             
             for config in configs:
                 if config['enabled'] and config['schedule_type'] == 'auto':
-                    self._schedule_monitor(config['id'], config['schedule_interval'])
+                    self._schedule_monitor(config['id'], self._monitor_schedule_interval_minutes())
                     restored_schedules += 1
             
             if restored_schedules > 0:
@@ -627,10 +627,11 @@ class YouTubeMonitor:
             # 保存配置到文件
             self._save_config_to_file(config_id, config_data)
             
-            # 如果是自动调度，添加到调度器
+            # 如果是自动调度，添加到调度器（统一走每日预算节拍）
             if config_data.get('schedule_type') == 'auto':
-                logger.info(f"配置 {config_id} 启用自动调度，间隔: {config_data.get('schedule_interval', 120)}分钟")
-                self._schedule_monitor(config_id, config_data.get('schedule_interval', 120))
+                interval = self._monitor_schedule_interval_minutes()
+                logger.info(f"配置 {config_id} 启用自动调度，间隔: {interval}分钟（按天轮流模式）")
+                self._schedule_monitor(config_id, interval)
             
             return config_id
         except Exception as e:
@@ -1061,7 +1062,9 @@ class YouTubeMonitor:
             # 策略：每轮最多只发 MONITOR_SEARCHES_PER_RUN 次 search（默认 2），
             # 并按「当天日期」在全部关键词里轮流挑选，使配额均匀分摊到各关键词、
             # 且相邻多天能覆盖不同关键词，而非每轮把所有关键词都搜一遍。
-            max_searches = max(int(config.get('MONITOR_SEARCHES_PER_RUN', 2)), 1)
+            # MONITOR_SEARCHES_PER_RUN 是「全局应用配置」，monitor DB 记录上并无此字段；
+            # 必须从全局配置显式读取（带非整数校验），否则会恒为默认值 2 而失效。
+            max_searches = self._resolve_monitor_searches_per_run()
             day_index = (datetime.utcnow() - datetime(1970, 1, 1)).days  # 按 UTC 天轮换
             if len(keywords_list) > max_searches:
                 start = (day_index * max_searches) % len(keywords_list)
@@ -1860,6 +1863,36 @@ class YouTubeMonitor:
             )
             conn.commit()
     
+    def _monitor_schedule_interval_minutes(self):
+        """统一调度间隔（配额预算节拍，单一策略来源）。
+
+        YouTube Data API 免费配额仅 10000 单位/天，一次 search 消耗 100 单位。
+        配额预算按「每天」分摊：无论用户在配置里填多少分钟，实际调度统一为每天
+        一次（1440 分钟），配合 _fetch_search_videos 内「按天轮流选关键词」实现
+        均匀分布，避免高频调度 + 多关键词把每日配额打满（429 quotaExceeded）。
+
+        所有调度入口（启动 start_all_schedules / 恢复 _restart_restored_schedules /
+        新建 / 编辑 _update_schedule）都必须走这里，不能各自用 config['schedule_interval']，
+        否则会绕过每日预算。
+        """
+        return 1440
+
+    def _resolve_monitor_searches_per_run(self):
+        """从全局应用配置读取每轮 search 次数上限，并做非整数校验。
+
+        MONITOR_SEARCHES_PER_RUN 属于全局应用配置（config_manager.DEFAULT_CONFIG），
+        而传入 _fetch_search_videos 的是 monitor DB 记录，上面没有该字段；若直接用
+        config.get(...) 会恒为默认值 2 而从未真正生效。这里显式从全局配置读取并校验。
+        """
+        try:
+            raw = (load_config() or {}).get('MONITOR_SEARCHES_PER_RUN')
+            if raw is None or raw == '':
+                return 2
+            return max(int(raw), 1)
+        except (TypeError, ValueError):
+            logger.warning("MONITOR_SEARCHES_PER_RUN 非整数，回退到默认值 2")
+            return 2
+
     def _schedule_monitor(self, config_id, interval_minutes):
         """添加监控任务到调度器"""
         job_id = f"monitor_{config_id}"
@@ -1892,9 +1925,9 @@ class YouTubeMonitor:
         # 移除现有任务
         self._remove_schedule(config_id)
         
-        # 如果是自动调度，重新添加
+        # 如果是自动调度，重新添加（统一走每日预算节拍）
         if config_data.get('schedule_type') == 'auto' and config_data.get('enabled'):
-            self._schedule_monitor(config_id, config_data.get('schedule_interval', 120))
+            self._schedule_monitor(config_id, self._monitor_schedule_interval_minutes())
     
     def _remove_schedule(self, config_id):
         """移除调度任务"""
@@ -2001,10 +2034,8 @@ class YouTubeMonitor:
         logger.info(f"找到 {len(auto_configs)} 个启用的自动调度配置")
         
         for config in auto_configs:
-            # 按天轮流模式：无论 DB 中配置何种间隔，统一以每天（1440 分钟）跑一次，
-            # 配合 _fetch_search_videos 内「按天轮流挑选关键词」实现均匀分布，避免
-            # 高频调度 + 多关键词把每日 search 配额打满（429 quotaExceeded）。
-            run_interval = 1440
+            # 统一走每日预算节拍（所有调度入口一致，避免高频调度打满配额）
+            run_interval = self._monitor_schedule_interval_minutes()
             logger.info(f"启动调度: {config['name']} (ID: {config['id']}), 间隔: {run_interval}分钟（按天轮流模式）")
             self._schedule_monitor(config['id'], run_interval)
             # 启动/重启后立即触发一次检查，避免首次检查被推到一整个间隔之后

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,10 @@ Pillow~=12.3.0
 lxml>=6.1.0,<7.0
 
 # Platform SDKs: stay on the verified release line unless tested otherwise.
+# tzdata：在缺少系统 IANA 时区库的环境（如部分精简镜像 / Windows）提供
+# America/Los_Angeles 等时区数据，确保 YouTube 配额日对齐太平洋时间（DST-aware）。
+# 缺失时 _quota_day_str 会回退 UTC 日（仅边界多一次重置，不会冬令时算错日期）。
+tzdata>=2024.1
 alibabacloud_green20220302==2.20.4
 alibabacloud_tea_openapi==0.3.15
 alibabacloud_tea_util==0.3.13

--- a/tests/test_youtube_monitor_quota_budget.py
+++ b/tests/test_youtube_monitor_quota_budget.py
@@ -1,3 +1,4 @@
+import datetime
 import os
 import shutil
 import sys
@@ -63,8 +64,9 @@ class YoutubeMonitorQuotaBudgetTests(unittest.TestCase):
         self.assertEqual(self.monitor._resolve_schedule_interval_minutes({"schedule_interval": 1440}), 1440)
 
     def test_interval_clamps_to_bounds(self):
-        # 超过每日（1440）截断为 1440；低于 1 截断为 1
-        self.assertEqual(self.monitor._resolve_schedule_interval_minutes({"schedule_interval": 100000}), 1440)
+        # 超过 30 天（43200 分钟）截断为 43200；低于 1 截断为 1
+        self.assertEqual(self.monitor._resolve_schedule_interval_minutes({"schedule_interval": 100000}), 43200)
+        self.assertEqual(self.monitor._resolve_schedule_interval_minutes({"schedule_interval": 43200}), 43200)
         self.assertEqual(self.monitor._resolve_schedule_interval_minutes({"schedule_interval": 0}), 1)
         self.assertEqual(self.monitor._resolve_schedule_interval_minutes({"schedule_interval": -30}), 1)
 
@@ -146,6 +148,261 @@ class YoutubeMonitorQuotaBudgetTests(unittest.TestCase):
         # immediate=False 时也不应新增
         self.monitor.start_all_schedules(immediate=False)
         self.assertEqual(immediate_job_ids(), first_immediate)
+
+
+class QuotaPersistenceAndAtomicTests(unittest.TestCase):
+    """PR #127 第三轮：预算 SQLite 持久化 + PT 配额日 + 跨实例可见 + 原子扣减。"""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.get_app_subdir_patcher = patch(
+            "modules.youtube_monitor.get_app_subdir",
+            side_effect=lambda sub: (os.makedirs(os.path.join(self.tmpdir, sub), exist_ok=True)
+                                     or os.path.join(self.tmpdir, sub)),
+        )
+        self.init_api_patcher = patch.object(
+            YouTubeMonitor, "_init_youtube_api",
+            return_value=(False, API_INIT_STATUS_MISSING_API_KEY),
+        )
+        self.get_app_subdir_patcher.start()
+        self.init_api_patcher.start()
+        self.monitor = YouTubeMonitor()
+
+    def tearDown(self):
+        try:
+            scheduler = getattr(self.monitor, "scheduler", None)
+            if scheduler and getattr(scheduler, "running", False):
+                scheduler.shutdown(wait=False)
+        finally:
+            self.get_app_subdir_patcher.stop()
+            self.init_api_patcher.stop()
+            shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def test_quota_day_is_pt_aligned_date_string(self):
+        day = self.monitor._quota_day_str()
+        # YYYY-MM-DD 且为合法日期（洛杉矶本地日期）
+        self.assertRegex(day, r"^\d{4}-\d{2}-\d{2}$")
+        datetime.datetime.strptime(day, "%Y-%m-%d")
+
+    def test_quota_budget_persists_across_instances(self):
+        # 扣减后重建实例（模拟进程重启），剩余量应保留而非归零
+        self.assertEqual(self.monitor._consume_quota_budget(10), 10)
+        m2 = YouTubeMonitor()
+        self.assertEqual(
+            m2._quota_budget_remaining(),
+            self.monitor._MONITOR_DAILY_SEARCH_BUDGET - 10,
+        )
+        # 新实例继续扣减同一份持久化预算
+        self.assertEqual(m2._consume_quota_budget(5), 5)
+        self.assertEqual(self.monitor._quota_budget_remaining(),
+                         self.monitor._MONITOR_DAILY_SEARCH_BUDGET - 15)
+
+    def test_consume_budget_atomic_cap(self):
+        budget = self.monitor._MONITOR_DAILY_SEARCH_BUDGET
+        # 第一次打满
+        self.assertEqual(self.monitor._consume_quota_budget(budget + 50), budget)
+        # 之后再扣 0
+        self.assertEqual(self.monitor._consume_quota_budget(1), 0)
+        self.assertEqual(self.monitor._quota_budget_remaining(), 0)
+
+    def test_try_consume_quota_shared_budget_cap(self):
+        budget = self.monitor._MONITOR_DAILY_SEARCH_BUDGET
+        cid = self.monitor.create_monitor_config(
+            {"name": "auto", "schedule_type": "auto", "enabled": True})
+        for _ in range(budget):
+            self.assertTrue(self.monitor._try_consume_quota(cid, 1))
+        self.assertFalse(self.monitor._try_consume_quota(cid, 1))
+
+
+class ExecuteWithRetryQuotaTests(unittest.TestCase):
+    """PR #127 第三轮：每次实际 attempt 原子扣减 + 429 不重试 + 预算耗尽即止。"""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.get_app_subdir_patcher = patch(
+            "modules.youtube_monitor.get_app_subdir",
+            side_effect=lambda sub: (os.makedirs(os.path.join(self.tmpdir, sub), exist_ok=True)
+                                     or os.path.join(self.tmpdir, sub)),
+        )
+        self.init_api_patcher = patch.object(
+            YouTubeMonitor, "_init_youtube_api",
+            return_value=(False, API_INIT_STATUS_MISSING_API_KEY),
+        )
+        self.get_app_subdir_patcher.start()
+        self.init_api_patcher.start()
+        self.monitor = YouTubeMonitor()
+
+    def tearDown(self):
+        try:
+            scheduler = getattr(self.monitor, "scheduler", None)
+            if scheduler and getattr(scheduler, "running", False):
+                scheduler.shutdown(wait=False)
+        finally:
+            self.get_app_subdir_patcher.stop()
+            self.init_api_patcher.stop()
+            shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    class _FakeRequest:
+        def __init__(self, behavior):
+            self._behavior = behavior  # list of outcomes
+
+        def execute(self):
+            outcome = self._behavior.pop(0)
+            if isinstance(outcome, Exception):
+                raise outcome
+            return outcome
+
+    def test_retries_deduct_budget_per_attempt(self):
+        import ssl
+        from modules.youtube_monitor import QuotaBudgetExhausted
+        req = self._FakeRequest([ssl.SSLError("boom"), ssl.SSLError("boom"), {"ok": True}])
+        calls = []
+
+        def consumer():
+            calls.append(1)
+            return True
+
+        result = self.monitor._execute_with_retry(
+            req, "search.list", max_attempts=3, backoff_seconds=0.01,
+            quota_consumer=consumer)
+        self.assertEqual(result, {"ok": True})
+        # 3 次 attempt 各扣一次 → 重试没有绕过预算
+        self.assertEqual(len(calls), 3)
+
+    def test_budget_exhausted_stops_without_executing(self):
+        from modules.youtube_monitor import QuotaBudgetExhausted
+        req = self._FakeRequest([])  # execute 不应被调用
+        calls = []
+
+        def consumer():
+            calls.append(1)
+            return False
+
+        with self.assertRaises(QuotaBudgetExhausted):
+            self.monitor._execute_with_retry(
+                req, "search.list", quota_consumer=consumer)
+        self.assertEqual(len(calls), 1)
+
+    def test_429_raises_without_retry(self):
+        from googleapiclient.errors import HttpError
+        from modules.youtube_monitor import QuotaBudgetExhausted
+
+        class _Resp:
+            status = 429
+            reason = "quotaExceeded"
+
+        err = HttpError(_Resp(), b"{}", uri="http://x")
+        req = self._FakeRequest([err, {"should-not-happen": True}])
+        calls = []
+
+        def consumer():
+            calls.append(1)
+            return True
+
+        with self.assertRaises(HttpError):
+            self.monitor._execute_with_retry(
+                req, "search.list", max_attempts=3, backoff_seconds=0.01,
+                quota_consumer=consumer)
+        # 429 当日跳过：只扣 1 次、不重试
+        self.assertEqual(len(calls), 1)
+
+
+class KeywordRotationCursorTests(unittest.TestCase):
+    """PR #127 第三轮：关键词轮转游标持久化、每轮推进。"""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.get_app_subdir_patcher = patch(
+            "modules.youtube_monitor.get_app_subdir",
+            side_effect=lambda sub: (os.makedirs(os.path.join(self.tmpdir, sub), exist_ok=True)
+                                     or os.path.join(self.tmpdir, sub)),
+        )
+        self.init_api_patcher = patch.object(
+            YouTubeMonitor, "_init_youtube_api",
+            return_value=(False, API_INIT_STATUS_MISSING_API_KEY),
+        )
+        self.get_app_subdir_patcher.start()
+        self.init_api_patcher.start()
+        self.monitor = YouTubeMonitor()
+
+    def tearDown(self):
+        try:
+            scheduler = getattr(self.monitor, "scheduler", None)
+            if scheduler and getattr(scheduler, "running", False):
+                scheduler.shutdown(wait=False)
+        finally:
+            self.get_app_subdir_patcher.stop()
+            self.init_api_patcher.stop()
+            shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def test_cursor_advances_each_round_and_persists(self):
+        # 10 个关键词、每轮 2 个：0 → 2 → 4 → ...（每轮推进，而非按天固定）
+        self.assertEqual(self.monitor._next_keyword_rotation_start(1, 10, 2), 0)
+        self.assertEqual(self.monitor._next_keyword_rotation_start(1, 10, 2), 2)
+        self.assertEqual(self.monitor._next_keyword_rotation_start(1, 10, 2), 4)
+        # 新实例（模拟重启）读到同一游标，继续推进
+        m2 = YouTubeMonitor()
+        self.assertEqual(m2._next_keyword_rotation_start(1, 10, 2), 6)
+
+    def test_cursor_wraps_around(self):
+        # 2 个关键词、每轮 2 个：0 → 0（覆盖全部后回到开头）
+        self.assertEqual(self.monitor._next_keyword_rotation_start(9, 2, 2), 0)
+        self.assertEqual(self.monitor._next_keyword_rotation_start(9, 2, 2), 0)
+
+
+class DisableCancelsImmediateTests(unittest.TestCase):
+    """PR #127 第三轮：禁用配置取消立即任务 + run_monitor 入口复核状态。"""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.get_app_subdir_patcher = patch(
+            "modules.youtube_monitor.get_app_subdir",
+            side_effect=lambda sub: (os.makedirs(os.path.join(self.tmpdir, sub), exist_ok=True)
+                                     or os.path.join(self.tmpdir, sub)),
+        )
+        self.init_api_patcher = patch.object(
+            YouTubeMonitor, "_init_youtube_api",
+            return_value=(False, API_INIT_STATUS_MISSING_API_KEY),
+        )
+        self.get_app_subdir_patcher.start()
+        self.init_api_patcher.start()
+        self.monitor = YouTubeMonitor()
+
+    def tearDown(self):
+        try:
+            scheduler = getattr(self.monitor, "scheduler", None)
+            if scheduler and getattr(scheduler, "running", False):
+                scheduler.shutdown(wait=False)
+        finally:
+            self.get_app_subdir_patcher.stop()
+            self.init_api_patcher.stop()
+            shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def test_remove_schedule_cancels_immediate_job(self):
+        cid = self.monitor.create_monitor_config(
+            {"name": "auto", "schedule_type": "auto", "enabled": True})
+        # 先移除 interval，再启动 → 模拟首次启动，立即任务被安排
+        self.monitor._remove_schedule(cid)
+        self.monitor.start_all_schedules(immediate=True)
+        immediate_id = f"monitor_immediate_{cid}"
+        interval_id = f"monitor_{cid}"
+        self.assertIsNotNone(self.monitor.scheduler.get_job(immediate_id))
+        self.assertIsNotNone(self.monitor.scheduler.get_job(interval_id))
+        # 禁用/删除时 _remove_schedule 必须同时取消立即任务
+        self.monitor._remove_schedule(cid)
+        self.assertIsNone(self.monitor.scheduler.get_job(immediate_id))
+        self.assertIsNone(self.monitor.scheduler.get_job(interval_id))
+
+    def test_run_monitor_skips_when_config_disabled(self):
+        # 让 API 对象存在以绕过 init 检查，走到 enabled 复核
+        self.monitor.youtube = object()
+        cid = self.monitor.create_monitor_config(
+            {"name": "disabled", "schedule_type": "manual", "enabled": False})
+        with patch.object(self.monitor, "_fetch_trending_videos",
+                          side_effect=AssertionError("禁用配置不应抓取")):
+            ok, msg = self.monitor.run_monitor(cid)
+        self.assertFalse(ok)
+        self.assertIn("已禁用", msg)
 
 
 if __name__ == "__main__":

--- a/tests/test_youtube_monitor_quota_budget.py
+++ b/tests/test_youtube_monitor_quota_budget.py
@@ -99,17 +99,19 @@ class YoutubeMonitorQuotaBudgetTests(unittest.TestCase):
     def test_quota_budget_caps_daily_searches(self):
         budget = self.monitor._MONITOR_DAILY_SEARCH_BUDGET
         self.assertGreater(budget, 0)
-        # 第一次把预算打满
-        allowed = self.monitor._consume_quota_budget(budget + 50)
-        self.assertEqual(allowed, budget)
-        # 之后再请求应被拒绝
-        self.assertEqual(self.monitor._consume_quota_budget(10), 0)
+        # 每次 search 只扣 1 次（真实用法）：逐次扣满后，下一次拒绝。
+        for _ in range(budget):
+            self.assertTrue(self.monitor._try_consume_quota(1))
+        # 预算用尽后再次请求应被拒绝
+        self.assertFalse(self.monitor._try_consume_quota(1))
         self.assertEqual(self.monitor._quota_budget_remaining(), 0)
 
     def test_quota_budget_partial_consumption(self):
-        self.assertEqual(self.monitor._consume_quota_budget(10), 10)
+        for _ in range(10):
+            self.assertTrue(self.monitor._try_consume_quota(1))
         self.assertEqual(self.monitor._quota_budget_remaining(), self.monitor._MONITOR_DAILY_SEARCH_BUDGET - 10)
-        self.assertEqual(self.monitor._consume_quota_budget(5), 5)
+        for _ in range(5):
+            self.assertTrue(self.monitor._try_consume_quota(1))
 
     # ---- 立即检查不绕过预算：仅首次（定时任务不存在时）安排 ----
 
@@ -186,32 +188,36 @@ class QuotaPersistenceAndAtomicTests(unittest.TestCase):
 
     def test_quota_budget_persists_across_instances(self):
         # 扣减后重建实例（模拟进程重启），剩余量应保留而非归零
-        self.assertEqual(self.monitor._consume_quota_budget(10), 10)
+        for _ in range(10):
+            self.assertTrue(self.monitor._try_consume_quota(1))
         m2 = YouTubeMonitor()
         self.assertEqual(
             m2._quota_budget_remaining(),
             self.monitor._MONITOR_DAILY_SEARCH_BUDGET - 10,
         )
         # 新实例继续扣减同一份持久化预算
-        self.assertEqual(m2._consume_quota_budget(5), 5)
+        for _ in range(5):
+            self.assertTrue(m2._try_consume_quota(1))
         self.assertEqual(self.monitor._quota_budget_remaining(),
                          self.monitor._MONITOR_DAILY_SEARCH_BUDGET - 15)
 
     def test_consume_budget_atomic_cap(self):
         budget = self.monitor._MONITOR_DAILY_SEARCH_BUDGET
-        # 第一次打满
-        self.assertEqual(self.monitor._consume_quota_budget(budget + 50), budget)
-        # 之后再扣 0
-        self.assertEqual(self.monitor._consume_quota_budget(1), 0)
+        # 逐次扣满
+        for _ in range(budget):
+            self.assertTrue(self.monitor._try_consume_quota(1))
+        # 之后再扣被拒绝
+        self.assertFalse(self.monitor._try_consume_quota(1))
         self.assertEqual(self.monitor._quota_budget_remaining(), 0)
 
     def test_try_consume_quota_shared_budget_cap(self):
+        # 单一全局令牌桶：搜索型配置共享同一天额度，不受配置数量/类型影响
+        # （不再按「每配置份额」分配，故 10 个 playlist + 1 个搜索时，搜索配置
+        #  仍能用满 95 次，而非旧模型被分母虚大压到 8 次而过度限流）。
         budget = self.monitor._MONITOR_DAILY_SEARCH_BUDGET
-        cid = self.monitor.create_monitor_config(
-            {"name": "auto", "schedule_type": "auto", "enabled": True})
         for _ in range(budget):
-            self.assertTrue(self.monitor._try_consume_quota(cid, 1))
-        self.assertFalse(self.monitor._try_consume_quota(cid, 1))
+            self.assertTrue(self.monitor._try_consume_quota(1))
+        self.assertFalse(self.monitor._try_consume_quota(1))
 
 
 class ExecuteWithRetryQuotaTests(unittest.TestCase):
@@ -283,7 +289,7 @@ class ExecuteWithRetryQuotaTests(unittest.TestCase):
                 req, "search.list", quota_consumer=consumer)
         self.assertEqual(len(calls), 1)
 
-    def test_429_raises_without_retry(self):
+    def test_429_triggers_day_circuit_breaker(self):
         from googleapiclient.errors import HttpError
         from modules.youtube_monitor import QuotaBudgetExhausted
 
@@ -291,20 +297,31 @@ class ExecuteWithRetryQuotaTests(unittest.TestCase):
             status = 429
             reason = "quotaExceeded"
 
-        err = HttpError(_Resp(), b"{}", uri="http://x")
+        err = HttpError(_Resp(), b'{"error": {"errors": [{"reason": "quotaExceeded"}]}}', uri="http://x")
         req = self._FakeRequest([err, {"should-not-happen": True}])
         calls = []
 
         def consumer():
             calls.append(1)
-            return True
+            return True  # 预算充足，但远端 429 仍应触发当日熔断
 
-        with self.assertRaises(HttpError):
+        with self.assertRaises(QuotaBudgetExhausted):
             self.monitor._execute_with_retry(
                 req, "search.list", max_attempts=3, backoff_seconds=0.01,
                 quota_consumer=consumer)
-        # 429 当日跳过：只扣 1 次、不重试
+        # 429 触发集中式当日熔断：只发 1 次请求、不重试；并标记当日耗尽
         self.assertEqual(len(calls), 1)
+        self.assertTrue(self.monitor._last_fetch_quota_skipped)
+        self.assertEqual(self.monitor._quota_budget_remaining(), 0)
+
+    def test_circuit_breaker_blocks_subsequent_searches(self):
+        # 当日熔断后，任何 search 入口的 _try_consume_quota / 前置检查都应短路，
+        # 解决旧实现「第一个关键词 429 后第二个仍真实发请求」的缺陷。
+        self.monitor._mark_quota_depleted_today()
+        self.assertEqual(self.monitor._quota_budget_remaining(), 0)
+        self.assertFalse(self.monitor._try_consume_quota(1))
+        # _fetch_search_videos / _fetch_channel_search_videos 的前置检查也会跳过
+        # （依赖 _quota_budget_remaining() <= 0），无需再发请求。
 
 
 class KeywordRotationCursorTests(unittest.TestCase):

--- a/tests/test_youtube_monitor_quota_budget.py
+++ b/tests/test_youtube_monitor_quota_budget.py
@@ -1,0 +1,152 @@
+import os
+import shutil
+import sys
+import tempfile
+import types
+import unittest
+from unittest.mock import patch
+
+try:
+    from modules.youtube_monitor import API_INIT_STATUS_MISSING_API_KEY, YouTubeMonitor
+except ModuleNotFoundError:
+    # 兜底打桩（与仓库其它 monitor 测试一致的轻量 stub 方案）
+    if "modules.utils" not in sys.modules:
+        modules_utils = types.ModuleType("modules.utils")
+        modules_utils.get_app_subdir = lambda subdir_name: os.path.join(os.getcwd(), "temp", "unit-tests", subdir_name)
+        sys.modules["modules.utils"] = modules_utils
+    if "modules.config_manager" not in sys.modules:
+        modules_config_manager = types.ModuleType("modules.config_manager")
+        modules_config_manager.load_config = lambda: {}
+        sys.modules["modules.config_manager"] = modules_config_manager
+    sys.modules.pop("modules.youtube_monitor", None)
+    from modules.youtube_monitor import API_INIT_STATUS_MISSING_API_KEY, YouTubeMonitor
+
+
+class YoutubeMonitorQuotaBudgetTests(unittest.TestCase):
+    """PR #127 跟进：调度间隔尊重用户配置 + 跨配置共享每日配额预算 + 立即检查不绕过预算。"""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.get_app_subdir_patcher = patch(
+            "modules.youtube_monitor.get_app_subdir",
+            side_effect=self._get_app_subdir,
+        )
+        self.init_api_patcher = patch.object(
+            YouTubeMonitor,
+            "_init_youtube_api",
+            return_value=(False, API_INIT_STATUS_MISSING_API_KEY),
+        )
+        self.get_app_subdir_patcher.start()
+        self.init_api_patcher.start()
+        self.monitor = YouTubeMonitor()
+
+    def tearDown(self):
+        try:
+            scheduler = getattr(self.monitor, "scheduler", None)
+            if scheduler and getattr(scheduler, "running", False):
+                scheduler.shutdown(wait=False)
+        finally:
+            self.get_app_subdir_patcher.stop()
+            self.init_api_patcher.stop()
+            shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _get_app_subdir(self, subdir_name):
+        path = os.path.join(self.tmpdir, subdir_name)
+        os.makedirs(path, exist_ok=True)
+        return path
+
+    # ---- 调度间隔：尊重用户配置（修复行为回归） ----
+
+    def test_interval_honors_configured_value(self):
+        self.assertEqual(self.monitor._resolve_schedule_interval_minutes({"schedule_interval": 120}), 120)
+        self.assertEqual(self.monitor._resolve_schedule_interval_minutes({"schedule_interval": 60}), 60)
+        self.assertEqual(self.monitor._resolve_schedule_interval_minutes({"schedule_interval": 1440}), 1440)
+
+    def test_interval_clamps_to_bounds(self):
+        # 超过每日（1440）截断为 1440；低于 1 截断为 1
+        self.assertEqual(self.monitor._resolve_schedule_interval_minutes({"schedule_interval": 100000}), 1440)
+        self.assertEqual(self.monitor._resolve_schedule_interval_minutes({"schedule_interval": 0}), 1)
+        self.assertEqual(self.monitor._resolve_schedule_interval_minutes({"schedule_interval": -30}), 1)
+
+    def test_interval_falls_back_to_default_on_invalid(self):
+        self.assertEqual(self.monitor._resolve_schedule_interval_minutes({"schedule_interval": "abc"}), 120)
+        self.assertEqual(self.monitor._resolve_schedule_interval_minutes({}), 120)
+
+    # ---- MONITOR_SEARCHES_PER_RUN 严格校验 ----
+
+    def test_searches_per_run_default_and_strict(self):
+        with patch("modules.youtube_monitor.load_config", return_value={}):
+            self.assertEqual(self.monitor._resolve_monitor_searches_per_run(), 2)
+
+        # 正整数保持不变（但受上限 10 约束）
+        with patch("modules.youtube_monitor.load_config", return_value={"MONITOR_SEARCHES_PER_RUN": 5}):
+            self.assertEqual(self.monitor._resolve_monitor_searches_per_run(), 5)
+
+        # 超过上限 10 -> 截断为 10
+        with patch("modules.youtube_monitor.load_config", return_value={"MONITOR_SEARCHES_PER_RUN": 999}):
+            self.assertEqual(self.monitor._resolve_monitor_searches_per_run(), 10)
+
+        # 非正整数 -> 回退 2
+        with patch("modules.youtube_monitor.load_config", return_value={"MONITOR_SEARCHES_PER_RUN": 0}):
+            self.assertEqual(self.monitor._resolve_monitor_searches_per_run(), 1)  # max(0,1)=1
+        with patch("modules.youtube_monitor.load_config", return_value={"MONITOR_SEARCHES_PER_RUN": "oops"}):
+            self.assertEqual(self.monitor._resolve_monitor_searches_per_run(), 2)
+
+    # ---- 跨配置共享的每日配额预算 ----
+
+    def test_quota_budget_caps_daily_searches(self):
+        budget = self.monitor._MONITOR_DAILY_SEARCH_BUDGET
+        self.assertGreater(budget, 0)
+        # 第一次把预算打满
+        allowed = self.monitor._consume_quota_budget(budget + 50)
+        self.assertEqual(allowed, budget)
+        # 之后再请求应被拒绝
+        self.assertEqual(self.monitor._consume_quota_budget(10), 0)
+        self.assertEqual(self.monitor._quota_budget_remaining(), 0)
+
+    def test_quota_budget_partial_consumption(self):
+        self.assertEqual(self.monitor._consume_quota_budget(10), 10)
+        self.assertEqual(self.monitor._quota_budget_remaining(), self.monitor._MONITOR_DAILY_SEARCH_BUDGET - 10)
+        self.assertEqual(self.monitor._consume_quota_budget(5), 5)
+
+    # ---- 立即检查不绕过预算：仅首次（定时任务不存在时）安排 ----
+
+    def test_start_all_schedules_immediate_only_when_job_absent(self):
+        # 创建两个自动调度配置
+        c1 = self.monitor.create_monitor_config({"name": "auto-1", "schedule_type": "auto", "enabled": True})
+        c2 = self.monitor.create_monitor_config({"name": "auto-2", "schedule_type": "auto", "enabled": True})
+
+        scheduler = self.monitor.scheduler
+
+        def immediate_job_ids():
+            return {jid.id for jid in scheduler.get_jobs() if jid.id.startswith("monitor_immediate_")}
+
+        def interval_job_ids():
+            return {jid.id for jid in scheduler.get_jobs() if jid.id.startswith("monitor_") and not jid.id.startswith("monitor_immediate_")}
+
+        # 配置创建时已自动排好 interval 任务；模拟「定时任务此前不存在」的场景：
+        # 先移除 interval 任务，再启动，验证此时会安排立即检查。
+        self.monitor._remove_schedule(c1)
+        self.monitor._remove_schedule(c2)
+        self.assertEqual(len(interval_job_ids()), 0, "移除后不应有定时任务")
+
+        # 第一次启动：定时任务此前不存在 -> 安排立即检查
+        self.monitor.start_all_schedules(immediate=True)
+        first_immediate = immediate_job_ids()
+        first_interval = interval_job_ids()
+        self.assertEqual(len(first_interval), 2, "应有两个定时任务")
+        self.assertEqual(len(first_immediate), 2, "首次启动应为两个配置都安排立即检查")
+
+        # 第二次启动（模拟设置保存触发的重启）：定时任务已存在 -> 不应再新增立即检查
+        self.monitor.start_all_schedules(immediate=True)
+        second_immediate = immediate_job_ids()
+        self.assertEqual(second_immediate, first_immediate, "再次启动时不应新增立即检查（避免绕过每日预算）")
+        self.assertEqual(len(interval_job_ids()), 2)
+
+        # immediate=False 时也不应新增
+        self.monitor.start_all_schedules(immediate=False)
+        self.assertEqual(immediate_job_ids(), first_immediate)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_youtube_monitor_quota_budget.py
+++ b/tests/test_youtube_monitor_quota_budget.py
@@ -548,5 +548,224 @@ class DisableCancelsImmediateTests(unittest.TestCase):
         self.assertIn("已禁用", msg)
 
 
+class SearchConsumerPredicateTests(unittest.TestCase):
+    """PR #127 第五轮：搜索消费者谓词修复（分母覆盖真实 search 消费者）。"""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.get_app_subdir_patcher = patch(
+            "modules.youtube_monitor.get_app_subdir",
+            side_effect=lambda sub: (os.makedirs(os.path.join(self.tmpdir, sub), exist_ok=True)
+                                     or os.path.join(self.tmpdir, sub)),
+        )
+        self.init_api_patcher = patch.object(
+            YouTubeMonitor, "_init_youtube_api",
+            return_value=(False, API_INIT_STATUS_MISSING_API_KEY),
+        )
+        self.get_app_subdir_patcher.start()
+        self.init_api_patcher.start()
+        self.monitor = YouTubeMonitor()
+
+    def tearDown(self):
+        try:
+            scheduler = getattr(self.monitor, "scheduler", None)
+            if scheduler and getattr(scheduler, "running", False):
+                scheduler.shutdown(wait=False)
+        finally:
+            self.get_app_subdir_patcher.stop()
+            self.init_api_patcher.stop()
+            shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def test_is_search_consumer_matches_dispatch(self):
+        # 分流谓词：无 channel_ids -> 走 search.list（是消费者）
+        self.assertTrue(self.monitor._is_search_consumer(
+            {"enabled": True, "keywords": "a", "channel_mode": "latest"}))
+        # 有 channel_ids + channel_mode=='search' -> 走频道内 search.list（是消费者）
+        self.assertTrue(self.monitor._is_search_consumer(
+            {"enabled": True, "channel_ids": "UC123", "channel_mode": "search"}))
+        # 有 channel_ids + channel_mode='latest' -> 走 playlist（非 search 消费者）
+        self.assertFalse(self.monitor._is_search_consumer(
+            {"enabled": True, "channel_ids": "UC123", "channel_mode": "latest"}))
+        # 有 channel_ids + channel_mode='historical' -> 走 playlist（非 search 消费者）
+        self.assertFalse(self.monitor._is_search_consumer(
+            {"enabled": True, "channel_ids": "UC123", "channel_mode": "historical"}))
+        # 未启用 -> 不是消费者（无论何种模式）
+        self.assertFalse(self.monitor._is_search_consumer(
+            {"enabled": False, "keywords": "a"}))
+
+    def test_search_config_count_uses_correct_denominator(self):
+        # 建 2 个「频道搜索」配置（channel_ids + channel_mode='search'）：
+        # 旧实现用错误字段 channel_id（单数）会漏掉它们，导致 count=0、份额=95、互相饿死。
+        c1 = self.monitor.create_monitor_config(
+            {"name": "ch1", "schedule_type": "auto", "enabled": True,
+             "channel_ids": "UC123", "channel_mode": "search"})
+        c2 = self.monitor.create_monitor_config(
+            {"name": "ch2", "schedule_type": "auto", "enabled": True,
+             "channel_ids": "UC456", "channel_mode": "search"})
+        # 另加一个 playlist 频道配置（latest），不应计入分母
+        self.monitor.create_monitor_config(
+            {"name": "pl", "schedule_type": "auto", "enabled": True,
+             "channel_ids": "UC789", "channel_mode": "latest"})
+        # 另加停用配置，不应计入
+        self.monitor.create_monitor_config(
+            {"name": "off", "schedule_type": "auto", "enabled": False,
+             "keywords": "z"})
+        count = self.monitor._monitor_search_config_count()
+        self.assertEqual(count, 2, "2 个频道搜索配置应被计入，其余不计入")
+        # 份额 = budget // 2，而非 95（旧实现会算成 95）
+        share = self.monitor._per_config_share()
+        self.assertEqual(share, self.monitor._MONITOR_DAILY_SEARCH_BUDGET // 2)
+
+    def test_manual_search_config_counted_to_avoid_starvation(self):
+        # manual 关键词配置同样消费 search，若不计入分母会被手动运行抢满 95 次。
+        c_auto = self.monitor.create_monitor_config(
+            {"name": "auto", "schedule_type": "auto", "enabled": True, "keywords": "a"})
+        c_manual = self.monitor.create_monitor_config(
+            {"name": "manual", "schedule_type": "manual", "enabled": True, "keywords": "b"})
+        count = self.monitor._monitor_search_config_count()
+        self.assertEqual(count, 2)
+        share = self.monitor._per_config_share()
+        # manual 与 auto 各获 budget//2，auto 不会被 manual 抢空
+        for _ in range(share):
+            self.assertTrue(self.monitor._try_consume_quota(1, c_manual))
+        self.assertFalse(self.monitor._try_consume_quota(1, c_manual))
+        # auto 仍有自己的份额
+        for _ in range(share):
+            self.assertTrue(self.monitor._try_consume_quota(1, c_auto))
+
+
+class HttpErrorReasonTypeSafeTests(unittest.TestCase):
+    """PR #127 第五轮：_http_error_quota_reason 对 error_details 形态健壮。"""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.get_app_subdir_patcher = patch(
+            "modules.youtube_monitor.get_app_subdir",
+            side_effect=lambda sub: (os.makedirs(os.path.join(self.tmpdir, sub), exist_ok=True)
+                                     or os.path.join(self.tmpdir, sub)),
+        )
+        self.init_api_patcher = patch.object(
+            YouTubeMonitor, "_init_youtube_api",
+            return_value=(False, API_INIT_STATUS_MISSING_API_KEY),
+        )
+        self.get_app_subdir_patcher.start()
+        self.init_api_patcher.start()
+        self.monitor = YouTubeMonitor()
+
+    def tearDown(self):
+        try:
+            scheduler = getattr(self.monitor, "scheduler", None)
+            if scheduler and getattr(scheduler, "running", False):
+                scheduler.shutdown(wait=False)
+        finally:
+            self.get_app_subdir_patcher.stop()
+            self.init_api_patcher.stop()
+            shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def test_reason_from_list_of_dicts(self):
+        from googleapiclient.errors import HttpError
+
+        class _Resp:
+            status = 403
+            reason = "Forbidden"
+
+        e = HttpError(_Resp(), b'x', uri="http://x")
+        e.error_details = [{"reason": "quotaExceeded"}]
+        self.assertEqual(self.monitor._http_error_quota_reason(e), "quotaExceeded")
+
+    def test_reason_from_string_error_details_does_not_crash(self):
+        # 仅 error.message 时 googleapiclient 会把 error_details 设为字符串：
+        # 旧实现 `for d in details: (d or {}).get(...)` 会遍历字符并 AttributeError。
+        from googleapiclient.errors import HttpError
+
+        class _Resp:
+            status = 500
+            reason = "Server Error"
+
+        e = HttpError(_Resp(), b'{"error":{"code":500,"message":"backend unavailable"}}', uri="http://x")
+        # error_details 是字符串（仅 message），不应崩溃，且没有 quota reason -> None
+        self.assertIsNone(self.monitor._http_error_quota_reason(e))
+
+    def test_reason_from_string_json_with_reason(self):
+        # error_details 是字符串形式的 JSON，含 errors[] -> 应能取出 reason
+        from googleapiclient.errors import HttpError
+
+        class _Resp:
+            status = 403
+            reason = "Forbidden"
+
+        e = HttpError(_Resp(), b'x', uri="http://x")
+        e.error_details = '{"errors":[{"reason":"dailyLimitExceeded"}]}'
+        self.assertEqual(self.monitor._http_error_quota_reason(e), "dailyLimitExceeded")
+
+    def test_reason_from_dict_error_details(self):
+        from googleapiclient.errors import HttpError
+
+        class _Resp:
+            status = 403
+            reason = "Forbidden"
+
+        e = HttpError(_Resp(), b'x', uri="http://x")
+        e.error_details = {"errors": [{"reason": "rateLimitExceeded"}]}
+        self.assertEqual(self.monitor._http_error_quota_reason(e), "rateLimitExceeded")
+
+
+class CursorShareGateTests(unittest.TestCase):
+    """PR #127 第五轮：本配置份额耗尽时不应空推进游标。"""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.get_app_subdir_patcher = patch(
+            "modules.youtube_monitor.get_app_subdir",
+            side_effect=lambda sub: (os.makedirs(os.path.join(self.tmpdir, sub), exist_ok=True)
+                                     or os.path.join(self.tmpdir, sub)),
+        )
+        self.init_api_patcher = patch.object(
+            YouTubeMonitor, "_init_youtube_api",
+            return_value=(False, API_INIT_STATUS_MISSING_API_KEY),
+        )
+        self.get_app_subdir_patcher.start()
+        self.init_api_patcher.start()
+        self.monitor = YouTubeMonitor()
+
+    def tearDown(self):
+        try:
+            scheduler = getattr(self.monitor, "scheduler", None)
+            if scheduler and getattr(scheduler, "running", False):
+                scheduler.shutdown(wait=False)
+        finally:
+            self.get_app_subdir_patcher.stop()
+            self.init_api_patcher.stop()
+            shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def test_config_share_remaining_false_blocks_cursor_advance(self):
+        # 全局桶仍有余额，但本配置份额已耗尽：不能空推进游标。
+        # 需要 ≥2 个 search 消费者，这样耗尽单个配置份额后全局桶仍有余额（share < budget）。
+        c1 = self.monitor.create_monitor_config(
+            {"name": "kw1", "schedule_type": "auto", "enabled": True, "keywords": "a,b,c,d"})
+        self.monitor.create_monitor_config(
+            {"name": "kw2", "schedule_type": "auto", "enabled": True, "keywords": "x,y"})
+        share = self.monitor._per_config_share()  # budget // 2
+        # 先耗尽 c1 的份额
+        for _ in range(share):
+            self.assertTrue(self.monitor._try_consume_quota(1, c1))
+        self.assertFalse(self.monitor._try_consume_quota(1, c1))
+        # 此时全局仍有余额（2*share <= budget，通常 < budget），但 c1 份额为 0
+        self.assertGreater(self.monitor._quota_budget_remaining(), 0)
+        self.assertFalse(self.monitor._config_share_remaining(c1))
+        # 关键断言：即便高频调度再次进入 _fetch_search_videos，也应在「发起请求前」
+        # 的份额闸门处短路返回，不调用搜索、不推进游标。
+        self.monitor.youtube = object()  # 绕过 init 检查，走到份额闸门
+        result = self.monitor._fetch_search_videos(
+            {"id": c1, "name": "kw1", "enabled": True, "keywords": "a,b,c,d", "max_results": 10,
+             "region_code": "US", "order_by": "viewCount", "time_period": 7, "video_types": "video",
+             "category_id": ""},
+            "2026-08-22T00:00")
+        self.assertEqual(result, [])
+        # 游标未被推进：仍停留在初始 0（未被推进到 2）——证明份额耗尽时不空转游标
+        self.assertEqual(self.monitor._next_keyword_rotation_start(c1, 4, 2), 0)
+        self.assertTrue(self.monitor._last_fetch_quota_skipped)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_youtube_monitor_quota_budget.py
+++ b/tests/test_youtube_monitor_quota_budget.py
@@ -1,5 +1,6 @@
 import datetime
 import os
+import sqlite3
 import shutil
 import sys
 import tempfile
@@ -298,6 +299,7 @@ class ExecuteWithRetryQuotaTests(unittest.TestCase):
             reason = "quotaExceeded"
 
         err = HttpError(_Resp(), b'{"error": {"errors": [{"reason": "quotaExceeded"}]}}', uri="http://x")
+        err.error_details = [{"reason": "quotaExceeded"}]  # 模拟 googleapiclient 从响应解析
         req = self._FakeRequest([err, {"should-not-happen": True}])
         calls = []
 
@@ -308,11 +310,135 @@ class ExecuteWithRetryQuotaTests(unittest.TestCase):
         with self.assertRaises(QuotaBudgetExhausted):
             self.monitor._execute_with_retry(
                 req, "search.list", max_attempts=3, backoff_seconds=0.01,
-                quota_consumer=consumer)
-        # 429 触发集中式当日熔断：只发 1 次请求、不重试；并标记当日耗尽
+                quota_consumer=consumer, operation_type='search')
+        # 429 + 当日配额耗尽 reason + search 操作 → 集中式当日熔断：
+        # 只发 1 次请求、不重试；并标记当日耗尽（全局桶置满）。
         self.assertEqual(len(calls), 1)
         self.assertTrue(self.monitor._last_fetch_quota_skipped)
         self.assertEqual(self.monitor._quota_budget_remaining(), 0)
+
+    def test_rate_limit_reason_retries_without_breaker(self):
+        # 短时速率限制（rateLimitExceeded）仅重试，不触发当日熔断。
+        from googleapiclient.errors import HttpError
+
+        class _Resp:
+            status = 429
+            reason = "rateLimitExceeded"
+
+        err = HttpError(_Resp(), b'{"error": {"errors": [{"reason": "rateLimitExceeded"}]}}', uri="http://x")
+        err.error_details = [{"reason": "rateLimitExceeded"}]
+        req = self._FakeRequest([err, err, {"ok": True}])
+        calls = []
+
+        def consumer():
+            calls.append(1)
+            return True
+
+        # search 操作 + rateLimitExceeded：应重试并最终成功，且不熔断
+        result = self.monitor._execute_with_retry(
+            req, "search.list", max_attempts=3, backoff_seconds=0.001,
+            quota_consumer=consumer, operation_type='search')
+        self.assertEqual(result, {"ok": True})
+        self.assertFalse(self.monitor._last_fetch_quota_skipped)
+        self.assertGreater(self.monitor._quota_budget_remaining(), 0)
+
+    def test_non_search_daily_quota_does_not_trip_breaker(self):
+        # 非 search 操作（videos.list 等）即便触发配额错误，也不熔断 search 预算。
+        from googleapiclient.errors import HttpError
+
+        class _Resp:
+            status = 429
+            reason = "quotaExceeded"
+
+        err = HttpError(_Resp(), b'{"error": {"errors": [{"reason": "quotaExceeded"}]}}', uri="http://x")
+        err.error_details = [{"reason": "quotaExceeded"}]
+        req = self._FakeRequest([err])
+        calls = []
+
+        def consumer():
+            calls.append(1)
+            return True
+
+        with self.assertRaises(HttpError):
+            self.monitor._execute_with_retry(
+                req, "videos.list", max_attempts=1, backoff_seconds=0.001,
+                quota_consumer=consumer, operation_type='other')
+        # 非 search 配额错误不熔断：breaker 标志未置、search 预算未受影响
+        self.assertFalse(self.monitor._last_fetch_quota_skipped)
+        self.assertEqual(self.monitor._quota_budget_remaining(), self.monitor._MONITOR_DAILY_SEARCH_BUDGET)
+
+    def test_http_error_quota_reason_parsing(self):
+        from googleapiclient.errors import HttpError
+
+        # 生产形态：error_details 由 googleapiclient 从响应 JSON 解析而来
+        class _Resp:
+            status = 403
+            reason = "dailyLimitExceeded"
+
+        e1 = HttpError(_Resp(), b'x', uri="http://x")
+        e1.error_details = [{"reason": "dailyLimitExceeded"}]
+        self.assertEqual(self.monitor._http_error_quota_reason(e1), "dailyLimitExceeded")
+
+        e2 = HttpError(_Resp(), b'x', uri="http://x")
+        e2.error_details = [{"reason": "quotaExceeded"}]
+        self.assertEqual(self.monitor._http_error_quota_reason(e2), "quotaExceeded")
+
+        # 退化路径：error_details 为空/缺失，从错误文本抓 reason
+        class _FakeErr(Exception):
+            def __init__(self, error_details, text):
+                self.error_details = error_details
+                self.args = (text,)
+
+            def __str__(self):
+                return self.args[0]
+
+        fe = _FakeErr(None, 'something reason: rateLimitExceeded happened')
+        self.assertEqual(self.monitor._http_error_quota_reason(fe), "rateLimitExceeded")
+
+        # error_details 无 reason 字段时也走文本退化
+        fe2 = _FakeErr([{"message": "quota exceeded"}], 'error reason: quotaExceeded')
+        self.assertEqual(self.monitor._http_error_quota_reason(fe2), "quotaExceeded")
+
+    def test_per_config_fair_share_caps_single_config(self):
+        # 每配置公平份额：N 个搜索配置时每个上限 = budget // N（最少 1）。
+        # 单一高频配置无法吃光全局桶，从而不会饿死其它配置。
+        budget = self.monitor._MONITOR_DAILY_SEARCH_BUDGET
+        c1 = self.monitor.create_monitor_config(
+            {"name": "auto-1", "schedule_type": "auto", "enabled": True, "keywords": "a,b"})
+        c2 = self.monitor.create_monitor_config(
+            {"name": "auto-2", "schedule_type": "auto", "enabled": True, "keywords": "x,y"})
+        # 仅 2 个搜索配置 → 份额 = budget // 2
+        share = budget // 2
+        # c1 可消费到自己的份额
+        for _ in range(share):
+            self.assertTrue(self.monitor._try_consume_quota(1, c1))
+        # 超过 c1 份额后，c1 被拒（但全局桶仍有余量，让给 c2）
+        self.assertFalse(self.monitor._try_consume_quota(1, c1))
+        # c2 仍能消费自己的份额（未被 c1 饿死）
+        for _ in range(share):
+            self.assertTrue(self.monitor._try_consume_quota(1, c2))
+        # 两份份额用尽后，全局桶约剩 budget - 2*share（可能为 0 或少量），任何配置都拒
+        self.assertFalse(self.monitor._try_consume_quota(1, c1))
+        self.assertFalse(self.monitor._try_consume_quota(1, c2))
+        # 总消耗不超过 budget
+        self.assertLessEqual(budget - self.monitor._quota_budget_remaining(), budget)
+
+    def test_circuit_breaker_fail_closed_on_persist_failure(self):
+        # 持久化失败（如磁盘/进程异常）时绝不能静默放过：
+        # 先置内存标志（fail-closed），再对 DB 写入重试；本进程仍停止发请求。
+        self.monitor._quota_tables_ready = True  # 跳过 reset_tables，集中测试 INSERT 失败路径
+        real_connect = sqlite3.connect
+
+        def _boom(*a, **k):
+            raise sqlite3.OperationalError("disk full")
+
+        with patch("sqlite3.connect", side_effect=_boom):
+            self.monitor._mark_quota_depleted_today()
+        # 内存 fail-closed 标志已设置，且当日剩余为 0（不会提前释放额度）
+        self.assertEqual(self.monitor._quota_depleted_day, self.monitor._quota_day_str())
+        self.assertEqual(self.monitor._quota_budget_remaining(), 0)
+        # 退出 patch 后（connect 恢复），本进程基于内存标志仍然拒绝新请求
+        self.assertFalse(self.monitor._try_consume_quota(1, 1))
 
     def test_circuit_breaker_blocks_subsequent_searches(self):
         # 当日熔断后，任何 search 入口的 _try_consume_quota / 前置检查都应短路，


### PR DESCRIPTION
## 关联
Closes #124

## 问题
YouTube Data API 自 2026-06 起为 search.list 使用独立的 Search Queries 配额桶：默认 100 次/天，每次调用计 1 次，并按太平洋时间日重置。监控中的多配置、高频调度、立即检查和重试需要共享并准确记账，否则仍可能在当天耗尽配额。

## 修复
- 保留主分支的原生 OR 查询：多个关键词合并为一次 q=a|b|c 的 search.list，不再逐关键词拆分请求或维护轮转游标。
- 新增 SQLite 持久化的每日 Search Queries 令牌桶：全局安全预算 95 次/天，按 America/Los_Angeles 配额日重置，跨重启、线程和进程共享。
- 每个自动搜索配置获得公平配额；实际运行的手动搜索共享一个配额槽，未运行的手动配置不预占额度。
- 每次真实 API attempt 前原子扣减；quotaExceeded / dailyLimitExceeded 触发 search 当日熔断，rateLimitExceeded 与临时 5xx 仍按退避策略重试。
- 配额跳过或抓取不完整时不推进 last_run_time，避免配额恢复后永久漏掉跳过窗口内的视频。
- 保留用户配置的 1–43200 分钟调度间隔；立即检查只在任务原先不存在时创建，禁用配置会取消立即任务且执行入口再次校验 enabled。
- 已合并最新 main，并与 #132 的单次 OR 搜索、去重后截断及错误游标保护保持一致。

## 验证
- python -m pytest -q：468 passed
- python -m unittest discover -s tests -p "test*.py"：468 passed
- 定向监控配额/OR 查询测试：35 passed
- Python compileall 与 git diff --check 通过

本 PR 不改前端页面或现有监控配置字段。