### PR TITLE
feat(ai): 增加 Responses API 兼容

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ python app.py
 - `FIXED_PARTITION_ID` / `FIXED_PARTITION_ID_BILIBILI`：固定分区
 - `YOUTUBE_UPLOADER_AS_FIRST_TAG`：将上传者作为首标签
 
-AI 文本功能统一使用 OpenAI Chat Completions 兼容接口。`OPENAI_BASE_URL` 可填写 API 根地址（例如 `https://api.openai.com/v1`）或完整的 `/chat/completions` 地址，后者会自动规范化。当兼容服务不支持 `response_format`、token 上限参数、自定义 `temperature` 或特定指令角色时，系统会根据端点实际错误逐级协商；若网关只返回笼统的请求 schema 错误，则降级为仅含 `model + user messages` 的最小标准请求。能力只在降级请求成功后按端点和模型缓存。
+AI 文本功能同时兼容 OpenAI Chat Completions 与 Responses API。`OPENAI_BASE_URL` 可填写 API 根地址（例如 `https://api.openai.com/v1`，默认使用 Chat Completions）或完整的 `/chat/completions`、`/responses` 地址；填写完整端点时会自动选择协议并规范化。Responses 请求会自动转换消息、JSON 输出格式和 token 上限参数，返回值也会归一化供翻译、质检、智能分段等现有功能使用。当兼容服务不支持 `response_format`、token 上限参数、自定义 `temperature` 或特定指令角色时，系统会根据端点实际错误逐级协商；若网关只返回笼统的请求 schema 错误，则降级为仅含 `model + user messages` 的最小标准请求。能力只在降级请求成功后按端点、协议和模型缓存。
 
 ### 字幕处理
 

--- a/modules/ai_fallback_client.py
+++ b/modules/ai_fallback_client.py
@@ -19,7 +19,7 @@ AI 客户端协议与兜底层：兼容 Chat Completions / Responses API，并�
 import logging
 import re
 from types import SimpleNamespace
-from urllib.parse import urlparse
+from urllib.parse import parse_qsl, urlparse, urlunparse
 
 import httpx
 from openai import OpenAI, APIConnectionError, APITimeoutError, APIStatusError
@@ -72,9 +72,20 @@ def _api_mode_from_url(base_url):
     return 'responses' if path.endswith('/responses') else 'chat_completions'
 
 
+def _base_url_and_default_query(base_url):
+    """拆分完整端点查询参数，避免 SDK 把资源路径追加到查询字符串之后。"""
+    value = str(base_url or '').strip()
+    if not value:
+        return '', {}
+    parsed = urlparse(value)
+    default_query = dict(parse_qsl(parsed.query, keep_blank_values=True))
+    normalized_value = urlunparse(parsed._replace(query='', fragment=''))
+    return normalize_openai_base_url(normalized_value), default_query
+
+
 def _build_endpoint(prefix, cfg, default_model="gpt-3.5-turbo",
                     default_base="https://api.openai.com/v1",
-                    default_api_mode='chat_completions'):
+                    default_api_mode='chat_completions', default_query=None):
     """从配置字典中按前缀读取一个端点配置。无 API key 时返回 None。"""
     api_key = (cfg.get(prefix + "API_KEY") or "").strip()
     if not api_key:
@@ -84,10 +95,11 @@ def _build_endpoint(prefix, cfg, default_model="gpt-3.5-turbo",
     configured_base = str(cfg.get(prefix + "BASE_URL") or '').strip()
     if configured_base:
         api_mode = _api_mode_from_url(configured_base)
-        base_url = normalize_openai_base_url(configured_base)
+        base_url, endpoint_query = _base_url_and_default_query(configured_base)
     else:
         api_mode = default_api_mode
         base_url = normalize_openai_base_url(default_base)
+        endpoint_query = dict(default_query or {})
     model = str(cfg.get(prefix + "MODEL_NAME") or "").strip() or str(default_model).strip()
     timeout = cfg.get("OPENAI_TIMEOUT_SECONDS", 600)
     try:
@@ -103,6 +115,7 @@ def _build_endpoint(prefix, cfg, default_model="gpt-3.5-turbo",
         "base_url": base_url,
         "model": model,
         "api_mode": api_mode,
+        "default_query": endpoint_query,
         "timeout": timeout,
         "label": f"{prefix.rstrip('_').lower()}:{base_url}",
     }
@@ -157,6 +170,8 @@ def _make_raw_client(ep, multi_endpoint=False):
     opts = {}
     if ep.get("base_url"):
         opts["base_url"] = ep["base_url"]
+    if ep.get("default_query"):
+        opts["default_query"] = dict(ep["default_query"])
     raw_to = ep.get("timeout")
     try:
         to = float(raw_to) if raw_to is not None else 600.0
@@ -546,10 +561,11 @@ def get_ai_client(openai_config):
     fb_default_base = (primary or {}).get("base_url") or "https://api.openai.com/v1"
     fb_default_model = (primary or {}).get("model") or "gpt-3.5-turbo"
     fb_default_api_mode = (primary or {}).get('api_mode') or 'chat_completions'
+    fb_default_query = (primary or {}).get('default_query') or {}
     fb = _build_endpoint(
         "FALLBACK_OPENAI_", openai_config,
         default_base=fb_default_base, default_model=fb_default_model,
-        default_api_mode=fb_default_api_mode,
+        default_api_mode=fb_default_api_mode, default_query=fb_default_query,
     )
     if fb:
         endpoints.append(fb)

--- a/modules/ai_fallback_client.py
+++ b/modules/ai_fallback_client.py
@@ -1,12 +1,14 @@
 """
-AI 客户端兜底层：当主 OpenAI 兼容端点不可用时，自动切换到用户配置的备用端点。
+AI 客户端协议与兜底层：兼容 Chat Completions / Responses API，并在主端点
+不可用时自动切换到用户配置的备用端点。
 
 设计要点（与具体 provider 无关，仅依赖 OpenAI 兼容协议）：
 - 主端点来自传入配置中的 OPENAI_*。
 - 备用端点来自配置中的 FALLBACK_OPENAI_*（可选；未配置则退化为单端点，行为与原先一致）。
 - 仅当主端点出现「连接错误 / 超时 / 5xx」这类“可用性”错误时才切换兜底；
   4xx（请求本身的问题，例如 JSON 模式不被某些网关支持）不切换，交由上层既有逻辑处理。
-- 调用方式与 openai.OpenAI 完全兼容：client.chat.completions.create(...)。
+- 上层继续使用 client.chat.completions.create(...)；当配置地址以 /responses 结尾时，
+  本层自动转换请求并调用 client.responses.create(...)，再把输出归一化为 chat 结构。
 - 每个端点的 model 以自身配置为准（主端点用 OPENAI_MODEL_NAME，兜底端点用
   FALLBACK_OPENAI_MODEL_NAME）；兜底端点的 base_url / model 若留空则**继承主端点**，
   与设置页「留空则沿用主端点」语义一致，而不是回退到硬编码的官方默认值。
@@ -16,6 +18,8 @@ AI 客户端兜底层：当主 OpenAI 兼容端点不可用时，自动切换到
 """
 import logging
 import re
+from types import SimpleNamespace
+from urllib.parse import urlparse
 
 import httpx
 from openai import OpenAI, APIConnectionError, APITimeoutError, APIStatusError
@@ -56,16 +60,33 @@ _CONNECTION_TEXT_SIGNALS = (
 )
 
 
+def _api_mode_from_url(base_url):
+    """完整 /responses 地址选择 Responses API；根地址保持原 Chat 默认。"""
+    value = str(base_url or '').strip()
+    if not value:
+        return 'chat_completions'
+    try:
+        path = urlparse(value).path.rstrip('/').lower()
+    except Exception:
+        path = value.rstrip('/').lower()
+    return 'responses' if path.endswith('/responses') else 'chat_completions'
+
+
 def _build_endpoint(prefix, cfg, default_model="gpt-3.5-turbo",
-                    default_base="https://api.openai.com/v1"):
+                    default_base="https://api.openai.com/v1",
+                    default_api_mode='chat_completions'):
     """从配置字典中按前缀读取一个端点配置。无 API key 时返回 None。"""
     api_key = (cfg.get(prefix + "API_KEY") or "").strip()
     if not api_key:
         return None
