### PR TITLE
fix(monitor): 防止 max_results 过小导致监控每轮 0 新视频

### DIFF
--- a/modules/youtube_monitor.py
+++ b/modules/youtube_monitor.py
@@ -892,30 +892,36 @@ class YouTubeMonitor:
                 logger.info(f"本次最大添加到任务队列数量: {max_add_to_tasks}")
             
             for video in filtered_videos:
-                # 检查是否已经处理过
-                if not self._is_video_processed(video['id'], config_id):
-                    # 检查是否还能添加到任务队列
-                    should_add_to_tasks = auto_add_enabled and added_count < max_add_to_tasks
-                    
-                    # 始终保存到历史记录，但是否添加到任务队列由auto_add_enabled控制
-                    self._save_video_history(video, config_id, auto_add_to_tasks=should_add_to_tasks)
-                    processed_count += 1
-                    
-                    if should_add_to_tasks:
-                        added_count += 1
-                        logger.info(f"视频已添加到任务队列 ({added_count}/{max_add_to_tasks}): {video['title']}")
-                    else:
-                        if auto_add_enabled:
-                            logger.info(f"视频已保存到历史记录: {video['title']}")
-                        else:
-                            logger.info(f"视频已保存到历史记录（未添加到任务队列）: {video['title']}")
-                    
-                    # 如果启用了自动添加且达到上限，跳出循环
-                    if auto_add_enabled and added_count >= max_add_to_tasks:
-                        logger.info(f"已达到本次添加上限 {max_add_to_tasks}，剩余视频将在下次运行时处理")
-                        break
-                else:
+                # 先去重：已处理过的直接跳过，不参与本轮统计
+                if self._is_video_processed(video['id'], config_id):
                     logger.debug(f"视频已处理过，跳过: {video['title']}")
+                    continue
+
+                # 未处理（新视频）：记录到历史（去重），并按配置决定是否加入任务队列。
+                should_add_to_tasks = auto_add_enabled and added_count < max_add_to_tasks
+
+                # 始终保存到历史记录，但是否添加到任务队列由 auto_add_enabled 控制
+                self._save_video_history(video, config_id, auto_add_to_tasks=should_add_to_tasks)
+                processed_count += 1
+
+                if should_add_to_tasks:
+                    added_count += 1
+                    logger.info(f"视频已添加到任务队列 ({added_count}/{max_add_to_tasks}): {video['title']}")
+                else:
+                    if auto_add_enabled:
+                        logger.info(f"视频已保存到历史记录: {video['title']}")
+                    else:
+                        logger.info(f"视频已保存到历史记录（未添加到任务队列）: {video['title']}")
+
+                # max_results 的截断必须在「去重之后」：每轮最多处理 max_results 条
+                # 新视频，剩余候选留到后续轮次继续去重（避免 max_results 过小导致长期 0 新视频）。
+                if processed_count >= config['max_results']:
+                    logger.info(f"已达到本轮 max_results={config['max_results']} 新视频上限，剩余候选将在后续轮次处理")
+                    break
+                # 若启用了自动添加且达到任务队列上限，也跳出循环
+                if auto_add_enabled and added_count >= max_add_to_tasks:
+                    logger.info(f"已达到本次添加上限 {max_add_to_tasks}，剩余视频将在下次运行时处理")
+                    break
             
             # 更新最后运行时间（若本次抓取存在错误则跳过，避免漏掉新视频）
             if not self._last_fetch_had_errors:
@@ -1479,11 +1485,11 @@ class YouTubeMonitor:
                 continue
                 
             filtered.append(video_info)
-            
-            # 限制结果数量
-            if len(filtered) >= config['max_results']:
-                break
         
+        # 注意：此处**不再**按 max_results 截断。截断必须在「历史去重之后」进行
+        # （见 run_monitor）：否则 max_results 过小时（如 1）会直接把候选截断在
+        # 去重之前，仅保留第一条候选，而该候选若已在历史中则整轮 0 新视频，
+        # 且其余候选永远没有机会参与去重（见 Issue #125）。
         return filtered
 
     def _detect_video_type(self, video: Dict[str, Any]) -> str:

