### PR TITLE
feat: add OrcaRouter as a named OpenAI-compatible gateway provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,8 +227,11 @@ python app.py
 
 - `OPENAI_API_KEY` / `OPENAI_BASE_URL` / `OPENAI_MODEL_NAME`：全局 AI 配置
 - `OPENAI_THINKING_ENABLED`：全局思考模式开关
+- `ORCAROUTER_API_KEY` / `ORCAROUTER_BASE_URL` / `ORCAROUTER_MODEL`：OrcaRouter 网关接入（OpenAI 兼容多模型网关，默认 `https://api.orcarouter.ai/v1`、模型 `orcarouter/auto`）。配置了 `ORCAROUTER_API_KEY` 时，元数据翻译、标签生成、分区推荐与智能分段会自动路由到 [OrcaRouter](https://www.orcarouter.ai)
 - `SUBTITLE_OPENAI_*`：字幕翻译专用覆盖配置，留空则回退全局
 - `SUBTITLE_QC_*`：字幕质检专用覆盖配置，留空则回退字幕翻译 / 全局配置
+- `SUBTITLE_API_PROVIDER`：字幕翻译提供商，支持 `openai` / `orcarouter`（orcarouter 时使用上方 OrcaRouter 网关配置）
+- `SUBTITLE_QC_PROVIDER`：字幕质检提供商，支持 `openai` / `orcarouter` / `none`
 - `TRANSLATE_TITLE` / `TRANSLATE_DESCRIPTION` / `GENERATE_TAGS`：自动生成标题、简介、标签
 - `RECOMMEND_PARTITION`：自动推荐分区
 - `FIXED_PARTITION_ID` / `FIXED_PARTITION_ID_BILIBILI`：固定分区
@@ -321,6 +324,9 @@ python app.py
   "OPENAI_BASE_URL": "https://api.openai.com/v1",
   "OPENAI_MODEL_NAME": "gpt-3.5-turbo",
   "OPENAI_THINKING_ENABLED": false,
+  "ORCAROUTER_API_KEY": "",
+  "ORCAROUTER_BASE_URL": "https://api.orcarouter.ai/v1",
+  "ORCAROUTER_MODEL": "orcarouter/auto",
   "SUBTITLE_TRANSLATION_ENABLED": false,
   "SUBTITLE_QC_ENABLED": false,
   "SPEECH_RECOGNITION_ENABLED": false,

--- a/modules/ai_segmentation.py
+++ b/modules/ai_segmentation.py
@@ -159,10 +159,12 @@ class AISegmentationConfig:
             boundary_window=int(app_config.get('AI_SEGMENTATION_BOUNDARY_WINDOW', 3) or 3),
             rhythm_enabled=coerce_bool(app_config.get('AI_SEGMENTATION_RHYTHM_ENABLED', False)),
         )
-        # 留空继承全局 OPENAI_*
-        cfg.resolved_base_url = cfg.base_url or str(app_config.get('OPENAI_BASE_URL', '') or '').strip()
-        cfg.resolved_api_key = cfg.api_key or str(app_config.get('OPENAI_API_KEY', '') or '').strip()
-        cfg.resolved_model_name = cfg.model_name or str(app_config.get('OPENAI_MODEL_NAME', '') or '').strip()
+        # 留空继承全局 OPENAI_*；配置了 ORCAROUTER_API_KEY 时全局自动路由到 OrcaRouter
+        from .utils import build_ai_openai_config
+        _resolved = build_ai_openai_config(app_config)
+        cfg.resolved_base_url = cfg.base_url or _resolved.get('OPENAI_BASE_URL', '') or ''
+        cfg.resolved_api_key = cfg.api_key or _resolved.get('OPENAI_API_KEY', '') or ''
+        cfg.resolved_model_name = cfg.model_name or _resolved.get('OPENAI_MODEL_NAME', '') or ''
         return cfg
 
     @property