-    # 兼容设置 API 根地址或完整的 /chat/completions 地址。规范化集中在统一
+    # 兼容设置 API 根地址或完整的 /chat/completions、/responses 地址。规范化集中在统一
     # 客户端入口，确保单端点、主端点和兜底端点采用完全一致的 URL 语义。
-    base_url = normalize_openai_base_url(cfg.get(prefix + "BASE_URL"))
-    if not base_url:
+    configured_base = str(cfg.get(prefix + "BASE_URL") or '').strip()
+    if configured_base:
+        api_mode = _api_mode_from_url(configured_base)
+        base_url = normalize_openai_base_url(configured_base)
+    else:
+        api_mode = default_api_mode
         base_url = normalize_openai_base_url(default_base)
     model = str(cfg.get(prefix + "MODEL_NAME") or "").strip() or str(default_model).strip()
     timeout = cfg.get("OPENAI_TIMEOUT_SECONDS", 600)
@@ -81,6 +102,7 @@ def _build_endpoint(prefix, cfg, default_model="gpt-3.5-turbo",
         "api_key": api_key,
         "base_url": base_url,
         "model": model,
+        "api_mode": api_mode,
         "timeout": timeout,
         "label": f"{prefix.rstrip('_').lower()}:{base_url}",
     }
@@ -214,6 +236,167 @@ class _ChatProxy:
         self.completions = _CompletionsProxy(parent)
 
 
