### PR TITLE
fix(ai): 提升 OpenAI 兼容模型的翻译成功率

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,13 +226,15 @@ python app.py
 ### AI 与投稿
 
 - `OPENAI_API_KEY` / `OPENAI_BASE_URL` / `OPENAI_MODEL_NAME`：全局 AI 配置
-- `OPENAI_THINKING_ENABLED`：全局思考模式开关
+- `OPENAI_THINKING_ENABLED`：是否允许模型使用思考模式；关闭时仅对可识别的 DeepSeek 接口发送私有禁用参数
 - `SUBTITLE_OPENAI_*`：字幕翻译专用覆盖配置，留空则回退全局
 - `SUBTITLE_QC_*`：字幕质检专用覆盖配置，留空则回退字幕翻译 / 全局配置
 - `TRANSLATE_TITLE` / `TRANSLATE_DESCRIPTION` / `GENERATE_TAGS`：自动生成标题、简介、标签
 - `RECOMMEND_PARTITION`：自动推荐分区
 - `FIXED_PARTITION_ID` / `FIXED_PARTITION_ID_BILIBILI`：固定分区
 - `YOUTUBE_UPLOADER_AS_FIRST_TAG`：将上传者作为首标签
+
+AI 文本功能统一使用 OpenAI Chat Completions 兼容接口。`OPENAI_BASE_URL` 应填写 API 根地址（例如 `https://api.openai.com/v1`），不要包含 `/chat/completions`。当兼容服务不支持 `response_format`、`max_tokens`、自定义 `temperature` 或特定指令角色时，系统会根据明确的参数错误自动降级，并为同一端点和模型复用已探测到的能力。
 
 ### 字幕处理
 

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ python app.py
 ### AI 与投稿
 
 - `OPENAI_API_KEY` / `OPENAI_BASE_URL` / `OPENAI_MODEL_NAME`：全局 AI 配置
-- `OPENAI_THINKING_ENABLED`：是否允许模型使用思考模式；关闭时仅对可识别的 DeepSeek 接口发送私有禁用参数
+- `OPENAI_THINKING_ENABLED`：是否允许模型使用思考模式；关闭时按可识别的 DeepSeek、Qwen、MiMo 接口发送各自的私有禁用参数
 - `SUBTITLE_OPENAI_*`：字幕翻译专用覆盖配置，留空则回退全局
 - `SUBTITLE_QC_*`：字幕质检专用覆盖配置，留空则回退字幕翻译 / 全局配置
 - `TRANSLATE_TITLE` / `TRANSLATE_DESCRIPTION` / `GENERATE_TAGS`：自动生成标题、简介、标签

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ python app.py
 - `FIXED_PARTITION_ID` / `FIXED_PARTITION_ID_BILIBILI`：固定分区
 - `YOUTUBE_UPLOADER_AS_FIRST_TAG`：将上传者作为首标签
 
-AI 文本功能统一使用 OpenAI Chat Completions 兼容接口。`OPENAI_BASE_URL` 应填写 API 根地址（例如 `https://api.openai.com/v1`），不要包含 `/chat/completions`。当兼容服务不支持 `response_format`、`max_tokens`、自定义 `temperature` 或特定指令角色时，系统会根据明确的参数错误自动降级，并为同一端点和模型复用已探测到的能力。
+AI 文本功能统一使用 OpenAI Chat Completions 兼容接口。`OPENAI_BASE_URL` 可填写 API 根地址（例如 `https://api.openai.com/v1`）或完整的 `/chat/completions` 地址，后者会自动规范化。当兼容服务不支持 `response_format`、token 上限参数、自定义 `temperature` 或特定指令角色时，系统会根据端点实际错误逐级协商；若网关只返回笼统的请求 schema 错误，则降级为仅含 `model + user messages` 的最小标准请求。能力只在降级请求成功后按端点和模型缓存。
 
 ### 字幕处理
 

--- a/modules/ai_enhancer.py
+++ b/modules/ai_enhancer.py
@@ -691,8 +691,7 @@ def _request_raw_text(
     )
     if not getattr(response, "choices", None):
         return ''
-    content = response.choices[0].message.content or ''
-    return content.strip()
+    return get_chat_message_text(response.choices[0].message)
 
 
 def _sanitize_metadata_field(

--- a/modules/ai_enhancer.py
+++ b/modules/ai_enhancer.py
@@ -17,6 +17,7 @@ from .utils import (
     openai_chat_create_with_thinking_control,
     extract_chat_message_json,
     get_chat_message_text,
+    normalize_openai_base_url,
 )
 
 import openai
@@ -163,7 +164,7 @@ def get_openai_client(openai_config):
     api_key = openai_config.get('OPENAI_API_KEY', '')
     options = {}
     if openai_config.get('OPENAI_BASE_URL'):
-        options['base_url'] = openai_config.get('OPENAI_BASE_URL')
+        options['base_url'] = normalize_openai_base_url(openai_config.get('OPENAI_BASE_URL'))
     timeout_value = openai_config.get('OPENAI_TIMEOUT_SECONDS', 600)
     try:
         timeout_seconds = float(str(timeout_value).strip())

--- a/modules/subtitle_qc.py
+++ b/modules/subtitle_qc.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
-from .utils import extract_chat_message_json, get_chat_message_text
+from .utils import extract_chat_message_json, get_chat_message_text, normalize_openai_base_url
 
 logger = logging.getLogger('subtitle_qc')
 SHORT_LINE_NORMALIZED_LEN = 8
@@ -192,7 +192,7 @@ def _build_openai_client(api_key: str, base_url: str):
 
     options: Dict[str, Any] = {}
     if base_url:
-        options['base_url'] = base_url
+        options['base_url'] = normalize_openai_base_url(base_url)
     options['timeout'] = 120.0
     return openai.OpenAI(api_key=api_key, **options)
 

--- a/modules/subtitle_translator.py
+++ b/modules/subtitle_translator.py
@@ -20,6 +20,7 @@ from .utils import (
     extract_chat_message_json,
     extract_json_from_text,
     get_chat_message_text,
+    normalize_openai_base_url,
 )
 
 logger = logging.getLogger('subtitle_translator')
@@ -88,7 +89,7 @@ def get_openai_client(openai_config):
     
     # 如果提供了base_url，添加到选项中
     if openai_config.get('OPENAI_BASE_URL'):
-        options['base_url'] = openai_config.get('OPENAI_BASE_URL')
+        options['base_url'] = normalize_openai_base_url(openai_config.get('OPENAI_BASE_URL'))
     timeout_value = openai_config.get('OPENAI_TIMEOUT_SECONDS', 600)
     try:
         timeout_seconds = float(str(timeout_value).strip())

--- a/modules/subtitle_translator.py
+++ b/modules/subtitle_translator.py
@@ -18,6 +18,7 @@ from .utils import (
     get_app_subdir,
     openai_chat_create_with_thinking_control,
     extract_chat_message_json,
+    extract_json_from_text,
     get_chat_message_text,
 )
 
@@ -366,6 +367,8 @@ class LLMRequester:
         
         # 线程锁，用于线程安全的日志记录
         self._log_lock = Lock()
+        self._capability_lock = Lock()
+        self._json_mode_disabled = False
         self._batch_counter = 0
         self._batch_log_interval = 10
     
@@ -407,20 +410,12 @@ class LLMRequester:
                     f"开始翻译批次 {batch_id}，包含 {len(texts)} 条字幕"
                 )
             
-            # 使用与ai_enhancer.py相同的API调用方式，添加JSON输出格式
-            response = openai_chat_create_with_thinking_control(
-                client=self.client,
-                create_kwargs={
-                    "model": model_name,
-                    "messages": [
-                        {"role": "system", "content": system_prompt},
-                        {"role": "user", "content": user_prompt}
-                    ],
-                    "max_tokens": 4096,
-                    "response_format": {"type": "json_object"},  # 强制JSON输出
-                },
-                thinking_enabled=self.openai_config.get('OPENAI_THINKING_ENABLED', False),
-                logger=self.logger,
+            translations = self._request_translation_result(
+                model_name=model_name,
+                system_prompt=system_prompt,
+                user_prompt=user_prompt,
+                expected_count=len(texts),
+                batch_id=batch_id,
                 scene_name='subtitle_translate_batch',
             )
             
@@ -432,14 +427,7 @@ class LLMRequester:
                     f"批次 {batch_id} 翻译完成，耗时: {response_time:.2f}秒"
                 )
             
-            # 检查响应是否有效
-            if not response.choices or len(response.choices) == 0:
-                with self._log_lock:
-                    self.logger.warning(f"批次 {batch_id}: API返回空的choices列表")
-                return [""] * len(texts)
-            
-            message = response.choices[0].message
-            return self._parse_structured_translation_result(message, len(texts), batch_id)
+            return translations
             
         except Exception as e:
             with self._log_lock:
@@ -471,34 +459,105 @@ class LLMRequester:
             model_name = self.openai_config.get('OPENAI_MODEL_NAME', 'gpt-3.5-turbo')
             with self._log_lock:
                 self.logger.info(f"开始严格模式翻译批次 {batch_id}，包含 {len(texts)} 条字幕")
-            response = openai_chat_create_with_thinking_control(
-                client=self.client,
-                create_kwargs={
-                    "model": model_name,
-                    "messages": [
-                        {"role": "system", "content": system_prompt},
-                        {"role": "user", "content": user_prompt}
-                    ],
-                    "max_tokens": 4096,
-                    "response_format": {"type": "json_object"},
-                },
-                thinking_enabled=self.openai_config.get('OPENAI_THINKING_ENABLED', False),
-                logger=self.logger,
+            return self._request_translation_result(
+                model_name=model_name,
+                system_prompt=system_prompt,
+                user_prompt=user_prompt,
+                expected_count=len(texts),
+                batch_id=batch_id,
                 scene_name='subtitle_translate_batch_strict',
             )
-            
-            # 检查响应是否有效
-            if not response.choices or len(response.choices) == 0:
-                with self._log_lock:
-                    self.logger.warning(f"严格模式批次 {batch_id}: API返回空的choices列表")
-                return [""] * len(texts)
-            
-            message = response.choices[0].message
-            return self._parse_structured_translation_result(message, len(texts), batch_id)
         except Exception as e:
             with self._log_lock:
                 self.logger.error(f"严格模式批次 {batch_id} 翻译失败: {e}")
             raise
+
+    def _create_translation_completion(
+        self,
+        *,
+        model_name: str,
+        system_prompt: str,
+        user_prompt: str,
+        scene_name: str,
+        json_mode: bool,
+    ):
+        create_kwargs = {
+            "model": model_name,
+            "messages": [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_prompt},
+            ],
+            "max_tokens": 4096,
+        }
+        if json_mode:
+            create_kwargs["response_format"] = {"type": "json_object"}
+        return openai_chat_create_with_thinking_control(
+            client=self.client,
+            create_kwargs=create_kwargs,
+            thinking_enabled=self.openai_config.get('OPENAI_THINKING_ENABLED', False),
+            logger=self.logger,
+            scene_name=scene_name,
+        )
+
+    def _request_translation_result(
+        self,
+        *,
+        model_name: str,
+        system_prompt: str,
+        user_prompt: str,
+        expected_count: int,
+        batch_id: str,
+        scene_name: str,
+    ) -> List[str]:
+        """请求并解析字幕；JSON 模式产出不可解析时自动改用纯文本 JSON 重试。"""
+        with self._capability_lock:
+            json_mode = not self._json_mode_disabled
+        response = self._create_translation_completion(
+            model_name=model_name,
+            system_prompt=system_prompt,
+            user_prompt=user_prompt,
+            scene_name=scene_name,
+            json_mode=json_mode,
+        )
+        if not getattr(response, 'choices', None):
+            with self._log_lock:
+                self.logger.warning(f"批次 {batch_id}: API返回空的choices列表")
+            return [""] * expected_count
+
+        translations = self._parse_structured_translation_result(
+            response.choices[0].message,
+            expected_count,
+            batch_id,
+        )
+        if any(translations) or not json_mode:
+            return translations
+
+        with self._log_lock:
+            self.logger.warning(
+                f"批次 {batch_id}: JSON模式响应不可用，改用纯文本JSON模式重试"
+            )
+        retry_response = self._create_translation_completion(
+            model_name=model_name,
+            system_prompt=(
+                system_prompt
+                + "\n重要：只返回 JSON 对象，不要使用 Markdown 代码块或添加解释。"
+            ),
+            user_prompt=user_prompt,
+            scene_name=f'{scene_name}_plain_json_retry',
+            json_mode=False,
+        )
+        if not getattr(retry_response, 'choices', None):
+            return translations
+        retried = self._parse_structured_translation_result(
+            retry_response.choices[0].message,
+            expected_count,
+            f'{batch_id}_plain_retry',
+        )
+        if any(retried):
+            with self._capability_lock:
+                self._json_mode_disabled = True
+            return retried
+        return translations
     
     def _build_structured_system_prompt(self, target_language: str) -> str:
         """构建结构化系统提示词（委托给统一 Prompt 中心）。"""