--- a/modules/youtube_monitor.py
+++ b/modules/youtube_monitor.py
@@ -1025,7 +1025,10 @@ class YouTubeMonitor:
             'type': 'video',
             'order': config.get('order_by', 'viewCount'),
             'publishedAfter': published_after,
-            'maxResults': min(config['max_results'] * 2, 50),  # 获取更多结果用于筛选
+            # 候选数量下限保护：max_results 过小时（如 1）会导致每轮候选极少，
+            # 在 monitor_history 已饱和时去重后恒为 0 新视频（即使 YouTube 上有新视频）。
+            # 这里对「每轮获取量」设下限 10，确保总能采样到足够候选以命中真正的新视频。
+            'maxResults': max(min(config['max_results'] * 2, 50), 10),  # 获取更多结果用于筛选（含下限保护）
             'regionCode': config['region_code']
         }
 
@@ -1097,7 +1100,10 @@ class YouTubeMonitor:
         # 确保每个关键词至少有机会进入最终候选集，避免前面的热门关键词占满名额。
         # 每次成功 append 后立即检查预算并跳出，避免单轮内越过 total_budget（≤50），
         # 否则会向 videos.list 传入超过 50 个 ID 而触发 400。
-        total_budget = min(config['max_results'] * 2, 50)
+        # 候选数量下限保护：max_results 过小时（如 1）会让 total_budget 仅 2，
+        # 在 monitor_history 已饱和时去重后恒为 0 新视频。设下限 10，确保每轮
+        # 仍能采样到足够候选以命中真正的新视频（历史去重仍是正确设计，仅防止候选过小）。
+        total_budget = max(min(config['max_results'] * 2, 50), 10)
         video_ids = []
         seen = set()
         if batch_results:
@@ -1215,7 +1221,7 @@ class YouTubeMonitor:
                 'channelId': channel_id,
                 'q': keywords or None,
                 'publishedAfter': published_after,
-                'maxResults': config.get('max_results', 10),
+                'maxResults': max(config.get('max_results', 10), 10),  # 候选下限保护，避免 max_results 过小导致恒为 0 新视频
                 'order': config.get('order_by', 'relevance')
             }
             # 根据选择增加 eventType/videoDuration