+def _value(obj, key, default=None):
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+def _content_text(content):
+    """把 Chat 消息内容转换成适合 Responses instructions 的纯文本。"""
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return str(content or '')
+    parts = []
+    for part in content:
+        part_type = _value(part, 'type', '')
+        if part_type in {'text', 'input_text', 'output_text'}:
+            text = _value(part, 'text', '')
+            if isinstance(text, dict):
+                text = text.get('value', '')
+            parts.append(str(text or ''))
+    return ''.join(parts)
+
+
+def _responses_message_content(content):
+    """将 Chat 多模态 content parts 转成 Responses 输入 content parts。"""
+    if not isinstance(content, list):
+        return content
+    converted = []
+    for part in content:
+        if not isinstance(part, dict):
+            converted.append(part)
+            continue
+        part_type = part.get('type')
+        if part_type == 'text':
+            converted.append({'type': 'input_text', 'text': part.get('text', '')})
+        elif part_type == 'image_url':
+            image = part.get('image_url')
+            if isinstance(image, dict):
+                converted_part = {
+                    'type': 'input_image',
+                    'image_url': image.get('url'),
+                }
+                if image.get('detail'):
+                    converted_part['detail'] = image['detail']
+            else:
+                converted_part = {'type': 'input_image', 'image_url': image}
+            converted.append(converted_part)
+        else:
+            converted.append(dict(part))
+    return converted
+
+
+def _responses_text_format(response_format):
+    """Responses 的 json_schema 格式比 Chat 少一层 json_schema 包装。"""
+    if not isinstance(response_format, dict):
+        return response_format
+    if response_format.get('type') != 'json_schema':
+        return dict(response_format)
+    schema_config = response_format.get('json_schema')
+    if not isinstance(schema_config, dict):
+        return dict(response_format)
+    return {'type': 'json_schema', **schema_config}
+
+
+def _responses_create_kwargs(chat_kwargs):
+    """将项目使用的 Chat Completions 参数转换为 Responses API 参数。"""
+    result = dict(chat_kwargs or {})
+    messages = result.pop('messages', []) or []
+    instructions = []
+    response_input = []
+    for message in messages:
+        role = _value(message, 'role', 'user')
+        content = _value(message, 'content', '')
+        if role in {'system', 'developer'}:
+            text = _content_text(content).strip()
+            if text:
+                instructions.append(text)
+            continue
+        response_input.append({
+            'role': role,
+            'content': _responses_message_content(content),
+        })
+    if instructions:
+        result['instructions'] = '\n\n'.join(instructions)
+    result['input'] = response_input
+
+    token_limit = result.pop('max_completion_tokens', None)
+    if token_limit is None:
+        token_limit = result.pop('max_tokens', None)
+    else:
+        result.pop('max_tokens', None)
+    if token_limit is not None:
+        result['max_output_tokens'] = token_limit
+
+    response_format = result.pop('response_format', None)
+    if response_format is not None:
+        text_config = result.get('text')
+        if not isinstance(text_config, dict):
+            text_config = {}
+        else:
+            text_config = dict(text_config)
+        text_config['format'] = _responses_text_format(response_format)
+        result['text'] = text_config
+    return result
+
+
+def _responses_output_text(response):
+    """兼容 SDK 对象和普通字典，提取 Responses API 的所有文本输出。"""
+    output_text = _value(response, 'output_text')
+    if isinstance(output_text, str) and output_text:
+        return output_text
+
+    parts = []
+    for item in _value(response, 'output', []) or []:
+        if _value(item, 'type') != 'message':
+            continue
+        for content in _value(item, 'content', []) or []:
+            content_type = _value(content, 'type')
+            if content_type == 'output_text':
+                parts.append(str(_value(content, 'text', '') or ''))
+            elif content_type == 'refusal':
+                parts.append(str(_value(content, 'refusal', '') or ''))
+    return ''.join(parts)
+
+
+def _as_chat_completion(response):
+    """把 Responses API 结果适配为项目既有的 choices[0].message 结构。"""
+    message = SimpleNamespace(role='assistant', content=_responses_output_text(response))
+    return SimpleNamespace(
+        id=_value(response, 'id'),
+        model=_value(response, 'model'),
+        usage=_value(response, 'usage'),
+        choices=[SimpleNamespace(index=0, message=message, finish_reason=None)],
+        raw_response=response,
+    )
+
+
+def _create_on_endpoint(raw_client, endpoint, chat_kwargs):
+    if endpoint.get('api_mode') == 'responses':
+        response = raw_client.responses.create(**_responses_create_kwargs(chat_kwargs))
+        return _as_chat_completion(response)
+    return raw_client.chat.completions.create(**chat_kwargs)
+
+
+class ResponsesChatClient:
+    """为单一 Responses 端点提供项目既有的 chat.completions 调用外观。"""
+
+    api_mode = 'responses'
+
+    def __init__(self, raw_client, endpoint):
+        self._raw = raw_client
+        self._endpoint = endpoint
+        self.base_url = getattr(raw_client, 'base_url', None) or endpoint.get('base_url', '')
+        self.chat = _ChatProxy(self)
+
+    def _create(self, kwargs):
+        call_kwargs = dict(kwargs)
+        call_kwargs['model'] = self._endpoint['model']
+        return _create_on_endpoint(self._raw, self._endpoint, call_kwargs)
+
+
 class FallbackChatClient:
     """按顺序尝试多个 OpenAI 兼容端点；前一个“不可用”时自动切到下一个。"""
 
@@ -224,6 +407,7 @@ class FallbackChatClient:
         # 兼容统一请求层基于 client.base_url 识别服务商、隔离能力缓存的约定。
         # 故障转移请求总是先访问主端点，因此这里暴露主端点的规范化地址。
         self.base_url = getattr(self._raw[0], "base_url", None) or endpoints[0].get("base_url", "")
+        self.api_mode = endpoints[0].get('api_mode', 'chat_completions')
         # 兼容 client.chat.completions.create(...) 调用链
         self.chat = _ChatProxy(self)
 
@@ -253,7 +437,7 @@ class FallbackChatClient:
             if merged_extra:
                 call_kwargs["extra_body"] = merged_extra
             try:
-                return self._raw[idx].chat.completions.create(**call_kwargs)
+                return _create_on_endpoint(self._raw[idx], ep, call_kwargs)
             except Exception as exc:  # noqa: BLE001
                 if _is_unavailable_error(exc):
                     logger.warning(
@@ -302,7 +486,8 @@ def get_ai_client(openai_config):
 
     - 若解析后存在 FALLBACK_OPENAI_API_KEY（可来自传入配置或全局配置），
       则返回带兜底能力的 FallbackChatClient；
-    - 否则返回与原来一致的裸 OpenAI 客户端（行为完全不变）。
+    - 单一 Chat 端点返回与原来一致的裸 OpenAI 客户端；单一 Responses 端点
+      返回保留 chat.completions 调用外观的 ResponsesChatClient。
     - 仅当主端点出现「连接 / 超时 / 5xx」时才切换兜底；4xx 类请求错误不切换。
 
     Args:
@@ -317,9 +502,11 @@ def get_ai_client(openai_config):
     # 因此空字段继承主端点的 base_url / model，而不是回退到硬编码的官方默认值。
     fb_default_base = (primary or {}).get("base_url") or "https://api.openai.com/v1"
     fb_default_model = (primary or {}).get("model") or "gpt-3.5-turbo"
+    fb_default_api_mode = (primary or {}).get('api_mode') or 'chat_completions'
     fb = _build_endpoint(
         "FALLBACK_OPENAI_", openai_config,
         default_base=fb_default_base, default_model=fb_default_model,
+        default_api_mode=fb_default_api_mode,
     )
     if fb:
         endpoints.append(fb)
@@ -328,5 +515,8 @@ def get_ai_client(openai_config):
         raise RuntimeError("未配置任何可用 AI 端点（OPENAI_API_KEY 为空）")
     if len(endpoints) == 1:
         # 单端点（无兜底）：保留 SDK 默认重试与用户配置超时，行为与原先一致
-        return _make_raw_client(endpoints[0], multi_endpoint=False)
+        raw_client = _make_raw_client(endpoints[0], multi_endpoint=False)
+        if endpoints[0].get('api_mode') == 'responses':
+            return ResponsesChatClient(raw_client, endpoints[0])
+        return raw_client
     return FallbackChatClient(endpoints)

--- a/modules/ai_fallback_client.py
+++ b/modules/ai_fallback_client.py
@@ -303,6 +303,10 @@ def _responses_text_format(response_format):
 def _responses_create_kwargs(chat_kwargs):
     """将项目使用的 Chat Completions 参数转换为 Responses API 参数。"""
     result = dict(chat_kwargs or {})
+    # Chat Completions 调用默认不创建可检索的服务端状态，而 Responses API
+    # 默认会保存响应。透明协议转换应保持原有数据留存语义；调用方显式传入
+    # store 时仍尊重其选择。
+    result.setdefault('store', False)
     messages = result.pop('messages', []) or []
     instructions = []
     response_input = []
@@ -373,9 +377,48 @@ def _as_chat_completion(response):
     )
 
 