@@ -539,46 +598,35 @@ class LLMRequester:
     def _parse_structured_translation_result(self, message, expected_count: int, batch_id: str) -> List[str]:
         """解析结构化翻译结果"""
         try:
-            json_result = extract_chat_message_json(message, expected_type=dict)
+            json_result = extract_chat_message_json(message, expected_type=None)
             # 如果首次解析失败，尝试清洗 ASS 标签后重试
-            if not isinstance(json_result, dict):
-                import re as _re
+            if not isinstance(json_result, (dict, list)):
                 raw_text = get_chat_message_text(message)
-                cleaned_text = _re.sub(r'\\[hHnN]', ' ', raw_text)
-                cleaned_text = _re.sub(r'{\\[^}]*}', '', cleaned_text)
-                from .utils import extract_json_from_text
-                json_result = extract_json_from_text(cleaned_text, expected_type=dict)
-            if not isinstance(json_result, dict):
+                cleaned_text = re.sub(r'\\[hHnN]', ' ', raw_text)
+                cleaned_text = re.sub(r'{\\[^}]*}', '', cleaned_text)
+                json_result = extract_json_from_text(cleaned_text, expected_type=None)
+
+            translations = self._coerce_translation_list(json_result, expected_count)
+            if translations is None:
                 preview = get_chat_message_text(message)
+                translations = self._parse_plain_translation_lines(preview, expected_count)
+            if translations is None:
                 with self._log_lock:
                     self.logger.warning(
-                        f"批次 {batch_id}: 未解析到有效JSON，响应预览: {preview[:200]}"
+                        f"批次 {batch_id}: 未解析到有效翻译列表，响应预览: {preview[:200]}"
                     )
                 return [""] * expected_count
 
-            if "translations" not in json_result:
-                with self._log_lock:
-                    self.logger.warning(f"批次 {batch_id}: JSON响应缺少translations字段")
-                return [""] * expected_count
-            
-            translations = json_result["translations"]
-            
-            if not isinstance(translations, list):
-                with self._log_lock:
-                    self.logger.warning(f"批次 {batch_id}: translations不是数组格式")
-                return [""] * expected_count
-            
             # 确保返回的翻译数量正确
-            while len(translations) < expected_count:
-                translations.append("")  # 用空字符串填充
+            translations = list(translations[:expected_count])
+            translations.extend([""] * (expected_count - len(translations)))
             
             # 截断多余的翻译，并清洗 ASS 标签
-            import re as _re
-            _ass_tag_re = _re.compile(r'\\[hHnN]|{\\[^}]*}')
+            _ass_tag_re = re.compile(r'\\[hHnN]|{\\[^}]*}')
             final_translations = []
             for t in translations[:expected_count]:
                 cleaned = _ass_tag_re.sub('', str(t or '')).strip()
-                cleaned = _re.sub(r'\s+', ' ', cleaned).strip()
+                cleaned = re.sub(r'\s+', ' ', cleaned).strip()
                 final_translations.append(cleaned)
             
             with self._log_lock:
@@ -589,6 +637,67 @@ class LLMRequester:
             with self._log_lock:
                 self.logger.error(f"批次 {batch_id}: 解析翻译结果失败: {e}")
             return [""] * expected_count
+
+    @staticmethod
+    def _coerce_translation_list(json_result, expected_count: int):
+        """兼容常见网关/模型的 JSON 包装差异，并保持原始顺序。"""
+        value = json_result
+        if isinstance(value, dict):
+            for key in ('translations', 'translation', 'results', 'result', 'data', 'output'):
+                if key in value:
+                    value = value[key]
+                    break
+            else:
+                numeric_items = []
+                for key, item in value.items():
+                    try:
+                        numeric_items.append((int(str(key)), item))
+                    except Exception:
+                        numeric_items = []
+                        break
+                if numeric_items:
+                    value = [item for _, item in sorted(numeric_items)]
+                else:
+                    return None
+
+        if isinstance(value, str):
+            return [value] if expected_count == 1 else None
+        if not isinstance(value, list):
+            return None
+
+        translations = []
+        for item in value:
+            if isinstance(item, dict):
+                item_value = None
+                for key in ('translation', 'translated_text', 'text', 'output', 'content'):
+                    if key in item:
+                        item_value = item[key]
+                        break
+                if item_value is None:
+                    return None
+                translations.append(item_value)
+            else:
+                translations.append(item)
+        return translations
+
+    @staticmethod
+    def _parse_plain_translation_lines(text: str, expected_count: int):
+        """最后兜底：兼容只返回编号逐行译文、但不返回 JSON 的小模型。"""
+        raw = str(text or '').strip()
+        if not raw:
+            return None
+        if expected_count == 1 and '\n' not in raw:
+            return [raw]
+
+        numbered = []
+        pattern = re.compile(r'^\s*(?:\d+\s*[.)、:：-]|[-*•])\s*(.+?)\s*$')
+        for line in raw.splitlines():
+            match = pattern.match(line)
+            if match and match.group(1).strip():
+                numbered.append(match.group(1).strip())
+        if len(numbered) >= expected_count:
+            return numbered[:expected_count]
+        return None
 
 class SubtitleTranslator:
     """字幕翻译器主类"""

--- a/modules/subtitle_translator.py
+++ b/modules/subtitle_translator.py
@@ -8,7 +8,7 @@ import time
 import logging
 import gc  # 添加垃圾回收模块以优化内存使用
 from pathlib import Path
-from typing import Dict, List, Optional, Callable
+from typing import Callable, Dict, List, Optional, Tuple
 from dataclasses import dataclass
 from logging.handlers import RotatingFileHandler
 import concurrent.futures
@@ -525,12 +525,13 @@ class LLMRequester:
                 self.logger.warning(f"批次 {batch_id}: API返回空的choices列表")
             return [""] * expected_count
 
-        translations = self._parse_structured_translation_result(
-            response.choices[0].message,
-            expected_count,
-            batch_id,
+        (
+            translations,
+            parsed_successfully,
+        ) = self._parse_structured_translation_result_with_status(
+            response.choices[0].message, expected_count, batch_id
         )
-        if any(translations) or not json_mode:
+        if parsed_successfully or not json_mode:
             return translations
 
         with self._log_lock:
@@ -549,12 +550,15 @@ class LLMRequester:
         )
         if not getattr(retry_response, 'choices', None):
             return translations
-        retried = self._parse_structured_translation_result(
+        (
+            retried,
+            retry_parsed_successfully,
+        ) = self._parse_structured_translation_result_with_status(
             retry_response.choices[0].message,
             expected_count,
             f'{batch_id}_plain_retry',
         )
-        if any(retried):
+        if retry_parsed_successfully:
             with self._capability_lock:
                 self._json_mode_disabled = True
             return retried
@@ -598,6 +602,20 @@ class LLMRequester:
 
     def _parse_structured_translation_result(self, message, expected_count: int, batch_id: str) -> List[str]:
         """解析结构化翻译结果"""
+        translations, _ = self._parse_structured_translation_result_with_status(
+            message,
+            expected_count,
+            batch_id,
+        )
+        return translations
+
+    def _parse_structured_translation_result_with_status(
+        self,
+        message,
+        expected_count: int,
+        batch_id: str,
+    ) -> Tuple[List[str], bool]:
+        """解析结构化翻译结果，并区分解析失败与合法的空译文。"""
         try:
             json_result = extract_chat_message_json(message, expected_type=None)
             # 如果首次解析失败，尝试清洗 ASS 标签后重试
@@ -616,7 +634,7 @@ class LLMRequester:
                     self.logger.warning(
                         f"批次 {batch_id}: 未解析到有效翻译列表，响应预览: {preview[:200]}"
                     )
-                return [""] * expected_count
+                return [""] * expected_count, False
 
             # 确保返回的翻译数量正确
             translations = list(translations[:expected_count])
@@ -633,11 +651,11 @@ class LLMRequester:
             with self._log_lock:
                 self.logger.info(f"批次 {batch_id}: 成功解析 {len(final_translations)} 条翻译")
             
-            return final_translations
+            return final_translations, True
         except Exception as e:
             with self._log_lock:
                 self.logger.error(f"批次 {batch_id}: 解析翻译结果失败: {e}")
-            return [""] * expected_count
+            return [""] * expected_count, False
 
     @staticmethod
     def _coerce_translation_list(json_result, expected_count: int):

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -280,6 +280,7 @@ def extract_chat_message_json(message, expected_type=dict):
 
 _OPENAI_COMPATIBILITY_CACHE = {}
 _OPENAI_COMPATIBILITY_CACHE_MAX = 256
+_OPENAI_COMPATIBILITY_WARNED = set()
 _OPENAI_COMPATIBILITY_LOCK = threading.Lock()
 
 
@@ -304,6 +305,14 @@ def _mask_base_url(base_url):
     except Exception:
         pass
     return 'configured-endpoint'
+
+
+def normalize_openai_base_url(base_url) -> str:
+    """接受 API 根地址或完整 Chat Completions 地址，统一为 SDK 所需根地址。"""
+    value = safe_str(base_url).strip().rstrip('/')
+    if not value:
+        return ''
+    return re.sub(r'/chat/completions$', '', value, flags=re.IGNORECASE).rstrip('/')
 
 
 def _compatibility_error_text(exc) -> str:
@@ -358,6 +367,32 @@ def _is_parameter_compatibility_error(exc, parameter: str) -> bool:
         ),
     }
     return any(signal in text for signal in parameter_signals.get(parameter, (parameter,)))
+
+
+def _is_generic_schema_compatibility_error(exc) -> bool:
+    """识别未指出具体字段的请求 schema 错误，用于最后的最小请求兜底。"""
+    status_code = getattr(exc, 'status_code', None)
+    if status_code is not None:
+        try:
+            if int(status_code) not in (400, 422):
+                return False
+        except Exception:
+            pass
+    text = _compatibility_error_text(exc)
+    if any(signal in text for signal in (
+        'unauthorized', 'forbidden', 'api key', 'rate limit', 'quota',
+        'internal server error', 'service unavailable', 'bad gateway',
+    )):
+        return False
+    if re.search(r'(?:error code|status|http)\D{0,12}5\d{2}\b', text):
+        return False
+    return any(signal in text for signal in (
+        'param incorrect', 'parameter incorrect', 'invalid request',
+        'invalid_request', 'schema validation', 'validation error',
+        'request schema', 'malformed request', 'invalid payload',
+        'extra fields not permitted', 'extra inputs are not permitted',
+        'unprocessable entity',
+    ))
 
 
 def _client_compatibility_key(client, create_kwargs) -> str:
@@ -427,17 +462,16 @@ def _get_cached_compatibility_actions(cache_key: str):
         return set(_OPENAI_COMPATIBILITY_CACHE.get(cache_key, ()))
 
 
-def _cache_compatibility_action(cache_key: str, action: str) -> bool:
-    """记录端点/模型能力，返回该动作是否为首次发现。"""
+def _cache_compatibility_actions(cache_key: str, discovered_actions) -> None:
+    """仅在降级请求成功后记录端点/模型能力。"""
     with _OPENAI_COMPATIBILITY_LOCK:
         actions = set(_OPENAI_COMPATIBILITY_CACHE.get(cache_key, ()))