--- a/modules/config_manager.py
+++ b/modules/config_manager.py
@@ -91,6 +91,11 @@ DEFAULT_CONFIG = {
     "OPENAI_MODEL_NAME": "gpt-3.5-turbo",
     "OPENAI_THINKING_ENABLED": False,
     "OPENAI_TIMEOUT_SECONDS": 600,  # OpenAI API 请求超时秒数；思考模型输出可达64k token，建议不低于300
+    # OrcaRouter 命名接入（OpenAI 兼容网关，https://www.orcarouter.ai）
+    # 配置了 ORCAROUTER_API_KEY 时，全局 AI（元数据翻译/标签/分区推荐/智能分段）自动路由到 OrcaRouter
+    "ORCAROUTER_API_KEY": "",
+    "ORCAROUTER_BASE_URL": "https://api.orcarouter.ai/v1",
+    "ORCAROUTER_MODEL": "orcarouter/auto",  # orcarouter/auto 自适应路由，也可指定 orcarouter/<模型名>
     # 固定分区ID（可选）：如设置则推荐分区将直接使用该ID
     "FIXED_PARTITION_ID": "",
     # bilibili固定分区ID（可选）：如设置则bilibili推荐分区将直接使用该ID
@@ -129,7 +134,7 @@ DEFAULT_CONFIG = {
     "SUBTITLE_SOURCE_LANGUAGE": "auto",  # 源语言 (auto, en, ja, ko等)
     "SUBTITLE_TARGET_LANGUAGE": "zh",  # 目标语言 (zh, en, ja, ko等)
     "SUBTITLE_FONT_NAME": "NotoSansCJKsc-Regular.otf",  # 烧录字幕使用的内置字体文件名
-    "SUBTITLE_API_PROVIDER": "openai",  # API提供商 (仅支持openai)
+    "SUBTITLE_API_PROVIDER": "openai",  # API提供商 (openai / orcarouter)
     "SUBTITLE_BATCH_SIZE": 3,  # 批次大小
     "SUBTITLE_MAX_RETRIES": 3,  # 最大重试次数
     "SUBTITLE_RETRY_DELAY": 2,  # 重试延迟(秒)
@@ -139,7 +144,7 @@ DEFAULT_CONFIG = {
 
     # ASR 源字幕预检（可选）
     "SUBTITLE_QC_ENABLED": True,  # 质量优先：失败则不烧录字幕，但保留字幕文件并继续上传原视频（任务最终仍为 completed）
-    "SUBTITLE_QC_PROVIDER": "openai",  # openai / none
+    "SUBTITLE_QC_PROVIDER": "openai",  # openai / orcarouter / none
     "SUBTITLE_QC_BASE_URL": "",  # 留空则回退到 SUBTITLE_OPENAI_BASE_URL / OPENAI_BASE_URL
     "SUBTITLE_QC_API_KEY": "",  # 留空则回退到 SUBTITLE_OPENAI_API_KEY / OPENAI_API_KEY
     "SUBTITLE_QC_MODEL_NAME": "",  # 留空则回退到 SUBTITLE_OPENAI_MODEL_NAME / OPENAI_MODEL_NAME

--- a/modules/subtitle_qc.py
+++ b/modules/subtitle_qc.py
@@ -693,22 +693,34 @@ def _call_ai_judge(
     metrics: Dict[str, Any],
     config: Dict[str, Any],
 ) -> Tuple[Optional[bool], Optional[float], Optional[Dict[str, Any]], str]:
-    api_key = (
-        (config.get('SUBTITLE_QC_API_KEY') or '').strip()
-        or (config.get('SUBTITLE_OPENAI_API_KEY') or '').strip()
-        or (config.get('OPENAI_API_KEY') or '').strip()
-    )
-    base_url = (
-        (config.get('SUBTITLE_QC_BASE_URL') or '').strip()
-        or (config.get('SUBTITLE_OPENAI_BASE_URL') or '').strip()
-        or (config.get('OPENAI_BASE_URL') or '').strip()
-    )
+    provider = str(config.get('SUBTITLE_QC_PROVIDER', 'openai')).lower().strip()
+    if provider == 'orcarouter':
+        from .utils import resolve_orca_llm_settings
+        base_url, api_key, model_name = resolve_orca_llm_settings(config)
+        # QC 专用覆盖优先于全局（保持与 openai 分支一致的回退顺序）
+        if (config.get('SUBTITLE_QC_BASE_URL') or '').strip():
+            base_url = str(config['SUBTITLE_QC_BASE_URL']).strip()
+        if (config.get('SUBTITLE_QC_API_KEY') or '').strip():
+            api_key = str(config['SUBTITLE_QC_API_KEY']).strip()
+        if (config.get('SUBTITLE_QC_MODEL_NAME') or '').strip():
+            model_name = str(config['SUBTITLE_QC_MODEL_NAME']).strip()
+    else:
+        api_key = (
+            (config.get('SUBTITLE_QC_API_KEY') or '').strip()
+            or (config.get('SUBTITLE_OPENAI_API_KEY') or '').strip()
+            or (config.get('OPENAI_API_KEY') or '').strip()
+        )
+        base_url = (
+            (config.get('SUBTITLE_QC_BASE_URL') or '').strip()
+            or (config.get('SUBTITLE_OPENAI_BASE_URL') or '').strip()
+            or (config.get('OPENAI_BASE_URL') or '').strip()
+        )
 
-    model_name = (
-        (config.get('SUBTITLE_QC_MODEL_NAME') or '').strip()
-        or (config.get('SUBTITLE_OPENAI_MODEL_NAME') or '').strip()
-        or (config.get('OPENAI_MODEL_NAME') or 'gpt-3.5-turbo')
-    )
+        model_name = (
+            (config.get('SUBTITLE_QC_MODEL_NAME') or '').strip()
+            or (config.get('SUBTITLE_OPENAI_MODEL_NAME') or '').strip()
+            or (config.get('OPENAI_MODEL_NAME') or 'gpt-3.5-turbo')
+        )
 
     if not api_key:
         return None, None, None, 'missing_openai_api_key'
@@ -863,7 +875,7 @@ def run_subtitle_qc(
         )
 
     provider = str(config.get('SUBTITLE_QC_PROVIDER', 'openai')).lower().strip()
-    if provider != 'openai':
+    if provider not in ('openai', 'orcarouter'):
         return _resolve_ai_unavailable_result(
             rule_result=rule_result,
             metrics=metrics,

--- a/modules/subtitle_translator.py
+++ b/modules/subtitle_translator.py
@@ -117,7 +117,7 @@ class TranslationConfig:
     """翻译配置"""
     source_language: str = "auto"
     target_language: str = "zh"
-    api_provider: str = "openai"  # 仅支持openai
+    api_provider: str = "openai"  # openai / orcarouter
     api_key: str = ""
     base_url: str = "https://api.openai.com/v1"
     model_name: str = "gpt-3.5-turbo"
@@ -608,6 +608,7 @@ class SubtitleTranslator:
             'OPENAI_MODEL_NAME': config.model_name or 'gpt-3.5-turbo',
             'OPENAI_THINKING_ENABLED': str(config.thinking_enabled).strip().lower() in ('true', '1', 'on', 'yes'),
             'OPENAI_TIMEOUT_SECONDS': config.timeout_seconds,
+            'API_PROVIDER': getattr(config, 'api_provider', 'openai'),
             # Prompt 中心配置（快照，避免热修改影响进行中的翻译）
             'PROMPT_MODE': getattr(config, 'prompt_mode', 'builtin'),
             'PROMPT_TEXT': getattr(config, 'prompt_text', ''),
@@ -1130,15 +1131,21 @@ def create_translator_from_config(app_config: Dict, task_id: Optional[str] = Non
         if isinstance(max_workers, str):
             max_workers = int(max_workers)
         
-        # 计算字幕翻译专用Base URL（优先使用SUBTITLE_OPENAI_BASE_URL，否则回退到OPENAI_BASE_URL）
-        subtitle_base_url = app_config.get('SUBTITLE_OPENAI_BASE_URL') or app_config.get('OPENAI_BASE_URL', 'https://api.openai.com/v1')
+        # 解析 API 提供商：字幕翻译专用覆盖（SUBTITLE_API_PROVIDER）
+        subtitle_provider = str(app_config.get('SUBTITLE_API_PROVIDER', 'openai')).strip().lower()
+        if subtitle_provider == 'orcarouter':
+            from .utils import resolve_orca_llm_settings
+            subtitle_base_url, subtitle_api_key, subtitle_model = resolve_orca_llm_settings(app_config)
+        else:
+            # 计算字幕翻译专用Base URL（优先使用SUBTITLE_OPENAI_BASE_URL，否则回退到OPENAI_BASE_URL）
+            subtitle_base_url = app_config.get('SUBTITLE_OPENAI_BASE_URL') or app_config.get('OPENAI_BASE_URL', 'https://api.openai.com/v1')
 
-        # 计算字幕翻译专用Key/模型，未配置则回退通用值
-        subtitle_api_key = app_config.get('SUBTITLE_OPENAI_API_KEY') or app_config.get('OPENAI_API_KEY', '')
-        subtitle_model = app_config.get('SUBTITLE_OPENAI_MODEL_NAME') or app_config.get('OPENAI_MODEL_NAME', 'gpt-3.5-turbo')
-        
+            # 计算字幕翻译专用Key/模型，未配置则回退通用值
+            subtitle_api_key = app_config.get('SUBTITLE_OPENAI_API_KEY') or app_config.get('OPENAI_API_KEY', '')
+            subtitle_model = app_config.get('SUBTITLE_OPENAI_MODEL_NAME') or app_config.get('OPENAI_MODEL_NAME', 'gpt-3.5-turbo')
+
         # 添加调试日志：检查配置值
-        logger.debug(f"配置值检查 - subtitle_base_url: {subtitle_base_url is None}, subtitle_api_key: {subtitle_api_key is None}, subtitle_model: {subtitle_model is None}")
+        logger.debug(f"配置值检查 - provider: {subtitle_provider}, subtitle_base_url: {subtitle_base_url is None}, subtitle_api_key: {subtitle_api_key is None}, subtitle_model: {subtitle_model is None}")
 
         # 读取 Prompt 中心配置
         prompt_mode = 'builtin'
@@ -1155,7 +1162,7 @@ def create_translator_from_config(app_config: Dict, task_id: Optional[str] = Non
         translation_config = TranslationConfig(
             source_language=app_config.get('SUBTITLE_SOURCE_LANGUAGE', 'auto'),
             target_language=app_config.get('SUBTITLE_TARGET_LANGUAGE', 'zh'),
-            api_provider=app_config.get('SUBTITLE_API_PROVIDER', 'openai'),
+            api_provider=subtitle_provider,
             api_key=subtitle_api_key,
             base_url=subtitle_base_url,
             model_name=subtitle_model,

--- a/modules/task_manager.py
+++ b/modules/task_manager.py
@@ -3051,15 +3051,9 @@ class TaskProcessor:
         upload_target = _get_task_upload_target(task)
         effective_limits = _get_effective_metadata_limits(upload_target)
         
-        # 构建OpenAI配置
-        openai_config = {
-            'OPENAI_API_KEY': self.config.get('OPENAI_API_KEY', ''),
-            'OPENAI_BASE_URL': self.config.get('OPENAI_BASE_URL', ''),
-            'OPENAI_MODEL_NAME': self.config.get('OPENAI_MODEL_NAME', 'gpt-3.5-turbo'),
-            'OPENAI_THINKING_ENABLED': self.config.get('OPENAI_THINKING_ENABLED', False),
-            # 可选：允许用户配置固定分区ID，确保一次命中
-            'FIXED_PARTITION_ID': self.config.get('FIXED_PARTITION_ID', ''),
-        }
+        # 构建OpenAI配置（配置了 ORCAROUTER_API_KEY 时自动路由到 OrcaRouter）
+        from modules.utils import build_ai_openai_config
+        openai_config = build_ai_openai_config(self.config)
         # 传递 Prompt 中心配置（元数据翻译）
         for prompt_key in (
             'METADATA_TRANSLATE_MODE', 'METADATA_TRANSLATE_TEXT',
@@ -7067,15 +7061,10 @@ class TaskProcessor:
         title = safe_str(task.get('video_title_translated') or task.get('video_title_original'))
         description = safe_str(task.get('description_translated') or task.get('description_original'))
         
-        # 构建OpenAI配置
-        openai_config = {
-            'OPENAI_API_KEY': self.config.get('OPENAI_API_KEY', ''),
-            'OPENAI_BASE_URL': self.config.get('OPENAI_BASE_URL', ''),
-            'OPENAI_MODEL_NAME': self.config.get('OPENAI_MODEL_NAME', 'gpt-3.5-turbo'),
-            'OPENAI_THINKING_ENABLED': self.config.get('OPENAI_THINKING_ENABLED', False),
-            'FIXED_PARTITION_ID': self.config.get('FIXED_PARTITION_ID', ''),
-        }
-        
+        # 构建OpenAI配置（配置了 ORCAROUTER_API_KEY 时自动路由到 OrcaRouter）
+        from modules.utils import build_ai_openai_config
+        openai_config = build_ai_openai_config(self.config)
+
         if self.config.get('GENERATE_TAGS', True) and (title or description):
             tags = generate_acfun_tags(
                 title, 
@@ -7124,16 +7113,13 @@ class TaskProcessor:
             task_logger.warning("解析 AI 标签失败或标签为空，分区推荐将忽略标签上下文")
         upload_target = _get_task_upload_target(task)
 
-        openai_config = {
-            'OPENAI_API_KEY': self.config.get('OPENAI_API_KEY', ''),
-            'OPENAI_BASE_URL': self.config.get('OPENAI_BASE_URL', ''),
-            'OPENAI_MODEL_NAME': self.config.get('OPENAI_MODEL_NAME', 'gpt-3.5-turbo'),
-            'OPENAI_THINKING_ENABLED': self.config.get('OPENAI_THINKING_ENABLED', False),
-            'OPENAI_TIMEOUT_SECONDS': self.config.get('OPENAI_TIMEOUT_SECONDS', 600),
+        from modules.utils import build_ai_openai_config
+        openai_config = build_ai_openai_config(self.config)
+        openai_config.update({
             'FIXED_PARTITION_ID': self.config.get('FIXED_PARTITION_ID', ''),
             'FIXED_PARTITION_ID_BILIBILI': self.config.get('FIXED_PARTITION_ID_BILIBILI', ''),
             'RECOMMEND_PARTITION_WITH_COVER': self.config.get('RECOMMEND_PARTITION_WITH_COVER', False),
-        }
+        })
         cover_path = task.get('cover_path_local', '')
 
         task_logger.info(f"RECOMMEND_PARTITION设置: {self.config.get('RECOMMEND_PARTITION', False)}")

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -353,3 +353,63 @@ def openai_chat_create_with_thinking_control(
                     "thinking 控制参数不受支持，继续普通请求"
                 )
         return client.chat.completions.create(**create_kwargs)
+
+
+# ---------------------------------------------------------------------------
+# OrcaRouter 命名接入（OpenAI 兼容网关）
+# 提供统一的 OrcaRouter 参数解析，供字幕翻译/字幕质检/全局 AI 消费复用。
+# ---------------------------------------------------------------------------
+
+ORCAROUTER_DEFAULT_BASE_URL = 'https://api.orcarouter.ai/v1'
+ORCAROUTER_DEFAULT_MODEL = 'orcarouter/auto'
+
+
+def resolve_orca_llm_settings(config):
+    """
+    解析 OrcaRouter 接入参数。
+
+    优先级：ORCAROUTER_* 显式配置 > 字幕专用覆盖（SUBTITLE_OPENAI_*）> OrcaRouter 默认值。
+    注意：不继承全局 OPENAI_BASE_URL / OPENAI_MODEL_NAME（它们总是存在且有默认值，
+    继承会让命名 OrcaRouter 接入错误地指向 OpenAI 端点/模型）。
+
+    Returns:
+        tuple[str, str, str]: (base_url, api_key, model)
+    """
+    base_url = (
+        str(config.get('ORCAROUTER_BASE_URL') or '').strip()
+        or str(config.get('SUBTITLE_OPENAI_BASE_URL') or '').strip()
+        or ORCAROUTER_DEFAULT_BASE_URL
+    )
+    api_key = (
+        str(config.get('ORCAROUTER_API_KEY') or '').strip()
+        or str(config.get('SUBTITLE_OPENAI_API_KEY') or '').strip()
+        or str(config.get('OPENAI_API_KEY') or '').strip()
+    )
+    model = (
+        str(config.get('ORCAROUTER_MODEL') or '').strip()
+        or str(config.get('SUBTITLE_OPENAI_MODEL_NAME') or '').strip()
+        or ORCAROUTER_DEFAULT_MODEL
+    )
+    return base_url, api_key, model
+
+
+def build_ai_openai_config(config):
+    """
+    构建全局 AI 消费（元数据翻译/标签/分区推荐/智能分段等）的 openai_config。
+
+    配置了 ORCAROUTER_API_KEY 时自动路由到 OrcaRouter 网关（命名接入）；
+    否则退回 OPENAI_* 通用配置，行为与原来完全一致。
+    """
+    openai_config = {
+        'OPENAI_API_KEY': config.get('OPENAI_API_KEY', ''),
+        'OPENAI_BASE_URL': config.get('OPENAI_BASE_URL', ''),
+        'OPENAI_MODEL_NAME': config.get('OPENAI_MODEL_NAME', 'gpt-3.5-turbo'),
+        'OPENAI_THINKING_ENABLED': config.get('OPENAI_THINKING_ENABLED', False),
+        'OPENAI_TIMEOUT_SECONDS': config.get('OPENAI_TIMEOUT_SECONDS', 600),
+    }
+    if str(config.get('ORCAROUTER_API_KEY') or '').strip():
+        base_url, api_key, model = resolve_orca_llm_settings(config)
+        openai_config['OPENAI_API_KEY'] = api_key
+        openai_config['OPENAI_BASE_URL'] = base_url
+        openai_config['OPENAI_MODEL_NAME'] = model
+    return openai_config

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -12,7 +12,7 @@
     {% set default_target_label = 'AcFun' %}
 {% endif %}
 {% set account_ready_count = (1 if config.get('ACFUN_COOKIES_PATH') else 0) + (1 if config.get('BILIBILI_COOKIES_PATH') else 0) + (1 if config.get('YOUTUBE_COOKIES_PATH') else 0) %}
-{% set ai_ready = config.get('OPENAI_API_KEY') or config.get('SUBTITLE_OPENAI_API_KEY') or config.get('WHISPER_API_KEY') or config.get('VOXTRAL_API_KEY') %}
+{% set ai_ready = config.get('OPENAI_API_KEY') or config.get('ORCAROUTER_API_KEY') or config.get('SUBTITLE_OPENAI_API_KEY') or config.get('WHISPER_API_KEY') or config.get('VOXTRAL_API_KEY') %}
 {% set moderation_ready = config.get('ALIYUN_ACCESS_KEY_ID') and config.get('ALIYUN_ACCESS_KEY_SECRET') %}
 
 <div class="settings-container">
@@ -713,6 +713,41 @@
 
                                                 <div class="settings-subcard">
                                                     <div class="settings-subcard-header">
+                                                        <h5>OrcaRouter 网关</h5>
+                                                        <span class="settings-status-badge {{ 'is-success' if config.get('ORCAROUTER_API_KEY') else 'is-warning' }}">
+                                                            {{ '已配置' if config.get('ORCAROUTER_API_KEY') else '未配置' }}
+                                                        </span>
+                                                    </div>
+                                                    <div class="row g-3">
+                                                        <div class="col-12">
+                                                            <div class="form-group">
+                                                                <label for="orcarouter-url" class="form-label">OrcaRouter 接口地址</label>
+                                                                <input type="text" id="orcarouter-url" name="ORCAROUTER_BASE_URL" value="{{ config.get('ORCAROUTER_BASE_URL', 'https://api.orcarouter.ai/v1') }}" class="form-control" placeholder="https://api.orcarouter.ai/v1">
+                                                            </div>
+                                                        </div>
+                                                        <div class="col-md-6">
+                                                            <div class="form-group">
+                                                                <label for="orcarouter-key" class="form-label">OrcaRouter API 密钥</label>
+                                                                <input type="password" id="orcarouter-key" name="ORCAROUTER_API_KEY" value="{{ config.get('ORCAROUTER_API_KEY', '') }}" class="form-control" placeholder="sk-orca-...">
+                                                            </div>
+                                                        </div>
+                                                        <div class="col-md-6">
+                                                            <div class="form-group">
+                                                                <label for="orcarouter-model" class="form-label">OrcaRouter 模型</label>
+                                                                <input type="text" id="orcarouter-model" name="ORCAROUTER_MODEL" value="{{ config.get('ORCAROUTER_MODEL', 'orcarouter/auto') }}" class="form-control" placeholder="orcarouter/auto">
+                                                            </div>
+                                                        </div>
+                                                        <div class="col-12">
+                                                            <p class="help-text mb-0">
+                                                                <a href="https://www.orcarouter.ai" target="_blank" rel="noopener">OrcaRouter</a> 是一个 OpenAI 兼容的多模型网关（https://api.orcarouter.ai/v1）。
+                                                                配置了 OrcaRouter API 密钥后，元数据翻译、标签生成、分区推荐与智能分段将自动路由到 OrcaRouter；字幕翻译/质检可在下方选择 orcarouter 提供商。
+                                                            </p>
+                                                        </div>
+                                                    </div>
+                                                </div>
+
+                                                <div class="settings-subcard">
+                                                    <div class="settings-subcard-header">
                                                         <h5>字幕翻译专用覆盖</h5>
                                                         <span class="settings-status-badge {{ 'is-info' if config.get('SUBTITLE_OPENAI_API_KEY') or config.get('SUBTITLE_OPENAI_MODEL_NAME') or config.get('SUBTITLE_OPENAI_BASE_URL') else 'is-neutral' }}">
                                                             {{ '已覆盖全局配置' if config.get('SUBTITLE_OPENAI_API_KEY') or config.get('SUBTITLE_OPENAI_MODEL_NAME') or config.get('SUBTITLE_OPENAI_BASE_URL') else '留空即继承全局' }}
@@ -1305,6 +1340,28 @@
                                                             <input type="checkbox" name="SUBTITLE_QC_ENABLED" {% if config.get('SUBTITLE_QC_ENABLED', False) %}checked{% endif %}>
                                                             启用 ASR 源字幕质检
                                                         </label>
+                                                    </div>
+                                                    <div class="col-md-6">
+                                                        <div class="form-group">
+                                                            <label for="subtitle-api-provider" class="form-label">字幕翻译提供商</label>
+                                                            <select id="subtitle-api-provider" name="SUBTITLE_API_PROVIDER" class="form-select">
+                                                                <option value="openai" {% if config.get('SUBTITLE_API_PROVIDER', 'openai') == 'openai' %}selected{% endif %}>OpenAI 兼容</option>
+                                                                <option value="orcarouter" {% if config.get('SUBTITLE_API_PROVIDER', 'openai') == 'orcarouter' %}selected{% endif %}>OrcaRouter</option>
+                                                            </select>
+                                                        </div>
+                                                    </div>
+                                                    <div class="col-md-6">
+                                                        <div class="form-group">
+                                                            <label for="subtitle-qc-provider" class="form-label">字幕质检提供商</label>
+                                                            <select id="subtitle-qc-provider" name="SUBTITLE_QC_PROVIDER" class="form-select">
+                                                                <option value="openai" {% if config.get('SUBTITLE_QC_PROVIDER', 'openai') == 'openai' %}selected{% endif %}>OpenAI 兼容</option>
+                                                                <option value="orcarouter" {% if config.get('SUBTITLE_QC_PROVIDER', 'openai') == 'orcarouter' %}selected{% endif %}>OrcaRouter</option>
+                                                                <option value="none" {% if config.get('SUBTITLE_QC_PROVIDER', 'openai') == 'none' %}selected{% endif %}>关闭（仅规则判定）</option>
+                                                            </select>
+                                                        </div>
+                                                    </div>
+                                                    <div class="col-12">
+                                                        <p class="help-text mb-0">选择 OrcaRouter 时使用上方「OrcaRouter 网关」配置的接口地址 / 密钥 / 模型（orcarouter/auto 自适应路由）。</p>
                                                     </div>
                                                     <div class="col-md-6">
                                                         <label class="checkbox-label">

--- a/tests/test_orcarouter_provider.py
+++ b/tests/test_orcarouter_provider.py
@@ -1,0 +1,209 @@
+"""Tests for the named OrcaRouter provider wiring.
+
+Covers:
+- resolve_orca_llm_settings priority / defaults
+- build_ai_openai_config auto-routing when ORCAROUTER_API_KEY is present
+- create_translator_from_config with SUBTITLE_API_PROVIDER=orcarouter
+- run_subtitle_qc / _call_ai_judge with SUBTITLE_QC_PROVIDER=orcarouter
+"""
+import unittest
+from unittest.mock import patch
+
+from modules.utils import (
+    ORCAROUTER_DEFAULT_BASE_URL,
+    ORCAROUTER_DEFAULT_MODEL,
+    build_ai_openai_config,
+    resolve_orca_llm_settings,
+)
+
+
+class ResolveOrcaLlmSettingsTests(unittest.TestCase):
+    """Tests for resolve_orca_llm_settings."""
+
+    def test_defaults(self):
+        base_url, api_key, model = resolve_orca_llm_settings({})
+        self.assertEqual(base_url, ORCAROUTER_DEFAULT_BASE_URL)
+        self.assertEqual(api_key, '')
+        self.assertEqual(model, ORCAROUTER_DEFAULT_MODEL)
+
+    def test_orca_explicit_overrides(self):
+        cfg = {
+            'ORCAROUTER_API_KEY': 'sk-orca-test',
+            'ORCAROUTER_BASE_URL': 'https://api.orcarouter.ai/v1',
+            'ORCAROUTER_MODEL': 'orcarouter/deepseek-v4-pro',
+            'OPENAI_API_KEY': 'sk-openai',
+            'OPENAI_BASE_URL': 'https://api.openai.com/v1',
+        }
+        base_url, api_key, model = resolve_orca_llm_settings(cfg)
+        self.assertEqual(base_url, 'https://api.orcarouter.ai/v1')
+        self.assertEqual(api_key, 'sk-orca-test')
+        self.assertEqual(model, 'orcarouter/deepseek-v4-pro')
+
+    def test_falls_back_to_subtitle_and_global(self):
+        cfg = {
+            'ORCAROUTER_API_KEY': 'sk-orca-test',
+            'SUBTITLE_OPENAI_BASE_URL': 'https://sub.example/v1',
+            'SUBTITLE_OPENAI_MODEL_NAME': 'sub-model',
+        }
+        base_url, api_key, model = resolve_orca_llm_settings(cfg)
+        self.assertEqual(base_url, 'https://sub.example/v1')
+        self.assertEqual(api_key, 'sk-orca-test')
+        self.assertEqual(model, 'sub-model')
+
+
+class BuildAiOpenaiConfigTests(unittest.TestCase):
+    """Tests for build_ai_openai_config."""
+
+    def test_without_orca_key_keeps_openai(self):
+        cfg = {
+            'OPENAI_API_KEY': 'sk-openai',
+            'OPENAI_BASE_URL': 'https://api.openai.com/v1',
+            'OPENAI_MODEL_NAME': 'gpt-4o-mini',
+        }
+        result = build_ai_openai_config(cfg)
+        self.assertEqual(result['OPENAI_API_KEY'], 'sk-openai')
+        self.assertEqual(result['OPENAI_BASE_URL'], 'https://api.openai.com/v1')
+        self.assertEqual(result['OPENAI_MODEL_NAME'], 'gpt-4o-mini')
+
+    def test_with_orca_key_routes_to_orca(self):
+        cfg = {
+            'OPENAI_API_KEY': 'sk-openai',
+            'ORCAROUTER_API_KEY': 'sk-orca-test',
+            'ORCAROUTER_MODEL': 'orcarouter/auto',
+        }
+        result = build_ai_openai_config(cfg)
+        self.assertEqual(result['OPENAI_API_KEY'], 'sk-orca-test')
+        self.assertEqual(result['OPENAI_BASE_URL'], ORCAROUTER_DEFAULT_BASE_URL)
+        self.assertEqual(result['OPENAI_MODEL_NAME'], ORCAROUTER_DEFAULT_MODEL)
+
+
+class SubtitleTranslatorOrcaTests(unittest.TestCase):
+    """Tests for create_translator_from_config with SUBTITLE_API_PROVIDER=orcarouter."""
+
+    def _config(self, **overrides):
+        cfg = {
+            'SUBTITLE_API_PROVIDER': 'orcarouter',
+            'ORCAROUTER_API_KEY': 'sk-orca-test',
+            'ORCAROUTER_BASE_URL': 'https://api.orcarouter.ai/v1',
+            'ORCAROUTER_MODEL': 'orcarouter/auto',
+            'SUBTITLE_TRANSLATION_ENABLED': True,
+            'SUBTITLE_BATCH_SIZE': 3,
+            'SUBTITLE_MAX_RETRIES': 3,
+            'SUBTITLE_RETRY_DELAY': 2,
+            'SUBTITLE_MAX_WORKERS': 2,
+            'SUBTITLE_OPENAI_THINKING_ENABLED': False,
+            'OPENAI_TIMEOUT_SECONDS': 600,
+        }
+        cfg.update(overrides)
+        return cfg
+
+    def test_translator_resolves_orca(self):
+        from modules.subtitle_translator import create_translator_from_config
+
+        translator = create_translator_from_config(self._config(), task_id='t1')
+        self.assertIsNotNone(translator)
+        self.assertEqual(translator.config.api_provider, 'orcarouter')
+        self.assertEqual(translator.config.base_url, 'https://api.orcarouter.ai/v1')
+        self.assertEqual(translator.config.api_key, 'sk-orca-test')
+        self.assertEqual(translator.config.model_name, 'orcarouter/auto')
+
+    def test_translator_openai_does_not_auto_route_with_orca_key(self):
+        from modules.subtitle_translator import create_translator_from_config
+
+        # SUBTITLE_API_PROVIDER=openai 时不因全局 ORCAROUTER_API_KEY 而自动路由，
+        # 命名 OrcaRouter 接入需显式选择 orcarouter 提供商。
+        cfg = self._config(SUBTITLE_API_PROVIDER='openai', OPENAI_API_KEY='sk-openai')
+        translator = create_translator_from_config(cfg, task_id='t2')
+        self.assertIsNotNone(translator)
+        self.assertEqual(translator.config.api_provider, 'openai')
+        self.assertEqual(translator.config.base_url, 'https://api.openai.com/v1')
+        self.assertEqual(translator.config.api_key, 'sk-openai')
+
+    def test_translator_openai_without_orca_key(self):
+        from modules.subtitle_translator import create_translator_from_config
+
+        cfg = {
+            'SUBTITLE_API_PROVIDER': 'openai',
+            'OPENAI_API_KEY': 'sk-openai',
+            'OPENAI_BASE_URL': 'https://api.openai.com/v1',
+            'OPENAI_MODEL_NAME': 'gpt-4o-mini',
+            'SUBTITLE_BATCH_SIZE': 3,
+            'SUBTITLE_MAX_RETRIES': 3,
+            'SUBTITLE_RETRY_DELAY': 2,
+            'SUBTITLE_MAX_WORKERS': 2,
+        }
+        translator = create_translator_from_config(cfg, task_id='t3')
+        self.assertIsNotNone(translator)
+        self.assertEqual(translator.config.api_provider, 'openai')
+        self.assertEqual(translator.config.base_url, 'https://api.openai.com/v1')
+
+
+class SubtitleQcOrcaTests(unittest.TestCase):
+    """Tests for run_subtitle_qc / _call_ai_judge with SUBTITLE_QC_PROVIDER=orcarouter."""
+
+    @staticmethod
+    def _qc_config(**overrides):
+        cfg = {
+            'SUBTITLE_QC_PROVIDER': 'orcarouter',
+            'ORCAROUTER_API_KEY': 'sk-orca-test',
+            'ORCAROUTER_BASE_URL': 'https://api.orcarouter.ai/v1',
+            'ORCAROUTER_MODEL': 'orcarouter/auto',
+            'SUBTITLE_QC_THRESHOLD': 0.60,
+            'SUBTITLE_QC_SAMPLE_MAX_ITEMS': 80,
+            'SUBTITLE_QC_MAX_CHARS': 9000,
+        }
+        cfg.update(overrides)
+        return cfg
+
+    def test_call_ai_judge_uses_orca(self):
+        from modules.subtitle_qc import _call_ai_judge
+
+        with patch('modules.subtitle_qc._build_openai_client') as mock_build, \
+             patch('modules.utils.openai_chat_create_with_thinking_control') as mock_create:
+            mock_client = mock_build.return_value
+            mock_create.return_value = type('Resp', (), {
+                'choices': [type('Choice', (), {
+                    'message': type('Msg', (), {
+                        'content': '{"passed":true,"score":0.9,"reason":"ok"}',
+                        'parsed': None,
+                        'reasoning_content': None,
+                    })
+                })]
+            })()
+            passed, score, raw, status = _call_ai_judge('sample', {}, self._qc_config())
+            self.assertEqual(status, 'ok')
+            self.assertTrue(passed)
+            self.assertAlmostEqual(score, 0.9)
+            build_kwargs = mock_build.call_args[1]
+            self.assertEqual(build_kwargs['base_url'], 'https://api.orcarouter.ai/v1')
+            self.assertEqual(build_kwargs['api_key'], 'sk-orca-test')
+
+    def test_run_subtitle_qc_orca_provider_allowed(self):
+        from modules.subtitle_qc import run_subtitle_qc
+        import tempfile, os
+
+        srt_content = (
+            "1\n00:00:00,000 --> 00:00:02,000\n"
+            "Welcome to today's tutorial on building a neural network from scratch using PyTorch.\n\n"
+            "2\n00:00:02,000 --> 00:00:04,000\n"
+            "We will cover the core concepts of tensor operations and automatic differentiation.\n\n"
+            "3\n00:00:04,000 --> 00:00:06,000\n"
+            "By the end of this video you will understand the full training loop implementation.\n"
+        )
+        with tempfile.NamedTemporaryFile('w', suffix='.srt', delete=False, encoding='utf-8') as f:
+            f.write(srt_content)
+            path = f.name
+        try:
+            with patch('modules.subtitle_qc._sample_items') as mock_sample, \
+                 patch('modules.subtitle_qc._call_ai_judge') as mock_judge:
+                mock_sample.return_value = ('sample text', {'count': 2})
+                mock_judge.return_value = (True, 0.9, {'passed': True}, 'ok')
+                result = run_subtitle_qc(path, self._qc_config())
+                self.assertTrue(result.passed)
+                mock_judge.assert_called_once()
+        finally:
+            os.unlink(path)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds **OrcaRouter** as a named OpenAI-compatible gateway provider.

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible multi-model gateway (`https://api.orcarouter.ai/v1`, key prefix `sk-orca-`). It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

### What changed

- **Config** (`modules/config_manager.py`): new `ORCAROUTER_API_KEY`, `ORCAROUTER_BASE_URL` (default `https://api.orcarouter.ai/v1`), `ORCAROUTER_MODEL` (default `orcarouter/auto`) keys; `SUBTITLE_API_PROVIDER` / `SUBTITLE_QC_PROVIDER` now document `orcarouter` as a supported value.
- **Shared helpers** (`modules/utils.py`): `resolve_orca_llm_settings()` (priority: `ORCAROUTER_*` > subtitle overrides > OrcaRouter defaults, deliberately not inheriting the always-present global OpenAI endpoint/model) and `build_ai_openai_config()` (global AI consumers auto-route to OrcaRouter when `ORCAROUTER_API_KEY` is set, otherwise behave exactly as before).
- **Global AI consumers** (`modules/task_manager.py`, `modules/ai_segmentation.py`): metadata translation, tag generation, partition recommendation and AI segmentation now use the shared builder, so a configured `ORCAROUTER_API_KEY` routes them through OrcaRouter.
- **Subtitle translation / QC** (`modules/subtitle_translator.py`, `modules/subtitle_qc.py`): explicit `orcarouter` provider selection supported, resolving gateway settings through the shared helper.
- **Settings UI** (`templates/settings.html`): new "OrcaRouter 网关" card (base URL / API key / model) plus subtitle translation & QC provider dropdowns.
- **README**: documents the OrcaRouter env vars and config example.
- **Tests**: `tests/test_orcarouter_provider.py` — 10 unit tests covering settings resolution, auto-routing, and translator/QC provider selection.

### How it was verified

- Full suite: `pytest tests/` → **328 passed, 21 subtests passed** (318 baseline + 10 new).
- L3 live test with a real key through the production code path: metadata-routing config resolved to `https://api.orcarouter.ai/v1`; subtitle translator issued a chat completion (routed to `MiniMax-M2.7`) returning `ORCA-OK`; subtitle QC `_call_ai_judge` returned a valid AI verdict.

Disclosure: I'm an engineer on the OrcaRouter team.