+class ResponsesResultError(RuntimeError):
+    """Responses API 在成功 HTTP 响应体中报告的生成失败。"""
+
+    def __init__(self, response):
+        self.response_result = response
+        self.response_status = str(_value(response, 'status', '') or '').strip().lower()
+        error = _value(response, 'error')
+        self.code = str(_value(error, 'code', '') or '').strip().lower()
+        message = str(_value(error, 'message', '') or '').strip()
+        self.status_code = self._status_code_for_error(self.code)
+        detail = message or self.code or self.response_status or 'unknown error'
+        super().__init__(f'Responses API generation failed: {detail}')
+
+    @staticmethod
+    def _status_code_for_error(code):
+        """映射为现有 failover 判定可识别的近似 HTTP 状态码。"""
+        if not code:
+            return None
+        if 'timeout' in code:
+            return 504
+        if any(signal in code for signal in (
+            'server_error', 'internal_error', 'service_unavailable', 'overloaded',
+        )):
+            return 500
+        if 'rate_limit' in code:
+            return 429
+        # Responses 的其余已知错误（invalid_prompt / invalid_image 等）属于请求问题，
+        # 不应绕过当前端点切换到兜底端点重复发送相同请求。
+        return 400
+
+
+def _raise_for_responses_failure(response):
+    """Responses 可用 2xx 返回 failed + error；在归一化前将其恢复为异常语义。"""
+    status = str(_value(response, 'status', '') or '').strip().lower()
+    if status == 'failed' or _value(response, 'error') is not None:
+        raise ResponsesResultError(response)
+
+
 def _create_on_endpoint(raw_client, endpoint, chat_kwargs):
     if endpoint.get('api_mode') == 'responses':
         response = raw_client.responses.create(**_responses_create_kwargs(chat_kwargs))
+        _raise_for_responses_failure(response)
         return _as_chat_completion(response)
     return raw_client.chat.completions.create(**chat_kwargs)
 

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -297,7 +297,7 @@ def _coerce_bool(value, default=False):
 
 
 def normalize_openai_base_url(base_url) -> str:
-    """接受 API 根地址或完整 Chat Completions 地址，统一为 SDK 所需根地址。"""
+    """接受 API 根地址或完整生成端点地址，统一为 OpenAI SDK 所需根地址。"""
     value = safe_str(base_url).strip()
     if not value:
         return ''
@@ -307,7 +307,12 @@ def normalize_openai_base_url(base_url) -> str:
         )
         return value
     value = value.rstrip('/')
-    return re.sub(r'/chat/completions$', '', value, flags=re.IGNORECASE).rstrip('/')
+    return re.sub(
+        r'/(?:chat/completions|responses)$',
+        '',
+        value,
+        flags=re.IGNORECASE,
+    ).rstrip('/')
 
 
 def _compatibility_error_text(exc) -> str:
@@ -348,7 +353,10 @@ def _is_parameter_compatibility_error(exc, parameter: str) -> bool:
 
     parameter_signals = {
         'thinking': ('thinking', 'enable_thinking'),
-        'response_format': ('response_format', 'response format', 'json_object', 'json mode'),
+        'response_format': (
+            'response_format', 'response format', 'text.format',
+            'text.format.type', 'json_object', 'json mode',
+        ),
         'max_tokens': ('max_tokens', 'max tokens'),
         'max_completion_tokens': ('max_completion_tokens', 'max completion tokens'),
         'temperature': ('temperature',),
@@ -401,7 +409,11 @@ def _client_compatibility_key(client, create_kwargs) -> str:
     except Exception:
         endpoint = endpoint_value or 'unknown'
     model = safe_str((create_kwargs or {}).get('model'), default='unknown').strip().lower()
-    return f'{endpoint}:{model}'
+    api_mode = safe_str(
+        getattr(client, 'api_mode', 'chat_completions'),
+        default='chat_completions',
+    ).strip().lower()
+    return f'{endpoint}:{api_mode}:{model}'
 
 
 def _thinking_control_style(client, create_kwargs) -> str:

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -359,6 +359,7 @@ def _is_parameter_compatibility_error(exc, parameter: str) -> bool:
         ),
         'max_tokens': ('max_tokens', 'max tokens'),
         'max_completion_tokens': ('max_completion_tokens', 'max completion tokens'),