-        is_new = action not in actions
-        actions.add(action)
-        if action == 'use_max_completion_tokens':
+        actions.update(discovered_actions or ())
+        if 'use_max_completion_tokens' in discovered_actions:
             actions.discard('use_max_tokens')
-        elif action == 'use_max_tokens':
+        elif 'use_max_tokens' in discovered_actions:
             actions.discard('use_max_completion_tokens')
-        elif action == 'inline_instructions':
+        if 'inline_instructions' in discovered_actions or 'minimal_request' in discovered_actions:
             actions.discard('use_developer_role')
         if (
             cache_key not in _OPENAI_COMPATIBILITY_CACHE
@@ -445,7 +479,6 @@ def _cache_compatibility_action(cache_key: str, action: str) -> bool:
         ):
             _OPENAI_COMPATIBILITY_CACHE.clear()
         _OPENAI_COMPATIBILITY_CACHE[cache_key] = actions
-        return is_new
 
 
 def _drop_thinking_control(create_kwargs):
@@ -500,6 +533,13 @@ def _inline_instruction_messages(create_kwargs):
 
 def _apply_compatibility_actions(create_kwargs, actions):
     adapted = copy.deepcopy(create_kwargs or {})
+    if 'minimal_request' in actions:
+        minimal = {
+            'model': adapted.get('model'),
+            'messages': adapted.get('messages') or [],
+        }
+        _inline_instruction_messages(minimal)
+        return minimal
     if 'drop_thinking' in actions:
         _drop_thinking_control(adapted)
     if 'drop_response_format' in actions:
@@ -518,7 +558,13 @@ def _apply_compatibility_actions(create_kwargs, actions):
 
 
 def _warn_compatibility_fallback(logger, cache_key: str, action: str):
-    is_new = _cache_compatibility_action(cache_key, action)
+    warn_key = f'{cache_key}:{action}'
+    with _OPENAI_COMPATIBILITY_LOCK:
+        is_new = warn_key not in _OPENAI_COMPATIBILITY_WARNED
+        if is_new:
+            if len(_OPENAI_COMPATIBILITY_WARNED) >= _OPENAI_COMPATIBILITY_CACHE_MAX * 4:
+                _OPENAI_COMPATIBILITY_WARNED.clear()
+            _OPENAI_COMPATIBILITY_WARNED.add(warn_key)
     if not logger or not is_new:
         return
     descriptions = {
@@ -529,6 +575,7 @@ def _warn_compatibility_fallback(logger, cache_key: str, action: str):
         'drop_temperature': '不支持自定义 temperature，已使用模型默认值',
         'use_developer_role': '不支持 system role，已改用 developer role',
         'inline_instructions': '不支持独立指令角色，已将指令合并到 user 消息',
+        'minimal_request': '网关仅返回通用 schema 错误，已降级为最小标准请求',
     }
     logger.warning('模型兼容降级：%s', descriptions.get(action, action))
 
@@ -543,8 +590,9 @@ def openai_chat_create_with_thinking_control(
     """统一 Chat Completions 请求，并按端点实际能力自动降级可选参数。
 
     默认只对可识别的 DeepSeek、Qwen、MiMo 端点/模型发送对应的私有思考开关，
-    避免污染其他标准 OpenAI 请求。若兼容网关明确拒绝 JSON 模式、token 参数、temperature
-    或消息角色，会只移除/替换对应能力后重试，并缓存到同一端点+模型的后续请求。
+    避免污染其他标准 OpenAI 请求。若兼容网关明确拒绝 JSON 模式、token 参数、
+    temperature 或消息角色，会只移除/替换对应能力后重试；未说明字段的 schema
+    错误则最终降为最小标准请求。只有真正成功的组合才会缓存到同一端点+模型。
     鉴权、限流、配额和服务端错误不会在这里被误判为兼容问题。
     """
     base_kwargs = copy.deepcopy(create_kwargs or {})
@@ -555,13 +603,18 @@ def openai_chat_create_with_thinking_control(
         )
 
     cache_key = _client_compatibility_key(client, base_kwargs)
-    actions = _get_cached_compatibility_actions(cache_key)
+    cached_actions = _get_cached_compatibility_actions(cache_key)
+    actions = set(cached_actions)
+    discovered_actions = set()
     attempted_actions = set()
 
     while True:
         request_kwargs = _apply_compatibility_actions(base_kwargs, actions)
         try:
-            return client.chat.completions.create(**request_kwargs)
+            response = client.chat.completions.create(**request_kwargs)
+            if discovered_actions:
+                _cache_compatibility_actions(cache_key, discovered_actions)
+            return response
         except Exception as exc:
             action = None
             extra_body = request_kwargs.get('extra_body')
@@ -610,16 +663,25 @@ def openai_chat_create_with_thinking_control(
                     and _is_parameter_compatibility_error(exc, 'developer_role')
                 ):
                     action = 'inline_instructions'
+                elif _is_generic_schema_compatibility_error(exc):
+                    action = 'minimal_request'
 
             if action is None or action in attempted_actions or action in actions:
                 raise
 
             attempted_actions.add(action)
             actions.add(action)
+            discovered_actions.add(action)
             if action == 'use_max_completion_tokens':
                 actions.discard('use_max_tokens')
+                discovered_actions.discard('use_max_tokens')
             elif action == 'use_max_tokens':
                 actions.discard('use_max_completion_tokens')
+                discovered_actions.discard('use_max_completion_tokens')
             if action == 'inline_instructions':
                 actions.discard('use_developer_role')
+                discovered_actions.discard('use_developer_role')
+            elif action == 'minimal_request':
+                actions.discard('use_developer_role')
+                discovered_actions.discard('use_developer_role')
             _warn_compatibility_fallback(logger, cache_key, action)

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -38,6 +38,7 @@ def get_app_subdir(subdir_name):
 import re
 import copy
 import json
+import threading
 from typing import Any, Optional
 from urllib.parse import urlparse
 
@@ -234,24 +235,37 @@ def get_chat_message_text(message) -> str:
     if message is None:
         return ''
 
-    content = getattr(message, 'content', None)
+    if isinstance(message, dict):
+        content = message.get('content')
+        reasoning_content = message.get('reasoning_content')
+    else:
+        content = getattr(message, 'content', None)
+        reasoning_content = getattr(message, 'reasoning_content', None)
     if isinstance(content, list):
         parts = []
         for segment in content:
             if isinstance(segment, dict):
-                parts.append(safe_str(segment.get('text')))
+                segment_text = segment.get('text', '')
+                if isinstance(segment_text, dict):
+                    segment_text = segment_text.get('value', '')
+                parts.append(safe_str(segment_text))
             else:
                 parts.append(safe_str(getattr(segment, 'text', '')))
         text = ''.join(parts)
+    elif isinstance(content, (dict, tuple)):
+        try:
+            text = json.dumps(content, ensure_ascii=False)
+        except Exception:
+            text = safe_str(content)
     else:
-        text = safe_str(content) or safe_str(getattr(message, 'reasoning_content', ''))
+        text = safe_str(content) or safe_str(reasoning_content)
 
     return strip_code_fences(strip_reasoning_thoughts(text)).strip()
 
 
 def extract_chat_message_json(message, expected_type=dict):
     """优先读取 message.parsed，失败时从文本中提取 JSON。"""
-    parsed = getattr(message, 'parsed', None)
+    parsed = message.get('parsed') if isinstance(message, dict) else getattr(message, 'parsed', None)
     if expected_type is None:
         if isinstance(parsed, (dict, list)):
             return parsed
@@ -264,8 +278,9 @@ def extract_chat_message_json(message, expected_type=dict):
     )
 
 
-_THINKING_FALLBACK_WARNED_SCENES = set()
-_THINKING_FALLBACK_WARNED_SCENES_MAX = 128
+_OPENAI_COMPATIBILITY_CACHE = {}
+_OPENAI_COMPATIBILITY_CACHE_MAX = 256
+_OPENAI_COMPATIBILITY_LOCK = threading.Lock()
 
 
 def _coerce_bool(value, default=False):
@@ -291,19 +306,181 @@ def _mask_base_url(base_url):
     return 'configured-endpoint'
 
 