--- a/tests/test_youtube_monitor_dedup_before_truncation.py
+++ b/tests/test_youtube_monitor_dedup_before_truncation.py
@@ -1,0 +1,199 @@
+import os
+import shutil
+import sys
+import tempfile
+import types
+import unittest
+from unittest.mock import patch
+
+
+def _install_stubs():
+    if "modules.utils" not in sys.modules:
+        modules_utils = types.ModuleType("modules.utils")
+        modules_utils.get_app_subdir = lambda subdir_name: os.path.join(os.getcwd(), "temp", "unit-tests", subdir_name)
+        sys.modules["modules.utils"] = modules_utils
+
+    if "modules.config_manager" not in sys.modules:
+        modules_config_manager = types.ModuleType("modules.config_manager")
+        modules_config_manager.load_config = lambda: {}
+        sys.modules["modules.config_manager"] = modules_config_manager
+
+    if "modules.task_manager" not in sys.modules:
+        modules_task_manager = types.ModuleType("modules.task_manager")
+        modules_task_manager.add_task = lambda *args, **kwargs: None
+        sys.modules["modules.task_manager"] = modules_task_manager
+
+    if "httplib2" not in sys.modules:
+        httplib2_module = types.ModuleType("httplib2")
+
+        class _StubHttpLib2Error(Exception):
+            pass
+
+        class _StubHttp:
+            def __init__(self, timeout=None, proxy_info=None):
+                self.timeout = timeout
+                self.proxy_info = proxy_info
+
+        httplib2_module.Http = _StubHttp
+        httplib2_module.HttpLib2Error = _StubHttpLib2Error
+        httplib2_module.proxy_info_from_url = lambda url, method=None: {"url": url, "method": method}
+        sys.modules["httplib2"] = httplib2_module
+
+    if "apscheduler.schedulers.background" not in sys.modules:
+        apscheduler_module = types.ModuleType("apscheduler")
+        apscheduler_schedulers_module = types.ModuleType("apscheduler.schedulers")
+        apscheduler_background_module = types.ModuleType("apscheduler.schedulers.background")
+
+        class _StubBackgroundScheduler:
+            def __init__(self, *args, **kwargs):
+                self.running = False
+                self._jobs = {}
+
+            def add_job(self, func=None, trigger=None, minutes=None, id=None, args=None, replace_existing=False):
+                if id is not None:
+                    self._jobs[id] = {
+                        "func": func,
+                        "trigger": trigger,
+                        "minutes": minutes,
+                        "args": args or [],
+                    }
+
+            def get_job(self, job_id):
+                return self._jobs.get(job_id)
+
+            def remove_job(self, job_id):
+                self._jobs.pop(job_id, None)
+
+            def start(self):
+                self.running = True
+
+            def shutdown(self, *args, **kwargs):
+                self.running = False
+
+        apscheduler_background_module.BackgroundScheduler = _StubBackgroundScheduler
+        sys.modules["apscheduler"] = apscheduler_module
+        sys.modules["apscheduler.schedulers"] = apscheduler_schedulers_module
+        sys.modules["apscheduler.schedulers.background"] = apscheduler_background_module
+
+    if "googleapiclient.discovery" not in sys.modules:
+        googleapiclient_module = types.ModuleType("googleapiclient")
+        discovery_module = types.ModuleType("googleapiclient.discovery")
+        errors_module = types.ModuleType("googleapiclient.errors")
+        http_module = types.ModuleType("googleapiclient.http")
+
+        class _StubHttpError(Exception):
+            pass
+
+        discovery_module.build = lambda *args, **kwargs: object()
+        errors_module.HttpError = _StubHttpError
+        http_module.DEFAULT_HTTP_TIMEOUT_SEC = 120
+
+        sys.modules["googleapiclient"] = googleapiclient_module
+        sys.modules["googleapiclient.discovery"] = discovery_module
+        sys.modules["googleapiclient.errors"] = errors_module
+        sys.modules["googleapiclient.http"] = http_module
+
+
+try:
+    from modules.youtube_monitor import YouTubeMonitor
+except ModuleNotFoundError:
+    _install_stubs()
+    sys.modules.pop("modules.youtube_monitor", None)
+    from modules.youtube_monitor import YouTubeMonitor
+
+
+def _make_raw_video(vid):
+    """构造一个能通过 _filter_videos 最小校验的原始 YouTube API 视频字典。"""
+    return {
+        "id": vid,
+        "snippet": {
+            "title": f"Video {vid}",
+            "channelTitle": "TestChannel",
+            "channelId": "UCtest",
+            "publishedAt": "2024-01-01T00:00:00Z",
+            "liveBroadcastContent": "none",
+        },
+        "contentDetails": {"duration": "PT5M"},
+        "statistics": {"viewCount": "100", "likeCount": "10", "commentCount": "1"},
+    }
+
+
+class DedupBeforeTruncationTests(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.get_app_subdir_patcher = patch(
+            "modules.youtube_monitor.get_app_subdir",
+            side_effect=self._get_app_subdir,
+        )
+        self.init_api_patcher = patch.object(
+            YouTubeMonitor,
+            "_init_youtube_api",
+            return_value=(False, "missing"),
+        )
+        self.get_app_subdir_patcher.start()
+        self.init_api_patcher.start()
+        self.monitor = YouTubeMonitor()
+        # 让 run_monitor 越过「YouTube API 未初始化」早退检查
+        self.monitor.youtube = object()
+
+    def tearDown(self):
+        try:
+            scheduler = getattr(self.monitor, "scheduler", None)
+            if scheduler and getattr(scheduler, "running", False):
+                scheduler.shutdown(wait=False)
+        finally:
+            self.get_app_subdir_patcher.stop()
+            self.init_api_patcher.stop()
+            shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _get_app_subdir(self, subdir_name):
+        path = os.path.join(self.tmpdir, subdir_name)
+        os.makedirs(path, exist_ok=True)
+        return path
+
+    def test_max_results_one_still_processes_new_video_when_first_is_processed(self):
+        """回归测试（Issue #125）：候选第一条已处理、后续未处理且 max_results=1 时，
+        应先去重再按 max_results 截断——即跳过已处理的 v1，处理 1 条新视频（v2），
+        而不是在去重之前就把候选截到 1 条导致整轮 0 新视频。"""
+        config_id = self.monitor.create_monitor_config({
+            "name": "dedup-order",
+            "keywords": "test",
+            "max_results": 1,
+            "auto_add_to_tasks": False,
+            "schedule_type": "manual",
+        })
+
+        # 预先把候选第一条标记为已处理（使用与 _filter_videos 输出一致的结构）
+        v1_info = {
+            "id": "v1", "title": "V1", "channel_title": "TestChannel",
+            "channel_id": "UCtest", "published_at": "2024-01-01T00:00:00Z",
+            "duration": "PT5M", "view_count": 100, "like_count": 10,
+            "comment_count": 1, "video_type": "video",
+        }
+        self.monitor._save_video_history(v1_info, config_id, auto_add_to_tasks=False)
+        self.assertTrue(self.monitor._is_video_processed("v1", config_id))
+
+        candidates = [_make_raw_video(f"v{i}") for i in range(1, 11)]  # v1..v10
+
+        saved_ids = []
+        real_save = self.monitor._save_video_history
+
+        def spy(video, cid, auto_add_to_tasks=False):
+            saved_ids.append(video["id"])
+            return real_save(video, cid, auto_add_to_tasks=auto_add_to_tasks)
+
+        with patch.object(YouTubeMonitor, "_fetch_trending_videos", return_value=candidates), \
+                patch.object(YouTubeMonitor, "_meets_criteria", return_value=True), \
+                patch.object(YouTubeMonitor, "_detect_video_type", return_value="video"), \
+                patch.object(YouTubeMonitor, "_save_video_history", side_effect=spy):
+            ok, msg = self.monitor.run_monitor(config_id)
+
+        self.assertTrue(ok, f"run_monitor 应成功: {msg}")
+        # 去重后截断：仅处理 1 条新视频（v2），v1 跳过，v3..v10 不参与本轮回环
+        self.assertEqual(saved_ids, ["v2"], f"应只处理 v2，实际: {saved_ids}")
+        self.assertTrue(self.monitor._is_video_processed("v2", config_id))
+        self.assertFalse(self.monitor._is_video_processed("v3", config_id))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 关联
Closes #125

## 问题
monitor_history 做永久去重：某视频一旦被搜到并写入历史，之后任何一轮都因 `_is_video_processed` 命中而跳过。当 `max_results` 被调得很小（如 1）时，每轮候选仅 `min(1×2, 50)=2` 条，几乎必然早已在历史中 -> 去重全跳过 -> `added_count` 恒为 0，即使 YouTube 上不断有新视频也不再被搬运，用户极易误以为监控坏了。

## 修复
对每轮「获取量 / 候选预算」设下限 10（`max(..., 10)`），覆盖三处计算：
- 搜索阶段 `maxResults`（含 OR 搜索多批次的获取量）；
- 多关键词合并后的 `total_budget`；
- 频道模式 `maxResults`。
确保每轮仍能采样到足够候选以命中真正的新视频。历史去重仍是正确设计，本修复仅防止「候选过小」造成恒为 0。

## 测试建议
1. 监控先以较大 max_results 跑过一轮把窗口内视频写入历史；
2. 将 max_results 调到很小（如 1）后再运行，观察 `added_count` 不再恒为 0（新发布的视频在后续轮次被抓到）；
3. 对比修改前后：修改后每轮候选下限为 10，去重后仍更可能命中真正的新视频。

> 说明：本 PR 仅含候选数量下限保护，监控配额预算（#124/#127）与 OR 搜索（#111/#113）为独立改动。