+        'max_output_tokens': ('max_output_tokens', 'max output tokens'),
         'temperature': ('temperature',),
         'system_role': (
             'system role', "role 'system'", 'role: system', 'messages[0].role',
@@ -492,7 +493,10 @@ def _cache_compatibility_actions(cache_key: str, discovered_actions) -> None:
             actions = set()
             _OPENAI_COMPATIBILITY_CACHE.pop(cache_key, None)
         actions.update(discovered_actions)
-        if 'use_max_completion_tokens' in discovered_actions:
+        if 'drop_max_output_tokens' in discovered_actions:
+            actions.discard('use_max_tokens')
+            actions.discard('use_max_completion_tokens')
+        elif 'use_max_completion_tokens' in discovered_actions:
             actions.discard('use_max_tokens')
         elif 'use_max_tokens' in discovered_actions:
             actions.discard('use_max_completion_tokens')
@@ -572,9 +576,12 @@ def _apply_compatibility_actions(create_kwargs, actions):
         _drop_thinking_control(adapted)
     if 'drop_response_format' in actions:
         adapted.pop('response_format', None)
-    if 'use_max_completion_tokens' in actions and 'max_tokens' in adapted:
+    if 'drop_max_output_tokens' in actions:
+        adapted.pop('max_tokens', None)
+        adapted.pop('max_completion_tokens', None)
+    elif 'use_max_completion_tokens' in actions and 'max_tokens' in adapted:
         adapted['max_completion_tokens'] = adapted.pop('max_tokens')
-    if 'use_max_tokens' in actions and 'max_completion_tokens' in adapted:
+    elif 'use_max_tokens' in actions and 'max_completion_tokens' in adapted:
         adapted['max_tokens'] = adapted.pop('max_completion_tokens')
     if 'drop_temperature' in actions:
         adapted.pop('temperature', None)
@@ -601,6 +608,7 @@ def _warn_compatibility_fallback(logger, cache_key: str, action: str, scene_name
         'drop_response_format': '不支持 JSON response_format，已改用提示词约束并解析文本 JSON',
         'use_max_completion_tokens': '不支持 max_tokens，已改用 max_completion_tokens',
         'use_max_tokens': '不支持 max_completion_tokens，已回退 max_tokens',
+        'drop_max_output_tokens': '不支持 Responses max_output_tokens，已使用模型默认输出上限',
         'drop_temperature': '不支持自定义 temperature，已使用模型默认值',
         'use_developer_role': '不支持 system role，已改用 developer role',
         'inline_instructions': '不支持独立指令角色，已将指令合并到 user 消息',
@@ -663,6 +671,11 @@ def openai_chat_create_with_thinking_control(
             ):
                 action = 'drop_response_format'
             elif (
+                ('max_tokens' in request_kwargs or 'max_completion_tokens' in request_kwargs)
+                and _is_parameter_compatibility_error(exc, 'max_output_tokens')
+            ):
+                action = 'drop_max_output_tokens'
+            elif (
                 'max_tokens' in request_kwargs
                 and _is_parameter_compatibility_error(exc, 'max_tokens')
             ):
@@ -706,6 +719,11 @@ def openai_chat_create_with_thinking_control(
                 discovered_actions.discard('use_max_tokens')
             elif action == 'use_max_tokens':
                 actions.discard('use_max_completion_tokens')
+                discovered_actions.discard('use_max_completion_tokens')
+            elif action == 'drop_max_output_tokens':
+                actions.discard('use_max_tokens')
+                actions.discard('use_max_completion_tokens')
+                discovered_actions.discard('use_max_tokens')
                 discovered_actions.discard('use_max_completion_tokens')
             if action == 'inline_instructions':
                 actions.discard('use_developer_role')

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ requests>=2.31,<3.0
 urllib3>=2.6.3,<3.0
 
 # AI and transcription stack: keep OpenAI/httpx within supported major lines.
-openai>=1.0,<3.0
+openai>=1.66.0,<3.0
 httpx>=0.27,<0.28
 numpy>=1.24,<3.0
 # silero-vad depends on torch/torchaudio; Dockerfile still installs CPU wheels explicitly.

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -688,7 +688,7 @@
                                                             <div class="form-group">
                                                                 <label for="openai-url" class="form-label">接口地址</label>
                                                                 <input type="text" id="openai-url" name="OPENAI_BASE_URL" value="{{ config.OPENAI_BASE_URL }}" class="form-control" placeholder="如 https://api.openai.com/v1">
-                                                                <p class="help-text mb-0 mt-2">填写 OpenAI 兼容 API 的根地址；若粘贴了完整 <code>/chat/completions</code> 地址，系统会自动规范化。请求参数和消息格式会按端点实际能力自动协商。</p>
+                                                                <p class="help-text mb-0 mt-2">填写 OpenAI 兼容 API 的根地址；也可粘贴完整 <code>/chat/completions</code> 或 <code>/responses</code> 地址，系统会自动选择并规范化协议。请求参数和消息格式会按端点实际能力自动协商。</p>
                                                             </div>
                                                         </div>
                                                         <div class="col-md-6">

--- a/tests/test_openai_responses_compatibility.py
+++ b/tests/test_openai_responses_compatibility.py
@@ -1,6 +1,9 @@
 import unittest
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
+
+import httpx
+from openai import OpenAI as SDKOpenAI
 
 from modules import ai_fallback_client as afc
 from modules import utils
@@ -57,8 +60,83 @@ class ResponsesUrlTests(unittest.TestCase):
 
         self.assertEqual(endpoint['api_mode'], 'chat_completions')
 
+    def test_full_responses_url_preserves_query_as_sdk_default_query(self):
+        endpoint = afc._build_endpoint('OPENAI_', {
+            'OPENAI_API_KEY': 'test-key',
+            'OPENAI_BASE_URL': (
+                'https://azure.example/openai/responses'
+                '?api-version=2025-04-01-preview'
+            ),
+        })
+
+        self.assertEqual(endpoint['api_mode'], 'responses')
+        self.assertEqual(endpoint['base_url'], 'https://azure.example/openai')
+        self.assertEqual(
+            endpoint['default_query'],
+            {'api-version': '2025-04-01-preview'},
+        )
+
+    def test_sdk_sends_query_after_responses_path(self):
+        seen_urls = []
+
+        def handler(request):
+            seen_urls.append(str(request.url))
+            return httpx.Response(200, request=request, json={
+                'id': 'resp_url',
+                'created_at': 0,
+                'error': None,
+                'incomplete_details': None,
+                'instructions': None,
+                'metadata': None,
+                'model': 'response-model',
+                'object': 'response',
+                'output': [],
+                'parallel_tool_calls': True,
+                'status': 'completed',
+                'temperature': 1,
+                'tool_choice': 'auto',
+                'tools': [],
+                'top_p': 1,
+            })
+
+        def make_sdk_client(**kwargs):
+            return SDKOpenAI(
+                http_client=httpx.Client(transport=httpx.MockTransport(handler)),
+                **kwargs,
+            )
+
+        config = {
+            'OPENAI_API_KEY': 'test-key',
+            'OPENAI_BASE_URL': (
+                'https://azure.example/openai/responses'
+                '?api-version=2025-04-01-preview'
+            ),
+            'OPENAI_MODEL_NAME': 'response-model',
+        }
+        with patch.object(afc, '_load_global_config', return_value={}), \
+             patch.object(afc, 'OpenAI', side_effect=make_sdk_client):
+            client = afc.get_ai_client(config)
+
+        client.chat.completions.create(
+            model='response-model',
+            messages=[{'role': 'user', 'content': 'hello'}],
+        )
+
+        self.assertEqual(
+            seen_urls,
+            [
+                'https://azure.example/openai/responses'
+                '?api-version=2025-04-01-preview'
+            ],
+        )
+
 
 class ResponsesRequestTests(unittest.TestCase):
+    def setUp(self):
+        with utils._OPENAI_COMPATIBILITY_LOCK:
+            utils._OPENAI_COMPATIBILITY_CACHE.clear()
+            utils._OPENAI_COMPATIBILITY_WARNED.clear()
+
     def _config(self, **overrides):
         config = {
             'OPENAI_API_KEY': 'test-key',
@@ -176,6 +254,40 @@ class ResponsesRequestTests(unittest.TestCase):
 
         self.assertIs(request['store'], True)
 
+    def test_unsupported_max_output_tokens_is_dropped_and_cached(self):
+        raw_response = {
+            'id': 'resp_token_fallback',
+            'status': 'completed',
+            'error': None,
+            'output': [{
+                'type': 'message',
+                'content': [{'type': 'output_text', 'text': 'ok'}],
+            }],
+        }
+        raw_client = _FakeRawClient(responses_result=raw_response)
+        raw_client.responses.create = MagicMock(side_effect=[
+            _StatusError('Unsupported parameter: max_output_tokens', 400),
+            raw_response,
+            raw_response,
+        ])
+        with patch.object(afc, '_load_global_config', return_value={}), \
+             patch.object(afc, '_make_raw_client', return_value=raw_client):
+            client = afc.get_ai_client(self._config())
+        kwargs = {
+            'model': 'response-model',
+            'messages': [{'role': 'user', 'content': 'hello'}],
+            'max_tokens': 256,
+        }
+
+        utils.openai_chat_create_with_thinking_control(client, kwargs)
+        utils.openai_chat_create_with_thinking_control(client, kwargs)
+
+        calls = [call.kwargs for call in raw_client.responses.create.call_args_list]
+        self.assertEqual(len(calls), 3)
+        self.assertEqual(calls[0]['max_output_tokens'], 256)
+        self.assertNotIn('max_output_tokens', calls[1])
+        self.assertNotIn('max_output_tokens', calls[2])
+
     def test_fallback_can_switch_from_responses_to_chat_completions(self):
         primary = _FakeRawClient(error=_StatusError('service unavailable', 503))
         chat_response = SimpleNamespace(
@@ -277,6 +389,23 @@ class ResponsesRequestTests(unittest.TestCase):
 
         self.assertEqual(client._endpoints[1]['api_mode'], 'responses')
         self.assertEqual(client._endpoints[1]['base_url'], 'https://gateway.example/v1')
+
+    def test_empty_fallback_url_inherits_primary_default_query(self):
+        config = self._config(
+            OPENAI_BASE_URL=(
+                'https://gateway.example/v1/responses?api-version=preview'
+            ),
+            FALLBACK_OPENAI_API_KEY='fallback-key',
+            FALLBACK_OPENAI_BASE_URL='',
+        )
+        with patch.object(afc, '_load_global_config', return_value={}), \
+             patch.object(afc, '_make_raw_client', side_effect=lambda ep, **_kw: ep):
+            client = afc.get_ai_client(config)
+
+        self.assertEqual(
+            client._endpoints[1]['default_query'],
+            {'api-version': 'preview'},
+        )
 
 
 if __name__ == '__main__':

--- a/tests/test_openai_responses_compatibility.py
+++ b/tests/test_openai_responses_compatibility.py
@@ -107,6 +107,7 @@ class ResponsesRequestTests(unittest.TestCase):
         self.assertEqual(request['max_output_tokens'], 256)
         self.assertEqual(request['text'], {'format': {'type': 'json_object'}})
         self.assertEqual(request['temperature'], 0.2)
+        self.assertIs(request['store'], False)
         self.assertNotIn('messages', request)
         self.assertNotIn('max_tokens', request)
         self.assertNotIn('response_format', request)
@@ -166,6 +167,15 @@ class ResponsesRequestTests(unittest.TestCase):
             'strict': True,
         })
 
+    def test_explicit_store_setting_is_preserved(self):
+        request = afc._responses_create_kwargs({
+            'model': 'response-model',
+            'messages': [{'role': 'user', 'content': 'hello'}],
+            'store': True,
+        })
+
+        self.assertIs(request['store'], True)
+
     def test_fallback_can_switch_from_responses_to_chat_completions(self):
         primary = _FakeRawClient(error=_StatusError('service unavailable', 503))
         chat_response = SimpleNamespace(
@@ -193,6 +203,67 @@ class ResponsesRequestTests(unittest.TestCase):
         self.assertEqual(response.choices[0].message.content, 'fallback')
         self.assertEqual(primary.responses.calls[0]['model'], 'response-model')
         self.assertEqual(fallback.chat.completions.calls[0]['model'], 'fallback-model')
+
+    def test_failed_responses_server_error_switches_to_fallback(self):
+        primary = _FakeRawClient(responses_result={
+            'id': 'resp_failed',
+            'status': 'failed',
+            'error': {'code': 'server_error', 'message': 'provider unavailable'},
+            'output': [],
+        })
+        chat_response = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content='fallback'))],
+        )
+        fallback = _FakeRawClient(chat_result=chat_response)
+
+        def make_client(endpoint, **_kwargs):
+            return primary if endpoint['api_mode'] == 'responses' else fallback
+
+        config = self._config(
+            FALLBACK_OPENAI_API_KEY='fallback-key',
+            FALLBACK_OPENAI_BASE_URL='https://fallback.example/v1/chat/completions',
+            FALLBACK_OPENAI_MODEL_NAME='fallback-model',
+        )
+        with patch.object(afc, '_load_global_config', return_value={}), \
+             patch.object(afc, '_make_raw_client', side_effect=make_client):
+            client = afc.get_ai_client(config)
+
+        response = client.chat.completions.create(
+            model='ignored',
+            messages=[{'role': 'user', 'content': 'hello'}],
+        )
+
+        self.assertEqual(response.choices[0].message.content, 'fallback')
+        self.assertEqual(len(fallback.chat.completions.calls), 1)
+
+    def test_failed_responses_request_error_does_not_switch_to_fallback(self):
+        primary = _FakeRawClient(responses_result={
+            'id': 'resp_failed',
+            'status': 'failed',
+            'error': {'code': 'invalid_prompt', 'message': 'invalid input'},
+            'output': [],
+        })
+        fallback = _FakeRawClient(chat_result=SimpleNamespace(choices=[]))
+
+        def make_client(endpoint, **_kwargs):
+            return primary if endpoint['api_mode'] == 'responses' else fallback
+
+        config = self._config(
+            FALLBACK_OPENAI_API_KEY='fallback-key',
+            FALLBACK_OPENAI_BASE_URL='https://fallback.example/v1/chat/completions',
+        )
+        with patch.object(afc, '_load_global_config', return_value={}), \
+             patch.object(afc, '_make_raw_client', side_effect=make_client):
+            client = afc.get_ai_client(config)
+
+        with self.assertRaises(afc.ResponsesResultError) as raised:
+            client.chat.completions.create(
+                model='ignored',
+                messages=[{'role': 'user', 'content': 'hello'}],
+            )
+
+        self.assertEqual(raised.exception.status_code, 400)
+        self.assertEqual(fallback.chat.completions.calls, [])
 
     def test_empty_fallback_url_inherits_primary_responses_protocol(self):
         config = self._config(

--- a/tests/test_openai_responses_compatibility.py
+++ b/tests/test_openai_responses_compatibility.py
@@ -1,0 +1,212 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from modules import ai_fallback_client as afc
+from modules import utils
+
+
+class _FakeResource:
+    def __init__(self, response=None, error=None):
+        self.response = response
+        self.error = error
+        self.calls = []
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        if self.error is not None:
+            raise self.error
+        return self.response
+
+
+class _FakeRawClient:
+    def __init__(self, *, responses_result=None, chat_result=None, error=None):
+        self.base_url = 'https://gateway.example/v1/'
+        self.responses = _FakeResource(responses_result, error)
+        self.chat = SimpleNamespace(
+            completions=_FakeResource(chat_result, error),
+        )
+
+
+class _StatusError(Exception):
+    def __init__(self, message, status_code):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class ResponsesUrlTests(unittest.TestCase):
+    def test_full_responses_url_is_detected_and_normalized(self):
+        endpoint = afc._build_endpoint('OPENAI_', {
+            'OPENAI_API_KEY': 'test-key',
+            'OPENAI_BASE_URL': 'https://gateway.example/custom/v1/responses/',
+            'OPENAI_MODEL_NAME': 'test-model',
+        })
+
+        self.assertEqual(endpoint['api_mode'], 'responses')
+        self.assertEqual(endpoint['base_url'], 'https://gateway.example/custom/v1')
+        self.assertEqual(
+            utils.normalize_openai_base_url('https://gateway.example/v1/responses'),
+            'https://gateway.example/v1',
+        )
+
+    def test_root_url_remains_chat_completions_for_backward_compatibility(self):
+        endpoint = afc._build_endpoint('OPENAI_', {
+            'OPENAI_API_KEY': 'test-key',
+            'OPENAI_BASE_URL': 'https://gateway.example/v1',
+        })
+
+        self.assertEqual(endpoint['api_mode'], 'chat_completions')
+
+
+class ResponsesRequestTests(unittest.TestCase):
+    def _config(self, **overrides):
+        config = {
+            'OPENAI_API_KEY': 'test-key',
+            'OPENAI_BASE_URL': 'https://gateway.example/v1/responses',
+            'OPENAI_MODEL_NAME': 'response-model',
+        }
+        config.update(overrides)
+        return config
+
+    def test_single_endpoint_converts_request_and_normalizes_output(self):
+        raw_response = {
+            'id': 'resp_test',
+            'model': 'response-model',
+            'usage': {'total_tokens': 12},
+            'output': [{
+                'type': 'message',
+                'role': 'assistant',
+                'content': [
+                    {'type': 'output_text', 'text': '{"translations":["你好"]}'},
+                ],
+            }],
+        }
+        raw_client = _FakeRawClient(responses_result=raw_response)
+
+        with patch.object(afc, '_load_global_config', return_value={}), \
+             patch.object(afc, '_make_raw_client', return_value=raw_client):
+            client = afc.get_ai_client(self._config())
+
+        response = client.chat.completions.create(
+            model='caller-model',
+            messages=[
+                {'role': 'system', 'content': 'Return JSON only.'},
+                {'role': 'user', 'content': 'hello'},
+            ],
+            max_tokens=256,
+            response_format={'type': 'json_object'},
+            temperature=0.2,
+        )
+
+        self.assertIsInstance(client, afc.ResponsesChatClient)
+        self.assertEqual(len(raw_client.responses.calls), 1)
+        request = raw_client.responses.calls[0]
+        self.assertEqual(request['model'], 'response-model')
+        self.assertEqual(request['instructions'], 'Return JSON only.')
+        self.assertEqual(request['input'], [{'role': 'user', 'content': 'hello'}])
+        self.assertEqual(request['max_output_tokens'], 256)
+        self.assertEqual(request['text'], {'format': {'type': 'json_object'}})
+        self.assertEqual(request['temperature'], 0.2)
+        self.assertNotIn('messages', request)
+        self.assertNotIn('max_tokens', request)
+        self.assertNotIn('response_format', request)
+        self.assertEqual(
+            utils.extract_chat_message_json(response.choices[0].message),
+            {'translations': ['你好']},
+        )
+        self.assertIs(response.raw_response, raw_response)
+
+    def test_sdk_output_text_property_is_used(self):
+        raw_response = SimpleNamespace(
+            id='resp_property',
+            model='response-model',
+            usage=None,
+            output_text='plain response text',
+            output=[],
+        )
+        normalized = afc._as_chat_completion(raw_response)
+
+        self.assertEqual(normalized.choices[0].message.content, 'plain response text')
+
+    def test_multimodal_content_and_json_schema_are_converted(self):
+        request = afc._responses_create_kwargs({
+            'model': 'vision-model',
+            'messages': [{
+                'role': 'user',
+                'content': [
+                    {'type': 'text', 'text': 'describe this image'},
+                    {
+                        'type': 'image_url',
+                        'image_url': {'url': 'data:image/png;base64,abc', 'detail': 'low'},
+                    },
+                ],
+            }],
+            'response_format': {
+                'type': 'json_schema',
+                'json_schema': {
+                    'name': 'result',
+                    'schema': {'type': 'object'},
+                    'strict': True,
+                },
+            },
+        })
+
+        self.assertEqual(request['input'][0]['content'], [
+            {'type': 'input_text', 'text': 'describe this image'},
+            {
+                'type': 'input_image',
+                'image_url': 'data:image/png;base64,abc',
+                'detail': 'low',
+            },
+        ])
+        self.assertEqual(request['text']['format'], {
+            'type': 'json_schema',
+            'name': 'result',
+            'schema': {'type': 'object'},
+            'strict': True,
+        })
+
+    def test_fallback_can_switch_from_responses_to_chat_completions(self):
+        primary = _FakeRawClient(error=_StatusError('service unavailable', 503))
+        chat_response = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content='fallback'))],
+        )
+        fallback = _FakeRawClient(chat_result=chat_response)
+
+        def make_client(endpoint, **_kwargs):
+            return primary if endpoint['api_mode'] == 'responses' else fallback
+
+        config = self._config(
+            FALLBACK_OPENAI_API_KEY='fallback-key',
+            FALLBACK_OPENAI_BASE_URL='https://fallback.example/v1/chat/completions',
+            FALLBACK_OPENAI_MODEL_NAME='fallback-model',
+        )
+        with patch.object(afc, '_load_global_config', return_value={}), \
+             patch.object(afc, '_make_raw_client', side_effect=make_client):
+            client = afc.get_ai_client(config)
+
+        response = client.chat.completions.create(
+            model='ignored',
+            messages=[{'role': 'user', 'content': 'hello'}],
+        )
+
+        self.assertEqual(response.choices[0].message.content, 'fallback')
+        self.assertEqual(primary.responses.calls[0]['model'], 'response-model')
+        self.assertEqual(fallback.chat.completions.calls[0]['model'], 'fallback-model')
+
+    def test_empty_fallback_url_inherits_primary_responses_protocol(self):
+        config = self._config(
+            FALLBACK_OPENAI_API_KEY='fallback-key',
+            FALLBACK_OPENAI_BASE_URL='',
+            FALLBACK_OPENAI_MODEL_NAME='',
+        )
+        with patch.object(afc, '_load_global_config', return_value={}), \
+             patch.object(afc, '_make_raw_client', side_effect=lambda ep, **_kw: ep):
+            client = afc.get_ai_client(config)
+
+        self.assertEqual(client._endpoints[1]['api_mode'], 'responses')
+        self.assertEqual(client._endpoints[1]['base_url'], 'https://gateway.example/v1')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## 变更说明

- 支持在 OpenAI Base URL 中填写完整的 `/responses` 端点，并自动选择 Responses API；根地址和 `/chat/completions` 继续保持原行为
- 将现有 Chat 请求转换为 Responses API 的 `instructions`、`input`、`max_output_tokens` 与 `text.format`，兼容文本、封面图片和结构化 JSON 输出
- 将 Responses 输出归一化为现有业务层使用的消息结构，覆盖字幕翻译、字幕质检、元数据生成和智能分段
- 支持主端点与兜底端点分别使用 Responses / Chat Completions 协议
- 更新设置页提示、README 与 OpenAI SDK 最低版本

## 验证

- `.\.venv\Scripts\python.exe -m pytest -q`
- 结果：416 passed, 21 subtests passed
- `.\.venv\Scripts\python.exe -m compileall -q modules app.py tests`
- `git diff --check`