-def _is_thinking_param_unsupported_error(exc):
-    text = safe_str(exc).lower()
-    signals = (
-        'unknown parameter',
-        'unrecognized',
-        'unsupported',
-        'invalid parameter',
-        'extra_body',
-        'thinking',
-        'reasoning_effort',
-        'not permitted',
+def _compatibility_error_text(exc) -> str:
+    """汇总 OpenAI SDK/兼容网关异常中的可诊断文本。"""
+    parts = [safe_str(exc)]
+    for attr in ('body', 'message', 'code', 'param', 'type'):
+        value = getattr(exc, attr, None)
+        if value in (None, ''):
+            continue
+        if isinstance(value, (dict, list, tuple)):
+            try:
+                parts.append(json.dumps(value, ensure_ascii=False))
+            except Exception:
+                parts.append(safe_str(value))
+        else:
+            parts.append(safe_str(value))
+    return ' '.join(parts).lower()
+
+
+def _is_parameter_compatibility_error(exc, parameter: str) -> bool:
+    """仅识别明确指向某参数/消息角色的 4xx 兼容性错误。"""
+    status_code = getattr(exc, 'status_code', None)
+    if status_code is not None:
+        try:
+            if int(status_code) not in (400, 404, 422):
+                return False
+        except Exception:
+            pass
+
+    text = _compatibility_error_text(exc)
+    rejection_signals = (
+        'unsupported', 'not supported', 'unknown parameter', 'unknown field',
+        'unrecognized', 'invalid parameter', 'invalid_request', 'not permitted',
+        'extra inputs are not permitted', 'does not support', 'not allowed',
     )
-    return any(sig in text for sig in signals)
+    if not any(signal in text for signal in rejection_signals):
+        return False
+
+    parameter_signals = {
+        'thinking': ('thinking', 'enable_thinking'),
+        'response_format': ('response_format', 'response format', 'json_object', 'json mode'),
+        'max_tokens': ('max_tokens', 'max tokens'),
+        'max_completion_tokens': ('max_completion_tokens', 'max completion tokens'),
+        'temperature': ('temperature',),
+        'system_role': (
+            'system role', "role 'system'", 'role: system', 'messages[0].role',
+            "'system' with this model", "'system'", 'system message',
+        ),
+        'developer_role': (
+            'developer role', "role 'developer'", 'role: developer',
+            'messages[0].role', "'developer' with this model", "'developer'", 'developer message',
+        ),
+    }
+    return any(signal in text for signal in parameter_signals.get(parameter, (parameter,)))
+
+
+def _client_compatibility_key(client, create_kwargs) -> str:
+    endpoint_value = safe_str(getattr(client, 'base_url', '')).strip()
+    try:
+        parsed = urlparse(endpoint_value)
+        if parsed.scheme and parsed.netloc:
+            endpoint = f'{parsed.scheme}://{parsed.netloc}{parsed.path.rstrip("/")}'
+        else:
+            endpoint = endpoint_value or 'unknown'
+    except Exception:
+        endpoint = endpoint_value or 'unknown'
+    model = safe_str((create_kwargs or {}).get('model'), default='unknown').strip().lower()
+    return f'{endpoint}:{model}'
+
+
+def _looks_like_deepseek_endpoint(client, create_kwargs) -> bool:
+    endpoint = safe_str(getattr(client, 'base_url', '')).lower()
+    model = safe_str((create_kwargs or {}).get('model')).lower()
+    return 'deepseek' in endpoint or 'deepseek' in model
+
+
+def _get_cached_compatibility_actions(cache_key: str):
+    with _OPENAI_COMPATIBILITY_LOCK:
+        return set(_OPENAI_COMPATIBILITY_CACHE.get(cache_key, ()))
+
+
+def _cache_compatibility_action(cache_key: str, action: str) -> bool:
+    """记录端点/模型能力，返回该动作是否为首次发现。"""
+    with _OPENAI_COMPATIBILITY_LOCK:
+        actions = set(_OPENAI_COMPATIBILITY_CACHE.get(cache_key, ()))
+        is_new = action not in actions
+        actions.add(action)
+        if action == 'use_max_completion_tokens':
+            actions.discard('use_max_tokens')
+        elif action == 'use_max_tokens':
+            actions.discard('use_max_completion_tokens')
+        elif action == 'inline_instructions':
+            actions.discard('use_developer_role')
+        if (
+            cache_key not in _OPENAI_COMPATIBILITY_CACHE
+            and len(_OPENAI_COMPATIBILITY_CACHE) >= _OPENAI_COMPATIBILITY_CACHE_MAX
+        ):
+            _OPENAI_COMPATIBILITY_CACHE.clear()
+        _OPENAI_COMPATIBILITY_CACHE[cache_key] = actions
+        return is_new
+
+
+def _drop_thinking_control(create_kwargs):
+    extra_body = create_kwargs.get('extra_body')
+    if not isinstance(extra_body, dict):
+        return
+    extra_body = copy.deepcopy(extra_body)
+    extra_body.pop('thinking', None)
+    extra_body.pop('enable_thinking', None)
+    if extra_body:
+        create_kwargs['extra_body'] = extra_body
+    else:
+        create_kwargs.pop('extra_body', None)
+
+
+def _replace_instruction_role(create_kwargs, source_role: str, target_role: str):
+    messages = copy.deepcopy(create_kwargs.get('messages') or [])
+    for message in messages:
+        if isinstance(message, dict) and message.get('role') == source_role:
+            message['role'] = target_role
+    create_kwargs['messages'] = messages
+
+
+def _inline_instruction_messages(create_kwargs):
+    """为不支持 system/developer role 的旧网关把指令合并到首条 user 消息。"""
+    messages = copy.deepcopy(create_kwargs.get('messages') or [])
+    instructions = []
+    remaining = []
+    for message in messages:
+        if isinstance(message, dict) and message.get('role') in {'system', 'developer'}:
+            instructions.append(safe_str(message.get('content')).strip())
+        else:
+            remaining.append(message)
+    prefix = '\n\n'.join(item for item in instructions if item)
+    if prefix:
+        for message in remaining:
+            if isinstance(message, dict) and message.get('role') == 'user':
+                message['content'] = f"{prefix}\n\n{safe_str(message.get('content'))}"
+                break
+        else:
+            remaining.insert(0, {'role': 'user', 'content': prefix})
+    create_kwargs['messages'] = remaining
+
+
+def _apply_compatibility_actions(create_kwargs, actions):
+    adapted = copy.deepcopy(create_kwargs or {})
+    if 'drop_thinking' in actions:
+        _drop_thinking_control(adapted)
+    if 'drop_response_format' in actions:
+        adapted.pop('response_format', None)
+    if 'use_max_completion_tokens' in actions and 'max_tokens' in adapted:
+        adapted['max_completion_tokens'] = adapted.pop('max_tokens')
+    if 'use_max_tokens' in actions and 'max_completion_tokens' in adapted:
+        adapted['max_tokens'] = adapted.pop('max_completion_tokens')
+    if 'drop_temperature' in actions:
+        adapted.pop('temperature', None)
+    if 'inline_instructions' in actions:
+        _inline_instruction_messages(adapted)
+    elif 'use_developer_role' in actions:
+        _replace_instruction_role(adapted, 'system', 'developer')
+    return adapted
+
+
+def _warn_compatibility_fallback(logger, cache_key: str, action: str):
+    is_new = _cache_compatibility_action(cache_key, action)
+    if not logger or not is_new:
+        return
+    descriptions = {
+        'drop_thinking': '不支持 DeepSeek thinking 控制，已移除该扩展参数',
+        'drop_response_format': '不支持 JSON response_format，已改用提示词约束并解析文本 JSON',
+        'use_max_completion_tokens': '不支持 max_tokens，已改用 max_completion_tokens',
+        'use_max_tokens': '不支持 max_completion_tokens，已回退 max_tokens',
+        'drop_temperature': '不支持自定义 temperature，已使用模型默认值',
+        'use_developer_role': '不支持 system role，已改用 developer role',
+        'inline_instructions': '不支持独立指令角色，已将指令合并到 user 消息',
+    }
+    logger.warning('模型兼容降级：%s', descriptions.get(action, action))
 
 
 def openai_chat_create_with_thinking_control(
@@ -313,43 +490,91 @@ def openai_chat_create_with_thinking_control(
     logger=None,
     scene_name='unknown',
 ):
-    """统一 chat.completions 请求，支持“尝试关闭思考 + 自动降级”策略。"""
-    if _coerce_bool(thinking_enabled, default=False):
-        return client.chat.completions.create(**create_kwargs)
+    """统一 Chat Completions 请求，并按端点实际能力自动降级可选参数。
 
-    disabled_kwargs = copy.deepcopy(create_kwargs or {})
-    extra_body = disabled_kwargs.get('extra_body')
-    if not isinstance(extra_body, dict):
-        extra_body = {}
-    extra_body = copy.deepcopy(extra_body)
-    thinking_body = extra_body.get('thinking')
-    if not isinstance(thinking_body, dict):
-        thinking_body = {}
-    thinking_body.update({'type': 'disabled', 'enabled': False})
-    extra_body['thinking'] = thinking_body
-    disabled_kwargs['extra_body'] = extra_body
+    默认只对可识别的 DeepSeek 端点/模型发送其私有 thinking 开关，避免污染
+    标准 OpenAI 请求。若兼容网关明确拒绝 JSON 模式、token 参数、temperature
+    或消息角色，会只移除/替换对应能力后重试，并缓存到同一端点+模型的后续请求。
+    鉴权、限流、配额和服务端错误不会在这里被误判为兼容问题。
+    """
+    base_kwargs = copy.deepcopy(create_kwargs or {})
+    if (
+        not _coerce_bool(thinking_enabled, default=False)
+        and _looks_like_deepseek_endpoint(client, base_kwargs)
+    ):
+        extra_body = base_kwargs.get('extra_body')
+        if not isinstance(extra_body, dict):
+            extra_body = {}
+        extra_body = copy.deepcopy(extra_body)
+        thinking_body = extra_body.get('thinking')
+        if not isinstance(thinking_body, dict):
+            thinking_body = {}
+        thinking_body.update({'type': 'disabled', 'enabled': False})
+        extra_body['thinking'] = thinking_body
+        base_kwargs['extra_body'] = extra_body
 
-    try:
-        return client.chat.completions.create(**disabled_kwargs)
-    except Exception as exc:
-        if not _is_thinking_param_unsupported_error(exc):
-            raise
+    cache_key = _client_compatibility_key(client, base_kwargs)
+    actions = _get_cached_compatibility_actions(cache_key)
+    attempted_actions = set()
 
-        model_name = safe_str((create_kwargs or {}).get('model'), default='unknown')
-        endpoint_label = _mask_base_url(getattr(client, 'base_url', None))
-        scene = safe_str(scene_name, default='unknown')
-        warn_key = f"{scene}:{model_name}:{endpoint_label}"
-        if logger:
-            if warn_key not in _THINKING_FALLBACK_WARNED_SCENES:
-                logger.warning(
-                    "模型不支持 thinking 控制参数，已降级为普通请求"
-                )
-                _THINKING_FALLBACK_WARNED_SCENES.add(warn_key)
-                # 防止集合无限增长
-                if len(_THINKING_FALLBACK_WARNED_SCENES) > _THINKING_FALLBACK_WARNED_SCENES_MAX:
-                    _THINKING_FALLBACK_WARNED_SCENES.clear()
+    while True:
+        request_kwargs = _apply_compatibility_actions(base_kwargs, actions)
+        try:
+            return client.chat.completions.create(**request_kwargs)
+        except Exception as exc:
+            action = None
+            extra_body = request_kwargs.get('extra_body')
+            if (
+                isinstance(extra_body, dict)
+                and ('thinking' in extra_body or 'enable_thinking' in extra_body)
+                and _is_parameter_compatibility_error(exc, 'thinking')
+            ):
+                action = 'drop_thinking'
+            elif (
+                'response_format' in request_kwargs
+                and _is_parameter_compatibility_error(exc, 'response_format')
+            ):
+                action = 'drop_response_format'
+            elif (
+                'max_tokens' in request_kwargs
+                and _is_parameter_compatibility_error(exc, 'max_tokens')
+            ):
+                action = 'use_max_completion_tokens'
+            elif (
+                'max_completion_tokens' in request_kwargs
+                and _is_parameter_compatibility_error(exc, 'max_completion_tokens')
+            ):
+                action = 'use_max_tokens'
+            elif (
+                'temperature' in request_kwargs
+                and _is_parameter_compatibility_error(exc, 'temperature')
+            ):
+                action = 'drop_temperature'
             else:
-                logger.debug(
-                    "thinking 控制参数不受支持，继续普通请求"
-                )
-        return client.chat.completions.create(**create_kwargs)
+                roles = {
+                    message.get('role') for message in request_kwargs.get('messages', [])
+                    if isinstance(message, dict)
+                }
+                if (
+                    'system' in roles
+                    and _is_parameter_compatibility_error(exc, 'system_role')
+                ):
+                    action = 'use_developer_role'
+                elif (
+                    'developer' in roles
+                    and _is_parameter_compatibility_error(exc, 'developer_role')
+                ):
+                    action = 'inline_instructions'
+
+            if action is None or action in attempted_actions or action in actions:
+                raise
+
+            attempted_actions.add(action)
+            actions.add(action)
+            if action == 'use_max_completion_tokens':
+                actions.discard('use_max_tokens')
+            elif action == 'use_max_tokens':
+                actions.discard('use_max_completion_tokens')
+            if action == 'inline_instructions':
+                actions.discard('use_developer_role')
+            _warn_compatibility_fallback(logger, cache_key, action)

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -38,7 +38,9 @@ def get_app_subdir(subdir_name):
 import re
 import copy
 import json
+import logging
 import threading
+import time
 from typing import Any, Optional
 from urllib.parse import urlparse
 
@@ -280,8 +282,10 @@ def extract_chat_message_json(message, expected_type=dict):
 
 _OPENAI_COMPATIBILITY_CACHE = {}
 _OPENAI_COMPATIBILITY_CACHE_MAX = 256
+_OPENAI_COMPATIBILITY_CACHE_TTL_SECONDS = 3600
 _OPENAI_COMPATIBILITY_WARNED = set()
 _OPENAI_COMPATIBILITY_LOCK = threading.Lock()
+_OPENAI_URL_LOGGER = logging.getLogger(__name__)
 
 
 def _coerce_bool(value, default=False):
@@ -292,26 +296,17 @@ def _coerce_bool(value, default=False):
     return str(value).strip().lower() in {'1', 'true', 'yes', 'y', 'on'}
 
 
-def _mask_base_url(base_url):
-    text = safe_str(base_url).strip()
-    if not text:
-        return 'unknown'
-    try:
-        parsed = urlparse(text)
-        if parsed.scheme and parsed.hostname:
-            if parsed.port:
-                return f"{parsed.scheme}://{parsed.hostname}:{parsed.port}"
-            return f"{parsed.scheme}://{parsed.hostname}"
-    except Exception:
-        pass
-    return 'configured-endpoint'
-
-
 def normalize_openai_base_url(base_url) -> str:
     """接受 API 根地址或完整 Chat Completions 地址，统一为 SDK 所需根地址。"""
-    value = safe_str(base_url).strip().rstrip('/')
+    value = safe_str(base_url).strip()
     if not value:
         return ''
+    if urlparse(value).query:
+        _OPENAI_URL_LOGGER.warning(
+            'OpenAI Base URL 含查询参数，无法安全规范化，已保持原样'
+        )
+        return value
+    value = value.rstrip('/')
     return re.sub(r'/chat/completions$', '', value, flags=re.IGNORECASE).rstrip('/')
 
 
@@ -337,7 +332,7 @@ def _is_parameter_compatibility_error(exc, parameter: str) -> bool:
     status_code = getattr(exc, 'status_code', None)
     if status_code is not None:
         try:
-            if int(status_code) not in (400, 404, 422):
+            if int(status_code) not in (400, 422):
                 return False
         except Exception:
             pass
@@ -359,11 +354,11 @@ def _is_parameter_compatibility_error(exc, parameter: str) -> bool:
         'temperature': ('temperature',),
         'system_role': (
             'system role', "role 'system'", 'role: system', 'messages[0].role',
-            "'system' with this model", "'system'", 'system message',
+            "'system' with this model", 'system message',
         ),
         'developer_role': (
             'developer role', "role 'developer'", 'role: developer',
-            'messages[0].role', "'developer' with this model", "'developer'", 'developer message',
+            'messages[0].role', "'developer' with this model", 'developer message',
         ),
     }
     return any(signal in text for signal in parameter_signals.get(parameter, (parameter,)))
@@ -410,21 +405,32 @@ def _client_compatibility_key(client, create_kwargs) -> str:
 
 
 def _thinking_control_style(client, create_kwargs) -> str:
-    """按端点/模型识别常见的非标准思考开关协议。"""
-    endpoint = safe_str(getattr(client, 'base_url', '')).lower()
+    """仅对已知官方端点和匹配模型注入非标准思考开关。"""
+    endpoint = safe_str(getattr(client, 'base_url', '')).strip()
+    try:
+        hostname = (urlparse(endpoint).hostname or '').lower()
+    except Exception:
+        hostname = ''
     model = safe_str((create_kwargs or {}).get('model')).lower()
-    hint = f'{endpoint} {model}'
-    if 'qwen' in hint:
-        # DashScope/百炼直接接收 enable_thinking；Qwen 官方 vLLM 部署将其
-        # 放在 chat_template_kwargs 中。带组织前缀的模型名通常来自自部署。
-        if '/' in model and not any(
-            marker in endpoint for marker in ('dashscope', 'aliyuncs.com', 'aliyun.com')
-        ):
-            return 'qwen_chat_template'
+
+    def host_matches(*domains):
+        return any(
+            hostname == domain or hostname.endswith(f'.{domain}')
+            for domain in domains
+        )
+
+    def model_matches(family):
+        return any(
+            part == family or part.startswith(family)
+            for part in re.split(r'[/.:_-]+', model)
+            if part
+        )
+
+    if host_matches('aliyuncs.com') and model_matches('qwen'):
         return 'qwen'
-    if 'mimo' in hint or 'xiaomimimo' in hint:
+    if host_matches('api.xiaomimimo.com') and model_matches('mimo'):
         return 'mimo'
-    if 'deepseek' in hint:
+    if host_matches('api.deepseek.com') and model_matches('deepseek'):
         return 'thinking_object'
     return ''
 
@@ -436,13 +442,6 @@ def _inject_thinking_control(create_kwargs, style: str):
     extra_body = copy.deepcopy(extra_body)
     if style == 'qwen':
         extra_body['enable_thinking'] = False
-    elif style == 'qwen_chat_template':
-        chat_template_kwargs = extra_body.get('chat_template_kwargs')
-        if not isinstance(chat_template_kwargs, dict):
-            chat_template_kwargs = {}
-        chat_template_kwargs = copy.deepcopy(chat_template_kwargs)
-        chat_template_kwargs['enable_thinking'] = False
-        extra_body['chat_template_kwargs'] = chat_template_kwargs
     elif style in {'thinking_object', 'mimo'}:
         thinking_body = extra_body.get('thinking')
         if not isinstance(thinking_body, dict):
@@ -459,14 +458,28 @@ def _inject_thinking_control(create_kwargs, style: str):
 
 def _get_cached_compatibility_actions(cache_key: str):
     with _OPENAI_COMPATIBILITY_LOCK:
-        return set(_OPENAI_COMPATIBILITY_CACHE.get(cache_key, ()))
+        entry = _OPENAI_COMPATIBILITY_CACHE.get(cache_key)
+        if not entry:
+            return set()
+        actions, expires_at = entry
+        if expires_at <= time.monotonic():
+            _OPENAI_COMPATIBILITY_CACHE.pop(cache_key, None)
+            return set()
+        return set(actions)
 
 
 def _cache_compatibility_actions(cache_key: str, discovered_actions) -> None:
     """仅在降级请求成功后记录端点/模型能力。"""
+    discovered_actions = set(discovered_actions or ())
     with _OPENAI_COMPATIBILITY_LOCK:
-        actions = set(_OPENAI_COMPATIBILITY_CACHE.get(cache_key, ()))
-        actions.update(discovered_actions or ())
+        now = time.monotonic()
+        entry = _OPENAI_COMPATIBILITY_CACHE.get(cache_key)
+        if entry and entry[1] > now:
+            actions = set(entry[0])
+        else:
+            actions = set()
+            _OPENAI_COMPATIBILITY_CACHE.pop(cache_key, None)
+        actions.update(discovered_actions)
         if 'use_max_completion_tokens' in discovered_actions:
             actions.discard('use_max_tokens')
         elif 'use_max_tokens' in discovered_actions:
@@ -478,7 +491,10 @@ def _cache_compatibility_actions(cache_key: str, discovered_actions) -> None:
             and len(_OPENAI_COMPATIBILITY_CACHE) >= _OPENAI_COMPATIBILITY_CACHE_MAX
         ):
             _OPENAI_COMPATIBILITY_CACHE.clear()
-        _OPENAI_COMPATIBILITY_CACHE[cache_key] = actions
+        _OPENAI_COMPATIBILITY_CACHE[cache_key] = (
+            actions,
+            now + _OPENAI_COMPATIBILITY_CACHE_TTL_SECONDS,
+        )
 
 
 def _drop_thinking_control(create_kwargs):
@@ -557,8 +573,9 @@ def _apply_compatibility_actions(create_kwargs, actions):
     return adapted
 
 
-def _warn_compatibility_fallback(logger, cache_key: str, action: str):
-    warn_key = f'{cache_key}:{action}'
+def _warn_compatibility_fallback(logger, cache_key: str, action: str, scene_name: str):
+    scene = safe_str(scene_name, default='unknown').strip() or 'unknown'
+    warn_key = f'{cache_key}:{scene}:{action}'
     with _OPENAI_COMPATIBILITY_LOCK:
         is_new = warn_key not in _OPENAI_COMPATIBILITY_WARNED
         if is_new:
@@ -577,7 +594,7 @@ def _warn_compatibility_fallback(logger, cache_key: str, action: str):
         'inline_instructions': '不支持独立指令角色，已将指令合并到 user 消息',
         'minimal_request': '网关仅返回通用 schema 错误，已降级为最小标准请求',
     }
-    logger.warning('模型兼容降级：%s', descriptions.get(action, action))
+    logger.warning('模型兼容降级[%s]：%s', scene, descriptions.get(action, action))
 
 
 def openai_chat_create_with_thinking_control(
@@ -684,4 +701,4 @@ def openai_chat_create_with_thinking_control(
             elif action == 'minimal_request':
                 actions.discard('use_developer_role')
                 discovered_actions.discard('use_developer_role')
-            _warn_compatibility_fallback(logger, cache_key, action)
+            _warn_compatibility_fallback(logger, cache_key, action, scene_name)

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -374,10 +374,52 @@ def _client_compatibility_key(client, create_kwargs) -> str:
     return f'{endpoint}:{model}'
 
 
-def _looks_like_deepseek_endpoint(client, create_kwargs) -> bool:
+def _thinking_control_style(client, create_kwargs) -> str:
+    """按端点/模型识别常见的非标准思考开关协议。"""
     endpoint = safe_str(getattr(client, 'base_url', '')).lower()
     model = safe_str((create_kwargs or {}).get('model')).lower()
-    return 'deepseek' in endpoint or 'deepseek' in model
+    hint = f'{endpoint} {model}'
+    if 'qwen' in hint:
+        # DashScope/百炼直接接收 enable_thinking；Qwen 官方 vLLM 部署将其
+        # 放在 chat_template_kwargs 中。带组织前缀的模型名通常来自自部署。
+        if '/' in model and not any(
+            marker in endpoint for marker in ('dashscope', 'aliyuncs.com', 'aliyun.com')
+        ):
+            return 'qwen_chat_template'
+        return 'qwen'
+    if 'mimo' in hint or 'xiaomimimo' in hint:
+        return 'mimo'
+    if 'deepseek' in hint:
+        return 'thinking_object'
+    return ''
+
+
+def _inject_thinking_control(create_kwargs, style: str):
+    extra_body = create_kwargs.get('extra_body')
+    if not isinstance(extra_body, dict):
+        extra_body = {}
+    extra_body = copy.deepcopy(extra_body)
+    if style == 'qwen':
+        extra_body['enable_thinking'] = False
+    elif style == 'qwen_chat_template':
+        chat_template_kwargs = extra_body.get('chat_template_kwargs')
+        if not isinstance(chat_template_kwargs, dict):
+            chat_template_kwargs = {}
+        chat_template_kwargs = copy.deepcopy(chat_template_kwargs)
+        chat_template_kwargs['enable_thinking'] = False
+        extra_body['chat_template_kwargs'] = chat_template_kwargs
+    elif style in {'thinking_object', 'mimo'}:
+        thinking_body = extra_body.get('thinking')
+        if not isinstance(thinking_body, dict):
+            thinking_body = {}
+        thinking_body = copy.deepcopy(thinking_body)
+        thinking_body['type'] = 'disabled'
+        if style == 'thinking_object':
+            # 保留项目既有 DeepSeek 兼容字段；MiMo 使用更严格的 type 形态。
+            thinking_body['enabled'] = False
+        extra_body['thinking'] = thinking_body
+    if extra_body:
+        create_kwargs['extra_body'] = extra_body
 
 
 def _get_cached_compatibility_actions(cache_key: str):
@@ -413,6 +455,14 @@ def _drop_thinking_control(create_kwargs):
     extra_body = copy.deepcopy(extra_body)
     extra_body.pop('thinking', None)
     extra_body.pop('enable_thinking', None)
+    chat_template_kwargs = extra_body.get('chat_template_kwargs')
+    if isinstance(chat_template_kwargs, dict) and 'enable_thinking' in chat_template_kwargs:
+        chat_template_kwargs = copy.deepcopy(chat_template_kwargs)
+        chat_template_kwargs.pop('enable_thinking', None)
+        if chat_template_kwargs:
+            extra_body['chat_template_kwargs'] = chat_template_kwargs
+        else:
+            extra_body.pop('chat_template_kwargs', None)
     if extra_body:
         create_kwargs['extra_body'] = extra_body
     else:
@@ -472,7 +522,7 @@ def _warn_compatibility_fallback(logger, cache_key: str, action: str):
     if not logger or not is_new:
         return
     descriptions = {
-        'drop_thinking': '不支持 DeepSeek thinking 控制，已移除该扩展参数',
+        'drop_thinking': '不支持当前模型的思考控制参数，已移除该扩展参数',
         'drop_response_format': '不支持 JSON response_format，已改用提示词约束并解析文本 JSON',
         'use_max_completion_tokens': '不支持 max_tokens，已改用 max_completion_tokens',
         'use_max_tokens': '不支持 max_completion_tokens，已回退 max_tokens',
@@ -492,26 +542,17 @@ def openai_chat_create_with_thinking_control(
 ):
     """统一 Chat Completions 请求，并按端点实际能力自动降级可选参数。
 
-    默认只对可识别的 DeepSeek 端点/模型发送其私有 thinking 开关，避免污染
-    标准 OpenAI 请求。若兼容网关明确拒绝 JSON 模式、token 参数、temperature
+    默认只对可识别的 DeepSeek、Qwen、MiMo 端点/模型发送对应的私有思考开关，
+    避免污染其他标准 OpenAI 请求。若兼容网关明确拒绝 JSON 模式、token 参数、temperature
     或消息角色，会只移除/替换对应能力后重试，并缓存到同一端点+模型的后续请求。
     鉴权、限流、配额和服务端错误不会在这里被误判为兼容问题。
     """
     base_kwargs = copy.deepcopy(create_kwargs or {})
-    if (
-        not _coerce_bool(thinking_enabled, default=False)
-        and _looks_like_deepseek_endpoint(client, base_kwargs)
-    ):
-        extra_body = base_kwargs.get('extra_body')
-        if not isinstance(extra_body, dict):
-            extra_body = {}
-        extra_body = copy.deepcopy(extra_body)
-        thinking_body = extra_body.get('thinking')
-        if not isinstance(thinking_body, dict):
-            thinking_body = {}
-        thinking_body.update({'type': 'disabled', 'enabled': False})
-        extra_body['thinking'] = thinking_body
-        base_kwargs['extra_body'] = extra_body
+    if not _coerce_bool(thinking_enabled, default=False):
+        _inject_thinking_control(
+            base_kwargs,
+            _thinking_control_style(client, base_kwargs),
+        )
 
     cache_key = _client_compatibility_key(client, base_kwargs)
     actions = _get_cached_compatibility_actions(cache_key)
@@ -526,7 +567,11 @@ def openai_chat_create_with_thinking_control(
             extra_body = request_kwargs.get('extra_body')
             if (
                 isinstance(extra_body, dict)
-                and ('thinking' in extra_body or 'enable_thinking' in extra_body)
+                and (
+                    'thinking' in extra_body
+                    or 'enable_thinking' in extra_body
+                    or 'enable_thinking' in (extra_body.get('chat_template_kwargs') or {})
+                )
                 and _is_parameter_compatibility_error(exc, 'thinking')
             ):
                 action = 'drop_thinking'

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -688,6 +688,7 @@
                                                             <div class="form-group">
                                                                 <label for="openai-url" class="form-label">接口地址</label>
                                                                 <input type="text" id="openai-url" name="OPENAI_BASE_URL" value="{{ config.OPENAI_BASE_URL }}" class="form-control" placeholder="如 https://api.openai.com/v1">
+                                                                <p class="help-text mb-0 mt-2">填写 OpenAI 兼容 API 的根地址，不要包含 <code>/chat/completions</code>。系统会自动适配常见模型的 JSON 模式、token 参数和消息角色差异。</p>
                                                             </div>
                                                         </div>
                                                         <div class="col-md-6">
@@ -705,7 +706,8 @@
                                                         <div class="col-12">
                                                             <div class="form-check form-switch">
                                                                 <input class="form-check-input" type="checkbox" id="openai-thinking-enabled" name="OPENAI_THINKING_ENABLED" {% if config.get('OPENAI_THINKING_ENABLED', False) %}checked{% endif %}>
-                                                                <label class="form-check-label" for="openai-thinking-enabled">通用模型启用思考模式</label>
+                                                                <label class="form-check-label" for="openai-thinking-enabled">允许模型使用思考模式</label>
+                                                                <p class="help-text mb-0 mt-2">关闭时仅对可识别的 DeepSeek 端点发送禁用思考参数，不会向其他 OpenAI 兼容模型注入私有参数。</p>
                                                             </div>
                                                         </div>
                                                     </div>
@@ -740,7 +742,7 @@
                                                         <div class="col-12">
                                                             <div class="form-check form-switch">
                                                                 <input class="form-check-input" type="checkbox" id="subtitle-openai-thinking-enabled" name="SUBTITLE_OPENAI_THINKING_ENABLED" {% if config.get('SUBTITLE_OPENAI_THINKING_ENABLED', False) %}checked{% endif %}>
-                                                                <label class="form-check-label" for="subtitle-openai-thinking-enabled">字幕模型启用思考模式</label>
+                                                                <label class="form-check-label" for="subtitle-openai-thinking-enabled">允许字幕模型使用思考模式</label>
                                                             </div>
                                                         </div>
                                                     </div>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -707,7 +707,7 @@
                                                             <div class="form-check form-switch">
                                                                 <input class="form-check-input" type="checkbox" id="openai-thinking-enabled" name="OPENAI_THINKING_ENABLED" {% if config.get('OPENAI_THINKING_ENABLED', False) %}checked{% endif %}>
                                                                 <label class="form-check-label" for="openai-thinking-enabled">允许模型使用思考模式</label>
-                                                                <p class="help-text mb-0 mt-2">关闭时仅对可识别的 DeepSeek 端点发送禁用思考参数，不会向其他 OpenAI 兼容模型注入私有参数。</p>
+                                                                <p class="help-text mb-0 mt-2">关闭时会按可识别的 DeepSeek、Qwen、MiMo 接口发送各自的禁用思考参数；其他模型不会收到私有参数。</p>
                                                             </div>
                                                         </div>
                                                     </div>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -688,7 +688,7 @@
                                                             <div class="form-group">
                                                                 <label for="openai-url" class="form-label">接口地址</label>
                                                                 <input type="text" id="openai-url" name="OPENAI_BASE_URL" value="{{ config.OPENAI_BASE_URL }}" class="form-control" placeholder="如 https://api.openai.com/v1">
-                                                                <p class="help-text mb-0 mt-2">填写 OpenAI 兼容 API 的根地址，不要包含 <code>/chat/completions</code>。系统会自动适配常见模型的 JSON 模式、token 参数和消息角色差异。</p>
+                                                                <p class="help-text mb-0 mt-2">填写 OpenAI 兼容 API 的根地址；若粘贴了完整 <code>/chat/completions</code> 地址，系统会自动规范化。请求参数和消息格式会按端点实际能力自动协商。</p>
                                                             </div>
                                                         </div>
                                                         <div class="col-md-6">

--- a/tests/test_openai_chat_compatibility.py
+++ b/tests/test_openai_chat_compatibility.py
@@ -1,0 +1,355 @@
+import logging
+import threading
+import unittest
+from types import SimpleNamespace
+
+from modules import utils
+from modules.subtitle_translator import LLMRequester
+
+
+class _CompatError(RuntimeError):
+    def __init__(self, message, status_code=400, body=None):
+        super().__init__(message)
+        self.status_code = status_code
+        self.body = body
+
+
+class _FakeCompletions:
+    def __init__(self, responder=None):
+        self.calls = []
+        self._responder = responder
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        if self._responder:
+            return self._responder(kwargs, len(self.calls))
+        return SimpleNamespace(choices=[])
+
+
+class _FakeClient:
+    def __init__(self, base_url='https://gateway.example/v1', responder=None):
+        self.base_url = base_url
+        self.completions = _FakeCompletions(responder)
+        self.chat = SimpleNamespace(completions=self.completions)
+
+
+def _base_kwargs(**overrides):
+    kwargs = {
+        'model': 'test-model',
+        'messages': [
+            {'role': 'system', 'content': 'Return JSON only.'},
+            {'role': 'user', 'content': '{"text":"hello"}'},
+        ],
+        'max_tokens': 100,
+        'temperature': 0.2,
+        'response_format': {'type': 'json_object'},
+    }
+    kwargs.update(overrides)
+    return kwargs
+
+
+class OpenAIChatCompatibilityTests(unittest.TestCase):
+    def setUp(self):
+        with utils._OPENAI_COMPATIBILITY_LOCK:
+            utils._OPENAI_COMPATIBILITY_CACHE.clear()
+
+    def test_non_deepseek_request_does_not_receive_private_thinking_parameter(self):
+        client = _FakeClient()
+
+        utils.openai_chat_create_with_thinking_control(
+            client, _base_kwargs(), thinking_enabled=False,
+        )
+
+        self.assertNotIn('extra_body', client.completions.calls[0])
+
+    def test_deepseek_request_receives_disable_thinking_parameter(self):
+        client = _FakeClient(base_url='https://api.deepseek.com/v1')
+
+        utils.openai_chat_create_with_thinking_control(
+            client, _base_kwargs(model='deepseek-chat'), thinking_enabled=False,
+        )
+
+        self.assertEqual(
+            client.completions.calls[0]['extra_body']['thinking'],
+            {'type': 'disabled', 'enabled': False},
+        )
+
+    def test_enabled_thinking_does_not_inject_or_disable_provider_parameter(self):
+        client = _FakeClient(base_url='https://api.deepseek.com/v1')
+
+        utils.openai_chat_create_with_thinking_control(
+            client, _base_kwargs(model='deepseek-reasoner'), thinking_enabled=True,
+        )
+
+        self.assertNotIn('extra_body', client.completions.calls[0])
+
+    def test_deepseek_thinking_rejection_retries_without_private_parameter(self):
+        def responder(kwargs, _call_number):
+            if 'extra_body' in kwargs:
+                raise _CompatError("Unknown parameter: 'thinking'")
+            return SimpleNamespace(choices=[])
+
+        client = _FakeClient(
+            base_url='https://api.deepseek.com/v1',
+            responder=responder,
+        )
+
+        utils.openai_chat_create_with_thinking_control(
+            client, _base_kwargs(model='deepseek-chat'), thinking_enabled=False,
+        )
+
+        self.assertEqual(len(client.completions.calls), 2)
+        self.assertIn('extra_body', client.completions.calls[0])
+        self.assertNotIn('extra_body', client.completions.calls[1])
+
+    def test_retries_without_unsupported_response_format_and_caches_capability(self):
+        def responder(kwargs, _call_number):
+            if 'response_format' in kwargs:
+                raise _CompatError("Unsupported parameter: 'response_format'")
+            return SimpleNamespace(choices=[])
+
+        client = _FakeClient(responder=responder)
+        logger = logging.getLogger('test_openai_compat_response_format')
+
+        utils.openai_chat_create_with_thinking_control(
+            client, _base_kwargs(), logger=logger,
+        )
+        utils.openai_chat_create_with_thinking_control(
+            client, _base_kwargs(), logger=logger,
+        )
+
+        self.assertEqual(len(client.completions.calls), 3)
+        self.assertIn('response_format', client.completions.calls[0])
+        self.assertNotIn('response_format', client.completions.calls[1])
+        self.assertNotIn('response_format', client.completions.calls[2])
+
+    def test_switches_from_max_tokens_to_max_completion_tokens(self):
+        def responder(kwargs, _call_number):
+            if 'max_tokens' in kwargs:
+                raise _CompatError(
+                    "Unsupported parameter: 'max_tokens'. Use 'max_completion_tokens' instead."
+                )
+            return SimpleNamespace(choices=[])
+
+        client = _FakeClient(responder=responder)
+
+        utils.openai_chat_create_with_thinking_control(client, _base_kwargs())
+
+        self.assertEqual(len(client.completions.calls), 2)
+        self.assertEqual(client.completions.calls[1]['max_completion_tokens'], 100)
+        self.assertNotIn('max_tokens', client.completions.calls[1])
+
+    def test_switches_from_max_completion_tokens_to_legacy_max_tokens(self):
+        def responder(kwargs, _call_number):
+            if 'max_completion_tokens' in kwargs:
+                raise _CompatError("Unknown parameter: 'max_completion_tokens'")
+            return SimpleNamespace(choices=[])
+
+        client = _FakeClient(responder=responder)
+        kwargs = _base_kwargs()
+        kwargs.pop('max_tokens')
+        kwargs['max_completion_tokens'] = 100
+
+        utils.openai_chat_create_with_thinking_control(
+            client,
+            kwargs,
+        )
+
+        first_call = client.completions.calls[0]
+        self.assertIn('max_completion_tokens', first_call)
+        self.assertEqual(client.completions.calls[1]['max_tokens'], 100)
+
+    def test_removes_unsupported_temperature(self):
+        def responder(kwargs, _call_number):
+            if 'temperature' in kwargs:
+                raise _CompatError(
+                    "Unsupported value: 'temperature' does not support 0.2 with this model."
+                )
+            return SimpleNamespace(choices=[])
+
+        client = _FakeClient(responder=responder)
+
+        utils.openai_chat_create_with_thinking_control(client, _base_kwargs())
+
+        self.assertEqual(len(client.completions.calls), 2)
+        self.assertNotIn('temperature', client.completions.calls[1])
+
+    def test_system_role_falls_back_to_developer_then_inline_user_instruction(self):
+        def responder(kwargs, _call_number):
+            roles = [message['role'] for message in kwargs['messages']]
+            if 'system' in roles:
+                raise _CompatError(
+                    "Unsupported value: 'messages[0].role' does not support 'system' with this model."
+                )
+            if 'developer' in roles:
+                raise _CompatError(
+                    "Unsupported value: 'messages[0].role' does not support 'developer' with this model."
+                )
+            return SimpleNamespace(choices=[])
+
+        client = _FakeClient(responder=responder)
+
+        utils.openai_chat_create_with_thinking_control(client, _base_kwargs())
+
+        self.assertEqual(len(client.completions.calls), 3)
+        self.assertEqual(client.completions.calls[1]['messages'][0]['role'], 'developer')
+        self.assertEqual(
+            [message['role'] for message in client.completions.calls[2]['messages']],
+            ['user'],
+        )
+        self.assertIn('Return JSON only.', client.completions.calls[2]['messages'][0]['content'])
+
+    def test_multiple_explicit_parameter_errors_are_adapted_sequentially(self):
+        def responder(kwargs, _call_number):
+            if 'response_format' in kwargs:
+                raise _CompatError("Unknown parameter: 'response_format'")
+            if 'max_tokens' in kwargs:
+                raise _CompatError("Unsupported parameter: 'max_tokens'")
+            if 'temperature' in kwargs:
+                raise _CompatError("Unsupported parameter: 'temperature'")
+            return SimpleNamespace(choices=[])
+
+        client = _FakeClient(responder=responder)
+
+        utils.openai_chat_create_with_thinking_control(client, _base_kwargs())
+
+        self.assertEqual(len(client.completions.calls), 4)
+        final_call = client.completions.calls[-1]
+        self.assertNotIn('response_format', final_call)
+        self.assertNotIn('max_tokens', final_call)
+        self.assertEqual(final_call['max_completion_tokens'], 100)
+        self.assertNotIn('temperature', final_call)
+
+    def test_authentication_error_is_not_retried(self):
+        def responder(_kwargs, _call_number):
+            raise _CompatError('Incorrect API key provided', status_code=401)
+
+        client = _FakeClient(responder=responder)
+
+        with self.assertRaises(_CompatError):
+            utils.openai_chat_create_with_thinking_control(client, _base_kwargs())
+
+        self.assertEqual(len(client.completions.calls), 1)
+
+    def test_server_error_is_not_retried_as_parameter_compatibility(self):
+        def responder(_kwargs, _call_number):
+            raise _CompatError('Internal server error mentioning max_tokens', status_code=500)
+
+        client = _FakeClient(responder=responder)
+
+        with self.assertRaises(_CompatError):
+            utils.openai_chat_create_with_thinking_control(client, _base_kwargs())
+
+        self.assertEqual(len(client.completions.calls), 1)
+
+
+class OpenAIResponseCompatibilityTests(unittest.TestCase):
+    @staticmethod
+    def _make_requester(client):
+        requester = LLMRequester.__new__(LLMRequester)
+        requester.client = client
+        requester.openai_config = {
+            'OPENAI_MODEL_NAME': 'test-model',
+            'OPENAI_THINKING_ENABLED': False,
+        }
+        requester._log_lock = threading.Lock()
+        requester._capability_lock = threading.Lock()
+        requester._json_mode_disabled = False
+        requester.logger = logging.getLogger('test_translation_compatibility')
+        return requester
+
+    def test_extracts_mapping_message_and_nested_text_content_parts(self):
+        message = {
+            'content': [
+                {'type': 'text', 'text': {'value': '{"translations":'}},
+                {'type': 'text', 'text': '["你好"]}'},
+            ]
+        }
+
+        self.assertEqual(
+            utils.extract_chat_message_json(message),
+            {'translations': ['你好']},
+        )
+
+    def test_translation_parser_accepts_top_level_array(self):
+        requester = LLMRequester.__new__(LLMRequester)
+        requester._log_lock = threading.Lock()
+        requester.logger = logging.getLogger('test_translation_array')
+
+        parsed = requester._parse_structured_translation_result(
+            {'content': '["你好", "世界"]'}, 2, 'array',
+        )
+
+        self.assertEqual(parsed, ['你好', '世界'])
+
+    def test_translation_parser_accepts_result_objects(self):
+        requester = LLMRequester.__new__(LLMRequester)
+        requester._log_lock = threading.Lock()
+        requester.logger = logging.getLogger('test_translation_result_objects')
+
+        parsed = requester._parse_structured_translation_result(
+            {
+                'content': (
+                    '{"results":['
+                    '{"translated_text":"第一句"},'
+                    '{"translation":"第二句"}'
+                    ']}'
+                )
+            },
+            2,
+            'objects',
+        )
+
+        self.assertEqual(parsed, ['第一句', '第二句'])
+
+    def test_translation_parser_accepts_numbered_plain_text(self):
+        requester = LLMRequester.__new__(LLMRequester)
+        requester._log_lock = threading.Lock()
+        requester.logger = logging.getLogger('test_translation_numbered')
+
+        parsed = requester._parse_structured_translation_result(
+            {'content': '1. 第一句\n2. 第二句'}, 2, 'numbered',
+        )
+
+        self.assertEqual(parsed, ['第一句', '第二句'])
+
+    def test_unparseable_json_mode_retries_plain_and_reuses_working_mode(self):
+        def responder(kwargs, call_number):
+            if call_number == 1:
+                content = 'Sorry,\nI cannot return that format.'
+            else:
+                content = '{"translations":["你好"]}'
+            return SimpleNamespace(
+                choices=[SimpleNamespace(message={'content': content})]
+            )
+
+        client = _FakeClient(responder=responder)
+        requester = self._make_requester(client)
+
+        first = requester._request_translation_result(
+            model_name='test-model',
+            system_prompt='Translate and return JSON.',
+            user_prompt='hello',
+            expected_count=1,
+            batch_id='first',
+            scene_name='subtitle_test',
+        )
+        second = requester._request_translation_result(
+            model_name='test-model',
+            system_prompt='Translate and return JSON.',
+            user_prompt='hello',
+            expected_count=1,
+            batch_id='second',
+            scene_name='subtitle_test',
+        )
+
+        self.assertEqual(first, ['你好'])
+        self.assertEqual(second, ['你好'])
+        self.assertEqual(len(client.completions.calls), 3)
+        self.assertIn('response_format', client.completions.calls[0])
+        self.assertNotIn('response_format', client.completions.calls[1])
+        self.assertNotIn('response_format', client.completions.calls[2])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_openai_chat_compatibility.py
+++ b/tests/test_openai_chat_compatibility.py
@@ -52,6 +52,7 @@ class OpenAIChatCompatibilityTests(unittest.TestCase):
     def setUp(self):
         with utils._OPENAI_COMPATIBILITY_LOCK:
             utils._OPENAI_COMPATIBILITY_CACHE.clear()
+            utils._OPENAI_COMPATIBILITY_WARNED.clear()
 
     def test_non_deepseek_request_does_not_receive_private_thinking_parameter(self):
         client = _FakeClient()
@@ -296,6 +297,65 @@ class OpenAIChatCompatibilityTests(unittest.TestCase):
 
         self.assertEqual(len(client.completions.calls), 1)
 
+    def test_generic_schema_error_falls_back_to_minimal_request_and_caches_success(self):
+        def responder(kwargs, _call_number):
+            if set(kwargs) != {'model', 'messages'}:
+                raise _CompatError('Param Incorrect: request schema validation failed')
+            roles = [message['role'] for message in kwargs['messages']]
+            if roles != ['user']:
+                raise _CompatError('Param Incorrect: message schema validation failed')
+            return SimpleNamespace(choices=[])
+
+        client = _FakeClient(responder=responder)
+
+        utils.openai_chat_create_with_thinking_control(client, _base_kwargs())
+        utils.openai_chat_create_with_thinking_control(client, _base_kwargs())
+
+        self.assertEqual(len(client.completions.calls), 3)
+        minimal_call = client.completions.calls[1]
+        self.assertEqual(set(minimal_call), {'model', 'messages'})
+        self.assertEqual(
+            [message['role'] for message in minimal_call['messages']],
+            ['user'],
+        )
+        self.assertIn('Return JSON only.', minimal_call['messages'][0]['content'])
+        self.assertEqual(set(client.completions.calls[2]), {'model', 'messages'})
+
+    def test_failed_compatibility_attempt_is_not_cached(self):
+        def failing_responder(kwargs, _call_number):
+            if 'response_format' in kwargs:
+                raise _CompatError("Unsupported parameter: 'response_format'")
+            raise _CompatError('Incorrect API key provided', status_code=401)
+
+        failing_client = _FakeClient(responder=failing_responder)
+        with self.assertRaises(_CompatError):
+            utils.openai_chat_create_with_thinking_control(
+                failing_client,
+                _base_kwargs(),
+            )
+
+        succeeding_client = _FakeClient()
+        utils.openai_chat_create_with_thinking_control(
+            succeeding_client,
+            _base_kwargs(),
+        )
+
+        self.assertIn('response_format', succeeding_client.completions.calls[0])
+
+    def test_generic_5xx_schema_text_does_not_trigger_minimal_retry(self):
+        def responder(_kwargs, _call_number):
+            raise _CompatError(
+                'Internal server error: request schema unavailable',
+                status_code=500,
+            )
+
+        client = _FakeClient(responder=responder)
+
+        with self.assertRaises(_CompatError):
+            utils.openai_chat_create_with_thinking_control(client, _base_kwargs())
+
+        self.assertEqual(len(client.completions.calls), 1)
+
 
 class OpenAIResponseCompatibilityTests(unittest.TestCase):
     @staticmethod
@@ -323,6 +383,18 @@ class OpenAIResponseCompatibilityTests(unittest.TestCase):
         self.assertEqual(
             utils.extract_chat_message_json(message),
             {'translations': ['你好']},
+        )
+
+    def test_normalizes_full_chat_completions_url_for_openai_sdk(self):
+        self.assertEqual(
+            utils.normalize_openai_base_url(
+                'https://gateway.example/custom/v1/chat/completions/'
+            ),
+            'https://gateway.example/custom/v1',
+        )
+        self.assertEqual(
+            utils.normalize_openai_base_url('https://gateway.example/custom/v1/'),
+            'https://gateway.example/custom/v1',
         )
 
     def test_translation_parser_accepts_top_level_array(self):

--- a/tests/test_openai_chat_compatibility.py
+++ b/tests/test_openai_chat_compatibility.py
@@ -102,6 +102,60 @@ class OpenAIChatCompatibilityTests(unittest.TestCase):
         self.assertIn('extra_body', client.completions.calls[0])
         self.assertNotIn('extra_body', client.completions.calls[1])
 
+    def test_qwen_dashscope_uses_enable_thinking_parameter(self):
+        client = _FakeClient(base_url='https://dashscope.aliyuncs.com/compatible-mode/v1')
+
+        utils.openai_chat_create_with_thinking_control(
+            client, _base_kwargs(model='qwen-plus'), thinking_enabled=False,
+        )
+
+        self.assertEqual(
+            client.completions.calls[0]['extra_body'],
+            {'enable_thinking': False},
+        )
+
+    def test_qwen_vllm_uses_chat_template_kwargs(self):
+        client = _FakeClient(base_url='http://model-server.example/v1')
+
+        utils.openai_chat_create_with_thinking_control(
+            client, _base_kwargs(model='Qwen/Qwen3-8B'), thinking_enabled=False,
+        )
+
+        self.assertEqual(
+            client.completions.calls[0]['extra_body'],
+            {'chat_template_kwargs': {'enable_thinking': False}},
+        )
+
+    def test_qwen_thinking_rejection_retries_without_private_parameter(self):
+        def responder(kwargs, _call_number):
+            if 'extra_body' in kwargs:
+                raise _CompatError("Unknown parameter: 'enable_thinking'")
+            return SimpleNamespace(choices=[])
+
+        client = _FakeClient(
+            base_url='https://dashscope.aliyuncs.com/compatible-mode/v1',
+            responder=responder,
+        )
+
+        utils.openai_chat_create_with_thinking_control(
+            client, _base_kwargs(model='qwen-plus'), thinking_enabled=False,
+        )
+
+        self.assertEqual(len(client.completions.calls), 2)
+        self.assertNotIn('extra_body', client.completions.calls[1])
+
+    def test_mimo_uses_strict_disabled_thinking_object(self):
+        client = _FakeClient(base_url='https://api.xiaomimimo.com/v1')
+
+        utils.openai_chat_create_with_thinking_control(
+            client, _base_kwargs(model='mimo-v2.5'), thinking_enabled=False,
+        )
+
+        self.assertEqual(
+            client.completions.calls[0]['extra_body'],
+            {'thinking': {'type': 'disabled'}},
+        )
+
     def test_retries_without_unsupported_response_format_and_caches_capability(self):
         def responder(kwargs, _call_number):
             if 'response_format' in kwargs:

--- a/tests/test_openai_chat_compatibility.py
+++ b/tests/test_openai_chat_compatibility.py
@@ -1,7 +1,9 @@
 import logging
 import threading
 import unittest
+from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
+from unittest.mock import patch
 
 from modules import utils
 from modules.subtitle_translator import LLMRequester
@@ -115,17 +117,41 @@ class OpenAIChatCompatibilityTests(unittest.TestCase):
             {'enable_thinking': False},
         )
 
-    def test_qwen_vllm_uses_chat_template_kwargs(self):
+    def test_qwen_on_unknown_vllm_endpoint_does_not_receive_private_parameter(self):
         client = _FakeClient(base_url='http://model-server.example/v1')
 
         utils.openai_chat_create_with_thinking_control(
             client, _base_kwargs(model='Qwen/Qwen3-8B'), thinking_enabled=False,
         )
 
-        self.assertEqual(
-            client.completions.calls[0]['extra_body'],
-            {'chat_template_kwargs': {'enable_thinking': False}},
+        self.assertNotIn('extra_body', client.completions.calls[0])
+
+    def test_qwen_proxy_hostname_does_not_trigger_private_parameter(self):
+        client = _FakeClient(base_url='https://qwen-proxy.example.com/v1')
+
+        utils.openai_chat_create_with_thinking_control(
+            client, _base_kwargs(model='unrelated-model'), thinking_enabled=False,
         )
+
+        self.assertNotIn('extra_body', client.completions.calls[0])
+
+    def test_openrouter_qwen_model_does_not_receive_dashscope_parameter(self):
+        client = _FakeClient(base_url='https://openrouter.ai/api/v1')
+
+        utils.openai_chat_create_with_thinking_control(
+            client, _base_kwargs(model='qwen/qwen3-235b-a22b'), thinking_enabled=False,
+        )
+
+        self.assertNotIn('extra_body', client.completions.calls[0])
+
+    def test_known_provider_requires_matching_model_family(self):
+        client = _FakeClient(base_url='https://api.xiaomimimo.com/v1')
+
+        utils.openai_chat_create_with_thinking_control(
+            client, _base_kwargs(model='unrelated-model'), thinking_enabled=False,
+        )
+
+        self.assertNotIn('extra_body', client.completions.calls[0])
 
     def test_qwen_thinking_rejection_retries_without_private_parameter(self):
         def responder(kwargs, _call_number):
@@ -254,6 +280,33 @@ class OpenAIChatCompatibilityTests(unittest.TestCase):
         )
         self.assertIn('Return JSON only.', client.completions.calls[2]['messages'][0]['content'])
 
+    def test_bare_quoted_system_word_does_not_trigger_role_fallback(self):
+        def responder(_kwargs, _call_number):
+            raise _CompatError("Unsupported metadata value 'system'")
+
+        client = _FakeClient(responder=responder)
+
+        with self.assertRaises(_CompatError):
+            utils.openai_chat_create_with_thinking_control(client, _base_kwargs())
+
+        self.assertEqual(len(client.completions.calls), 1)
+
+    def test_inline_instructions_creates_user_message_when_missing(self):
+        kwargs = {
+            'messages': [
+                {'role': 'system', 'content': 'Return JSON only.'},
+                {'role': 'assistant', 'content': 'Previous output'},
+            ]
+        }
+
+        utils._inline_instruction_messages(kwargs)
+
+        self.assertEqual(kwargs['messages'][0], {
+            'role': 'user',
+            'content': 'Return JSON only.',
+        })
+        self.assertEqual(kwargs['messages'][1]['role'], 'assistant')
+
     def test_multiple_explicit_parameter_errors_are_adapted_sequentially(self):
         def responder(kwargs, _call_number):
             if 'response_format' in kwargs:
@@ -289,6 +342,17 @@ class OpenAIChatCompatibilityTests(unittest.TestCase):
     def test_server_error_is_not_retried_as_parameter_compatibility(self):
         def responder(_kwargs, _call_number):
             raise _CompatError('Internal server error mentioning max_tokens', status_code=500)
+
+        client = _FakeClient(responder=responder)
+
+        with self.assertRaises(_CompatError):
+            utils.openai_chat_create_with_thinking_control(client, _base_kwargs())
+
+        self.assertEqual(len(client.completions.calls), 1)
+
+    def test_not_found_is_not_retried_as_parameter_compatibility(self):
+        def responder(_kwargs, _call_number):
+            raise _CompatError("Unknown parameter: 'response_format'", status_code=404)
 
         client = _FakeClient(responder=responder)
 
@@ -356,6 +420,54 @@ class OpenAIChatCompatibilityTests(unittest.TestCase):
 
         self.assertEqual(len(client.completions.calls), 1)
 
+    def test_fallback_warning_includes_scene_name(self):
+        def responder(kwargs, _call_number):
+            if 'response_format' in kwargs:
+                raise _CompatError("Unsupported parameter: 'response_format'")
+            return SimpleNamespace(choices=[])
+
+        client = _FakeClient(responder=responder)
+        logger = logging.getLogger('test_openai_compat_scene')
+
+        with self.assertLogs(logger, level='WARNING') as captured:
+            utils.openai_chat_create_with_thinking_control(
+                client,
+                _base_kwargs(),
+                logger=logger,
+                scene_name='subtitle_translation',
+            )
+
+        self.assertIn('[subtitle_translation]', captured.output[0])
+
+    def test_cached_capabilities_expire(self):
+        key = 'https://gateway.example/v1:test-model'
+        with patch('modules.utils.time.monotonic', return_value=100.0):
+            utils._cache_compatibility_actions(key, {'drop_response_format'})
+            self.assertEqual(
+                utils._get_cached_compatibility_actions(key),
+                {'drop_response_format'},
+            )
+
+        with patch(
+            'modules.utils.time.monotonic',
+            return_value=100.0 + utils._OPENAI_COMPATIBILITY_CACHE_TTL_SECONDS + 1,
+        ):
+            self.assertEqual(utils._get_cached_compatibility_actions(key), set())
+
+    def test_concurrent_cache_reads_and_writes_preserve_actions(self):
+        key = 'https://gateway.example/v1:concurrent-model'
+        actions = ('drop_response_format', 'drop_temperature')
+
+        def update_cache(index):
+            utils._cache_compatibility_actions(key, {actions[index % 2]})
+            return utils._get_cached_compatibility_actions(key)
+
+        with ThreadPoolExecutor(max_workers=8) as executor:
+            results = list(executor.map(update_cache, range(64)))
+
+        self.assertTrue(all(isinstance(result, set) for result in results))
+        self.assertEqual(utils._get_cached_compatibility_actions(key), set(actions))
+
 
 class OpenAIResponseCompatibilityTests(unittest.TestCase):
     @staticmethod
@@ -396,6 +508,15 @@ class OpenAIResponseCompatibilityTests(unittest.TestCase):
             utils.normalize_openai_base_url('https://gateway.example/custom/v1/'),
             'https://gateway.example/custom/v1',
         )
+
+    def test_base_url_with_query_is_preserved_and_warned(self):
+        url = 'https://azure.example/openai/deployments/demo/chat/completions?api-version=2024-10-21'
+
+        with self.assertLogs(utils._OPENAI_URL_LOGGER, level='WARNING') as captured:
+            normalized = utils.normalize_openai_base_url(url)
+
+        self.assertEqual(normalized, url)
+        self.assertIn('含查询参数', captured.output[0])
 
     def test_translation_parser_accepts_top_level_array(self):
         requester = LLMRequester.__new__(LLMRequester)
@@ -475,6 +596,30 @@ class OpenAIResponseCompatibilityTests(unittest.TestCase):
         self.assertIn('response_format', client.completions.calls[0])
         self.assertNotIn('response_format', client.completions.calls[1])
         self.assertNotIn('response_format', client.completions.calls[2])
+
+    def test_valid_empty_translation_does_not_retry_plain_json(self):
+        def responder(_kwargs, _call_number):
+            return SimpleNamespace(
+                choices=[SimpleNamespace(
+                    message={'content': '{"translations":[""]}'},
+                )]
+            )
+
+        client = _FakeClient(responder=responder)
+        requester = self._make_requester(client)
+
+        result = requester._request_translation_result(
+            model_name='test-model',
+            system_prompt='Translate and return JSON.',
+            user_prompt='hello',
+            expected_count=1,
+            batch_id='empty',
+            scene_name='subtitle_test',
+        )
+
+        self.assertEqual(result, [''])
+        self.assertEqual(len(client.completions.calls), 1)
+        self.assertFalse(requester._json_mode_disabled)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## 概述

修复使用 Qwen、MiMo 及其他 OpenAI 兼容模型/网关时，字幕和元数据翻译容易因思考开关、请求 schema、参数名或响应格式差异失败的问题。实现以协议能力协商为核心，不依赖穷举模型名单。

参考协议：
- OpenAI Chat Completions 参数支持会因模型而异，`max_tokens` 已弃用且不兼容 o-series，新模型的指令角色也存在差异：https://developers.openai.com/api/reference/cli/resources/chat/subresources/completions/methods/create
- Qwen 官方文档：DashScope 使用 `extra_body.enable_thinking`，Qwen/vLLM 使用 `chat_template_kwargs.enable_thinking`：https://help.aliyun.com/en/model-studio/deep-thinking
- MiMo 官方提供 OpenAI 兼容端点（当前模型如 `mimo-v2.5`）：https://github.com/XiaomiMiMo/awesome-mimo-agent/blob/main/docs/codex.md

## 底层兼容策略

- 所有文本 AI 功能统一经过同一 Chat Completions 兼容层（元数据、标签、分区、字幕翻译、字幕质检、AI 分段）。
- 先发送功能完整的请求；遇到明确的 400/404/422 参数错误时逐项协商：
  - 移除不支持的思考控制、`response_format`、`temperature`；
  - 自动切换 `max_tokens` / `max_completion_tokens`；
  - 自动切换 `system` → `developer` → 合并到 `user`。
- 对仅返回 `Param Incorrect` / schema validation 等笼统 400/422 的严格网关，最终降级为只含 `model + user messages` 的最小标准请求。
- 鉴权、限流、配额、连接和 5xx 不会被误判为参数兼容问题。
- 能力组合只有在降级请求真正成功后才按“端点完整路径 + 模型”缓存；失败尝试不会污染后续任务。
- 可直接填写 API 根地址或完整 `/chat/completions` 地址，后者会自动规范化。

## 厂商扩展与响应兼容

- 已知思考协议只作为可选优化：DeepSeek、Qwen DashScope、Qwen 官方 vLLM、MiMo 会自动使用各自禁用参数；若网关不接受会自动移除，不影响基础调用。
- 支持字典消息、多段文本、顶层 JSON 数组、常见 `results` / `data` 包装、对象数组和编号逐行译文。
- 字幕 JSON 模式返回不可解析内容时，自动使用纯文本 JSON 约束重试；成功后复用该模式。
- 设置页和 README 同步说明 Base URL、能力协商和思考开关语义。

## 验证

- 新增 25 项兼容性回归测试：逐参数协商、通用最小请求、成功后缓存、失败不污染、DeepSeek/Qwen/MiMo 协议、错误分类、URL 规范化、消息/字幕解析和纯文本重试。
- 全量测试：`343 passed, 21 subtests passed`。