### PR TITLE
fix: 修复 4.10 发布审计问题

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -25,6 +25,22 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Set up Python for release tests
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest
+          python -m pip install -r requirements.txt
+
+      - name: Run full test suite
+        run: python -m pytest tests/
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 

--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -21,8 +21,27 @@ jobs:
       contents: write
 
     steps:
+      - name: Resolve and validate release tag
+        id: release-ref
+        shell: pwsh
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name || github.event.inputs.release_tag }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          if ([string]::IsNullOrWhiteSpace($env:RELEASE_TAG)) {
+            throw 'A release tag is required for both release and workflow_dispatch runs.'
+          }
+          if ($env:RELEASE_TAG -notmatch '^v?\d+\.\d+\.\d+$') {
+            throw "Release tag '$env:RELEASE_TAG' must use three-part semver (for example, 4.10.0); two-part tags such as 4.10 are not supported."
+          }
+
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "release_tag=$($env:RELEASE_TAG)"
+
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.release-ref.outputs.release_tag }}
 
       - name: Prepare bundled FFmpeg (latest)
         shell: pwsh
@@ -84,7 +103,11 @@ jobs:
       - name: Install pip dependencies
         run: |
           python -m pip install --upgrade pip
+          python -m pip install pytest
           pip install -r requirements.txt
+
+      - name: Run full test suite
+        run: python -m pytest tests/
 
       - name: Build Windows EXE
         run: |
@@ -122,7 +145,7 @@ jobs:
       - name: Validate target GitHub Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_TAG: ${{ github.event.release.tag_name || github.event.inputs.release_tag }}
+          RELEASE_TAG: ${{ steps.release-ref.outputs.release_tag }}
         run: |
           gh release view "$env:RELEASE_TAG" --json tagName
 
@@ -130,6 +153,6 @@ jobs:
         if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_TAG: ${{ github.event.release.tag_name || github.event.inputs.release_tag }}
+          RELEASE_TAG: ${{ steps.release-ref.outputs.release_tag }}
         run: |
           gh release upload "$env:RELEASE_TAG" Y2A-Auto-win64.zip --clobber

--- a/app.py
+++ b/app.py
@@ -2863,6 +2863,53 @@ def settings():
     )
 
 
+@app.route('/settings/update_cover_mode', methods=['POST'])
+@login_required
+def update_cover_mode():
+    """Persist the cover processing mode used by subsequent uploads."""
+    payload = request.get_json(silent=True)
+    if not isinstance(payload, dict):
+        return jsonify({
+            'success': False,
+            'message': '请求体必须是 JSON 对象。',
+        }), 400
+
+    mode = payload.get('mode')
+    if not isinstance(mode, str) or mode not in ('crop', 'pad'):
+        return jsonify({
+            'success': False,
+            'message': '封面处理模式必须是 crop 或 pad。',
+        }), 400
+
+    try:
+        updated_config = update_config({'COVER_PROCESSING_MODE': mode})
+    except Exception as exc:
+        logger.error('保存封面处理模式失败: %s', exc)
+        return jsonify({
+            'success': False,
+            'message': '保存封面处理模式失败，请稍后重试。',
+        }), 500
+
+    # Keep the running application and task processor in sync with the
+    # persisted value; a restart should not be required for the next upload.
+    try:
+        configure_app(app, updated_config)
+        from modules.task_manager import get_global_task_processor
+        get_global_task_processor(updated_config)
+    except Exception as exc:
+        # Persistence already succeeded.  Log a runtime-refresh failure but
+        # still report success so the caller does not incorrectly retry a
+        # setting that is already stored on disk.
+        logger.warning('封面处理模式已保存，但刷新运行时配置失败: %s', exc)
+
+    return jsonify({
+        'success': True,
+        'mode': mode,
+        'cover_processing_mode': mode,
+        'message': '封面处理模式已更新。',
+    })
+
+
 @app.route('/settings/tgbot-token', methods=['POST'])
 @login_required
 def settings_tgbot_token():

--- a/modules/ai_fallback_client.py
+++ b/modules/ai_fallback_client.py
@@ -251,6 +251,51 @@ class _ChatProxy:
         self.completions = _CompletionsProxy(parent)
 
 
+class _FallbackEndpointClient:
+    """Expose one concrete failover endpoint to the request adaptation layer.
+
+    ``modules.utils`` needs the endpoint identity before it builds a request
+    (thinking controls and compatibility actions are endpoint-specific).  The
+    public ``FallbackChatClient`` cannot provide that identity because the
+    endpoint is selected only after the request starts.  This small proxy
+    makes one endpoint look like the existing chat client while keeping the
+    actual failover loop in ``FallbackChatClient``.
+    """
+
+    def __init__(self, raw_client, endpoint):
+        self._raw = raw_client
+        self._endpoint = endpoint
+        self.base_url = getattr(raw_client, "base_url", None) or endpoint.get("base_url", "")
+        self.api_mode = endpoint.get("api_mode", "chat_completions")
+        self._endpoint_model = endpoint.get("model", "")
+        self.chat = _ChatProxy(self)
+
+    def _create(self, kwargs):
+        call_kwargs = dict(kwargs)
+        # Each endpoint owns its model; callers may pass the primary model.
+        call_kwargs["model"] = self._endpoint["model"]
+
+        # Merge endpoint-level extra_body with request-level values while
+        # preserving the request's values on conflicts.
+        merged_extra = dict(self._endpoint.get("extra_body") or {})
+        caller_extra = call_kwargs.pop("extra_body", None)
+        if isinstance(caller_extra, dict):
+            merged_extra.update(caller_extra)
+
+        # DeepSeek's native Chat Completions field differs from the generic
+        # thinking object used by the utility layer.  This conversion must be
+        # performed here, after the actual endpoint has been selected.
+        if "deepseek" in (self._endpoint.get("base_url") or "").lower():
+            thinking_cfg = merged_extra.get("thinking")
+            if isinstance(thinking_cfg, dict) and thinking_cfg.get("enabled") is False:
+                merged_extra.pop("thinking", None)
+                merged_extra["enable_thinking"] = False
+        if merged_extra:
+            call_kwargs["extra_body"] = merged_extra
+
+        return _create_on_endpoint(self._raw, self._endpoint, call_kwargs)
+
+
 def _value(obj, key, default=None):
     if isinstance(obj, dict):
         return obj.get(key, default)
@@ -447,6 +492,8 @@ class ResponsesChatClient:
         self._raw = raw_client
         self._endpoint = endpoint
         self.base_url = getattr(raw_client, 'base_url', None) or endpoint.get('base_url', '')
+        self._endpoint_model = endpoint.get('model', '')
+        self.api_mode = endpoint.get('api_mode', 'responses')
         self.chat = _ChatProxy(self)
 
     def _create(self, kwargs):
@@ -462,40 +509,27 @@ class FallbackChatClient:
         self._endpoints = endpoints
         # 仅故障转移（多端点）模式下关闭 SDK 重试、使用 failover 连接短超时
         self._raw = [_make_raw_client(ep, multi_endpoint=True) for ep in endpoints]
-        # 兼容统一请求层基于 client.base_url 识别服务商、隔离能力缓存的约定。
-        # 故障转移请求总是先访问主端点，因此这里暴露主端点的规范化地址。
+        # 保留主端点身份供旧的直接调用方/诊断代码使用。统一请求层通过
+        # _create_with_endpoint_fallback() 获取实际处理请求的端点代理，避免
+        # thinking 控制和兼容性缓存把备用端点的能力写入主端点。
         self.base_url = getattr(self._raw[0], "base_url", None) or endpoints[0].get("base_url", "")
         self.api_mode = endpoints[0].get('api_mode', 'chat_completions')
         # 兼容 client.chat.completions.create(...) 调用链
         self.chat = _ChatProxy(self)
 
-    def _create(self, kwargs):
-        requested_model = kwargs.pop("model", None)
+    def _create_with_endpoint_fallback(self, request_callback):
+        """Run an endpoint-aware request callback with normal failover rules.
+
+        The callback is responsible for retries that change request shape
+        (for example dropping ``response_format``).  Such retries must stay on
+        the same endpoint; this method only switches endpoints for genuine
+        availability errors raised by the callback.
+        """
         last_exc = None
         for idx, ep in enumerate(self._endpoints):
-            call_kwargs = dict(kwargs)
-            # 以端点自身配置的 model 为准
-            call_kwargs["model"] = ep["model"]
-            # 合并端点级 extra_body 与调用方 extra_body（调用方优先）
-            merged_extra = dict(ep.get("extra_body") or {})
-            caller_extra = call_kwargs.pop("extra_body", None)
-            if isinstance(caller_extra, dict):
-                merged_extra.update(caller_extra)
-            # 部分推理模型（如 DeepSeek 的推理系列）默认把结果放在 reasoning_content、
-            # content 为空；翻译 / 质检等场景需要 content 有值。但仅在调用方**显式要求
-            # 关闭思考**（extra_body.thinking = {type:disabled, enabled:False}，由
-            # utils.openai_chat_create_with_thinking_control 在 thinking_enabled=False
-            # 时注入）时才改写为 DeepSeek 原生禁用参数；调用方启用思考（无 thinking 键）
-            # 时不得覆盖，否则用户显式开启的思考模式会被静默关掉。
-            if "deepseek" in (ep.get("base_url") or "").lower():
-                thinking_cfg = merged_extra.get("thinking")
-                if isinstance(thinking_cfg, dict) and thinking_cfg.get("enabled") is False:
-                    merged_extra.pop("thinking", None)
-                    merged_extra["enable_thinking"] = False
-            if merged_extra:
-                call_kwargs["extra_body"] = merged_extra
+            endpoint_client = _FallbackEndpointClient(self._raw[idx], ep)
             try:
-                return _create_on_endpoint(self._raw[idx], ep, call_kwargs)
+                return request_callback(endpoint_client)
             except Exception as exc:  # noqa: BLE001
                 if _is_unavailable_error(exc):
                     logger.warning(
@@ -509,6 +543,11 @@ class FallbackChatClient:
                 raise
         logger.error("[AI兜底] 所有 AI 端点均不可用")
         raise last_exc if last_exc else RuntimeError("all AI endpoints failed")
+
+    def _create(self, kwargs):
+        return self._create_with_endpoint_fallback(
+            lambda endpoint_client: endpoint_client.chat.completions.create(**dict(kwargs))
+        )
 
 
 def _global_fallback_fields():

--- a/modules/config_manager.py
+++ b/modules/config_manager.py
@@ -4,6 +4,7 @@
 import os
 import json
 import logging
+from copy import deepcopy
 from .utils import get_app_subdir
 from .speech_pipeline_settings import (
     inject_speech_pipeline_defaults,
@@ -398,8 +399,11 @@ def load_config():
     
     # 如果配置文件不存在或读取失败，创建默认配置
     logger.info("使用默认配置并创建配置文件")
-    save_config(DEFAULT_CONFIG, config_path)
-    return DEFAULT_CONFIG
+    # 调用方会原地更新 load_config() 的返回值。这里必须返回独立副本，
+    # 否则首次启动或配置损坏后的更新会污染模块级默认值，后续“重置”也会失效。
+    default_config = deepcopy(DEFAULT_CONFIG)
+    save_config(default_config, config_path)
+    return default_config
 
 def save_config(config, config_path=None):
     """

--- a/modules/task_manager.py
+++ b/modules/task_manager.py
@@ -1995,7 +1995,7 @@ def delete_task_files(task_id):
             logger.info(f"任务 {task_id} 的下载目录已删除: {task_dir_real}")
         except Exception as e:
             logger.error(f"删除任务 {task_id} 的下载目录失败: {str(e)}")
-            # 不直接返回False，尝试继续删除其他文件
+            return False
 
     # 封面图片现在保存在downloads目录中，无需单独删除
 
@@ -8061,8 +8061,10 @@ class TaskProcessor:
                         self.config.get('DELETE_DOWNLOAD_FILES_AFTER_UPLOAD', False)
                         and _get_task_upload_target(task) == UPLOAD_TARGET_ACFUN
                     ):
-                        delete_task_files(task_id)
-                        task_logger.info(f"AcFun 上传完成，已删除本地文件释放空间: {task_id}")
+                        if delete_task_files(task_id):
+                            task_logger.info(f"AcFun 上传完成，已删除本地文件释放空间: {task_id}")
+                        else:
+                            task_logger.warning(f"AcFun 上传完成，但本地文件删除失败，请手动清理: {task_id}")
                 except Exception as _e:
                     task_logger.warning(f"上传后删除本地文件失败（不影响已完成的 AcFun 上传）: {_e}")
             else:
@@ -8328,8 +8330,10 @@ class TaskProcessor:
                         self.config.get('DELETE_DOWNLOAD_FILES_AFTER_UPLOAD', False)
                         and _get_task_upload_target(task) != UPLOAD_TARGET_ACFUN
                     ):
-                        delete_task_files(task_id)
-                        task_logger.info(f"bilibili 上传完成，已删除本地文件释放空间: {task_id}")
+                        if delete_task_files(task_id):
+                            task_logger.info(f"bilibili 上传完成，已删除本地文件释放空间: {task_id}")
+                        else:
+                            task_logger.warning(f"bilibili 上传完成，但本地文件删除失败，请手动清理: {task_id}")
                 except Exception as _e:
                     task_logger.warning(f"上传后删除本地文件失败（不影响已完成的 B 站上传）: {_e}")
             else:

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -399,6 +399,20 @@ def _is_generic_schema_compatibility_error(exc) -> bool:
     ))
 
 
+def _effective_client_model(client, create_kwargs):
+    """Return the model that the concrete client will actually send.
+
+    A failover endpoint proxy supplies ``_endpoint_model`` because the caller's
+    model is the primary endpoint's model and is intentionally overwritten by
+    the fallback client.  Plain OpenAI-compatible clients keep using the
+    caller-provided model.
+    """
+    endpoint_model = safe_str(getattr(client, '_endpoint_model', '')).strip()
+    if endpoint_model:
+        return endpoint_model
+    return safe_str((create_kwargs or {}).get('model'), default='unknown').strip()
+
+
 def _client_compatibility_key(client, create_kwargs) -> str:
     endpoint_value = safe_str(getattr(client, 'base_url', '')).strip()
     try:
@@ -409,7 +423,7 @@ def _client_compatibility_key(client, create_kwargs) -> str:
             endpoint = endpoint_value or 'unknown'
     except Exception:
         endpoint = endpoint_value or 'unknown'
-    model = safe_str((create_kwargs or {}).get('model'), default='unknown').strip().lower()
+    model = _effective_client_model(client, create_kwargs).lower() or 'unknown'
     api_mode = safe_str(
         getattr(client, 'api_mode', 'chat_completions'),
         default='chat_completions',
@@ -424,7 +438,7 @@ def _thinking_control_style(client, create_kwargs) -> str:
         hostname = (urlparse(endpoint).hostname or '').lower()
     except Exception:
         hostname = ''
-    model = safe_str((create_kwargs or {}).get('model')).lower()
+    model = _effective_client_model(client, create_kwargs).lower()
 
     def host_matches(*domains):
         return any(
@@ -617,7 +631,7 @@ def _warn_compatibility_fallback(logger, cache_key: str, action: str, scene_name
     logger.warning('模型兼容降级[%s]：%s', scene, descriptions.get(action, action))
 
 
-def openai_chat_create_with_thinking_control(
+def _openai_chat_create_with_thinking_control_single(
     client,
     create_kwargs,
     thinking_enabled=False,
@@ -633,6 +647,12 @@ def openai_chat_create_with_thinking_control(
     鉴权、限流、配额和服务端错误不会在这里被误判为兼容问题。
     """
     base_kwargs = copy.deepcopy(create_kwargs or {})
+    effective_model = _effective_client_model(client, base_kwargs)
+    if effective_model and effective_model != 'unknown':
+        # Compatibility retries (especially minimal_request) must carry the
+        # model selected by the concrete endpoint, not the primary caller's
+        # model passed into a failover wrapper.
+        base_kwargs['model'] = effective_model
     if not _coerce_bool(thinking_enabled, default=False):
         _inject_thinking_control(
             base_kwargs,
@@ -732,3 +752,37 @@ def openai_chat_create_with_thinking_control(
                 actions.discard('use_developer_role')
                 discovered_actions.discard('use_developer_role')
             _warn_compatibility_fallback(logger, cache_key, action, scene_name)
+
+
+def openai_chat_create_with_thinking_control(
+    client,
+    create_kwargs,
+    thinking_enabled=False,
+    logger=None,
+    scene_name='unknown',
+):
+    """Create a Chat/Responses request with endpoint-scoped compatibility.
+
+    For a failover client, the endpoint is selected before this function
+    derives thinking controls or reads/writes the compatibility cache.  This
+    keeps a fallback provider's capabilities from changing the primary
+    provider's future requests.  Plain clients retain the original path.
+    """
+    endpoint_runner = getattr(client, '_create_with_endpoint_fallback', None)
+    if callable(endpoint_runner):
+        return endpoint_runner(
+            lambda endpoint_client: _openai_chat_create_with_thinking_control_single(
+                endpoint_client,
+                create_kwargs,
+                thinking_enabled=thinking_enabled,
+                logger=logger,
+                scene_name=scene_name,
+            )
+        )
+    return _openai_chat_create_with_thinking_control_single(
+        client,
+        create_kwargs,
+        thinking_enabled=thinking_enabled,
+        logger=logger,
+        scene_name=scene_name,
+    )

--- a/modules/youtube_monitor.py
+++ b/modules/youtube_monitor.py
@@ -1058,83 +1058,37 @@ class YouTubeMonitor:
         if config['category_id'] and config['category_id'] != '0':
             search_params['videoCategoryId'] = config['category_id']
 
-        # 添加关键词搜索：支持多关键词 OR 搜索。
-        # 多个关键词可用逗号/分号/空格/换行分隔，每个关键词单独发起一次搜索请求，
-        # 最后合并并去重，实现“任一关键词匹配即搬运”的语义（原先是整串 AND 搜索）。
+        # 添加关键词搜索：YouTube q 参数原生支持使用“|”进行 OR 搜索。
+        # 把多个关键词合并到一次 search.list，避免关键词数量线性消耗搜索配额。
         raw_kw = (config.get('keywords') or '').strip()
         keywords_list = [k for k in re.split(r'[\s,;，；\n]+', raw_kw) if k] if raw_kw else []
         if keywords_list:
-            search_batches = []
-            for kw in keywords_list:
-                sp = dict(search_params)
-                sp['q'] = kw
-                search_batches.append(sp)
+            search_params['q'] = '|'.join(keywords_list)
             logger.info(f"多关键词 OR 搜索，共 {len(keywords_list)} 个: {keywords_list}")
-        else:
-            # 无关键词则按空查询搜索（返回热门视频），保持原有行为
-            search_batches = [dict(search_params)]
 
-        # 多关键词 OR 搜索：逐个关键词请求，并在每个 batch 外层单独容错，
-        # 单个关键词失败不影响其他关键词与整轮监控。
-        batch_results = []  # 每个关键词的 videoId 列表
-        failed_keywords = []
-        for idx, sp in enumerate(search_batches, 1):
-            kw_label = sp.get('q') or f'batch{idx}'
-            try:
-                logger.debug(f"准备执行搜索请求({idx}/{len(search_batches)})，参数: {sp}")
-                search_request = self.youtube.search().list(**sp)
-                search_response = self._execute_with_retry(search_request, 'search.list')
-            except Exception as e:
-                # 单批失败只跳过该关键词，继续处理其余关键词
-                logger.error(f"关键词搜索失败，跳过该关键词继续其他：q={kw_label}, 错误: {e}")
-                failed_keywords.append(kw_label)
-                continue
-            if not search_response or 'items' not in search_response:
-                logger.error(f"搜索响应异常（关键词: {kw_label}）：{search_response}")
-                failed_keywords.append(kw_label)
-                continue
-            ids = [item['id']['videoId'] for item in search_response['items'] if 'id' in item and 'videoId' in item['id']]
-            batch_results.append(ids)
+        try:
+            logger.debug(f"准备执行搜索请求，参数: {search_params}")
+            search_request = self.youtube.search().list(**search_params)
+            search_response = self._execute_with_retry(search_request, 'search.list')
+        except Exception as e:
+            logger.error(f"关键词搜索失败: q={search_params.get('q') or '无'}, 错误: {e}")
+            self._last_fetch_had_errors = True
+            return []
 
-        if failed_keywords:
-            logger.warning(f"多关键词搜索中有 {len(failed_keywords)} 个关键词失败（已跳过并继续其余）：{failed_keywords}")
-        # 多关键词会线性增加 search.list 配额消耗（每关键词 1 次请求），无论是否失败都提示
-        if len(batch_results) > 1:
-            logger.warning(f"多关键词 OR 搜索共 {len(batch_results)} 个关键词，将线性增加 search.list 配额消耗（每关键词 1 次请求）。")
+        if not search_response or 'items' not in search_response:
+            logger.error(f"搜索响应异常: {search_response}")
+            self._last_fetch_had_errors = True
+            return []
 
-        # 公平合并：round-robin 交错各关键词候选，去重后截断，
-        # 确保每个关键词至少有机会进入最终候选集，避免前面的热门关键词占满名额。
-        # 每次成功 append 后立即检查预算并跳出，避免单轮内越过 total_budget（≤50），
-        # 否则会向 videos.list 传入超过 50 个 ID 而触发 400。
-        # 候选数量下限保护：max_results 过小时（如 1）会让 total_budget 仅 2，
-        # 在 monitor_history 已饱和时去重后恒为 0 新视频。设下限 10，确保每轮
-        # 仍能采样到足够候选以命中真正的新视频（历史去重仍是正确设计，仅防止候选过小）。
+        # 候选数量下限保护：max_results 过小时（如 1）会让候选过少，
+        # 在 monitor_history 已饱和时去重后恒为 0 新视频。
         total_budget = max(min(config['max_results'] * 2, 50), 10)
-        video_ids = []
-        seen = set()
-        if batch_results:
-            iterators = [iter(ids) for ids in batch_results]
-            active = list(iterators)
-            while active and len(video_ids) < total_budget:
-                still_active = []
-                budget_reached = False
-                for it in active:
-                    try:
-                        vid = next(it)
-                    except StopIteration:
-                        continue
-                    if vid not in seen:
-                        seen.add(vid)
-                        video_ids.append(vid)
-                        if len(video_ids) >= total_budget:
-                            budget_reached = True
-                            break  # 立即跳出内层，停止本轮其余关键词
-                    # 该批仍有剩余则保留，继续顺序轮转（即便本批本轮贡献为重复项）
-                    still_active.append(it)
-                active = still_active
-                if budget_reached:
-                    break  # 跳出外层 while
-        logger.info(f"多关键词合并后候选 {len(video_ids)} 个（预算 {total_budget}，来源批次 {len(batch_results)}）")
+        video_ids = list(dict.fromkeys(
+            item['id']['videoId']
+            for item in search_response['items']
+            if 'id' in item and 'videoId' in item['id']
+        ))[:total_budget]
+        logger.info(f"搜索得到候选 {len(video_ids)} 个（预算 {total_budget}）")
         
         if not video_ids:
             return []
@@ -1152,10 +1106,12 @@ class YouTubeMonitor:
         logger.debug(f"视频响应类型: {type(videos_response)}, 值: {videos_response}")
         if videos_response is None:
             logger.error("视频响应为 None")
+            self._last_fetch_had_errors = True
             return []
         
         if 'items' not in videos_response:
             logger.error(f"视频响应中缺少 'items' 字段，响应内容: {videos_response}")
+            self._last_fetch_had_errors = True
             return []
         
         return videos_response['items']

--- a/templates/edit_task.html
+++ b/templates/edit_task.html
@@ -473,7 +473,7 @@
             toggleCoverModeBtn.addEventListener('click', function() {
                 const newMode = coverModeSwitch.checked ? 'crop' : 'pad';
                 
-                fetch('/settings/update_cover_mode', {
+                fetch('{{ url_for("update_cover_mode") }}', {
                     method: 'POST',
                     headers: {
                         'Content-Type': 'application/json',

--- a/tests/test_ai_fallback_client.py
+++ b/tests/test_ai_fallback_client.py
@@ -8,12 +8,14 @@
 - 各调用路径（元数据翻译 / 标签 / 分区 / 字幕）都能实际拿到兜底配置
 """
 import unittest
+from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
 
 import openai
 from openai import APIConnectionError, APITimeoutError, APIStatusError
 
 from modules import ai_fallback_client as afc
+from modules import utils
 
 
 # ---------------------------------------------------------------------------
@@ -446,6 +448,130 @@ class DeepSeekThinkingControlTests(unittest.TestCase):
         extra = self._create_with_extra({"thinking": {"enabled": True}})
         self.assertIsNotNone(extra)
         self.assertIsNone(extra.get("enable_thinking"))
+
+
+class EndpointScopedCompatibilityTests(unittest.TestCase):
+    """回归：兼容能力和 thinking 控制必须绑定实际处理请求的端点。"""
+
+    class _SequencedClient:
+        def __init__(self, *effects):
+            self.effects = list(effects)
+            self.calls = []
+            self.chat = SimpleNamespace(
+                completions=SimpleNamespace(create=self._create)
+            )
+
+        def _create(self, **kwargs):
+            self.calls.append(dict(kwargs))
+            effect = self.effects[min(len(self.calls) - 1, len(self.effects) - 1)]
+            if isinstance(effect, BaseException):
+                raise effect
+            return effect
+
+    def setUp(self):
+        with utils._OPENAI_COMPATIBILITY_LOCK:
+            utils._OPENAI_COMPATIBILITY_CACHE.clear()
+            utils._OPENAI_COMPATIBILITY_WARNED.clear()
+
+    def tearDown(self):
+        with utils._OPENAI_COMPATIBILITY_LOCK:
+            utils._OPENAI_COMPATIBILITY_CACHE.clear()
+            utils._OPENAI_COMPATIBILITY_WARNED.clear()
+
+    def test_fallback_capability_cache_does_not_pollute_recovered_primary(self):
+        primary = self._SequencedClient(
+            _StubStatusError("primary down", 503),
+            {"choices": []},
+        )
+        fallback = self._SequencedClient(
+            _StubStatusError("Unsupported parameter: response_format", 400),
+            {"choices": []},
+        )
+
+        def maker(endpoint, **_kwargs):
+            return fallback if "fallback" in endpoint["label"] else primary
+
+        with patch.object(afc, "_make_raw_client", side_effect=maker):
+            client = afc.get_ai_client(_full_config())
+
+        kwargs = {
+            "model": "caller-model",
+            "messages": [{"role": "user", "content": "hello"}],
+            "response_format": {"type": "json_object"},
+        }
+        utils.openai_chat_create_with_thinking_control(client, kwargs)
+
+        # The fallback learns its own incompatibility, but the primary has no
+        # reason to drop JSON once it recovers on the next request.
+        self.assertIn("response_format", primary.calls[0])
+        self.assertIn("response_format", fallback.calls[0])
+        self.assertNotIn("response_format", fallback.calls[1])
+        utils.openai_chat_create_with_thinking_control(client, kwargs)
+        self.assertIn("response_format", primary.calls[1])
+        self.assertEqual(primary.calls[1]["model"], "m1")
+        self.assertEqual(fallback.calls[1]["model"], "m2")
+
+    def _assert_fallback_thinking(self, base_url, model_name, expected_extra):
+        primary = self._SequencedClient(_StubStatusError("primary down", 503))
+        fallback = self._SequencedClient({"choices": []})
+
+        def maker(endpoint, **_kwargs):
+            return fallback if "fallback" in endpoint["label"] else primary
+
+        cfg = _full_config(
+            FALLBACK_OPENAI_BASE_URL=base_url,
+            FALLBACK_OPENAI_MODEL_NAME=model_name,
+        )
+        with patch.object(afc, "_make_raw_client", side_effect=maker):
+            client = afc.get_ai_client(cfg)
+        utils.openai_chat_create_with_thinking_control(
+            client,
+            {"model": "primary-model", "messages": []},
+            thinking_enabled=False,
+        )
+        self.assertEqual(fallback.calls[-1].get("extra_body"), expected_extra)
+        self.assertEqual(fallback.calls[-1]["model"], model_name)
+
+    def test_fallback_deepseek_thinking_control_uses_backup_identity(self):
+        self._assert_fallback_thinking(
+            "https://api.deepseek.com/v1",
+            "deepseek-reasoner",
+            {"enable_thinking": False},
+        )
+
+    def test_fallback_qwen_thinking_control_uses_backup_identity(self):
+        self._assert_fallback_thinking(
+            "https://dashscope.aliyuncs.com/compatible-mode/v1",
+            "qwen-plus",
+            {"enable_thinking": False},
+        )
+
+    def test_compatibility_key_separates_model_and_api_mode(self):
+        chat_client = SimpleNamespace(
+            base_url="https://same.example/v1",
+            api_mode="chat_completions",
+            _endpoint_model="model-a",
+        )
+        responses_client = SimpleNamespace(
+            base_url="https://same.example/v1",
+            api_mode="responses",
+            _endpoint_model="model-a",
+        )
+        other_model_client = SimpleNamespace(
+            base_url="https://same.example/v1",
+            api_mode="chat_completions",
+            _endpoint_model="model-b",
+        )
+
+        chat_key = utils._client_compatibility_key(chat_client, {})
+        self.assertNotEqual(
+            chat_key,
+            utils._client_compatibility_key(responses_client, {}),
+        )
+        self.assertNotEqual(
+            chat_key,
+            utils._client_compatibility_key(other_model_client, {}),
+        )
 
 
 class TimeoutNonPositiveNormalizationTests(unittest.TestCase):

--- a/tests/test_edit_task_cover_mode_route.py
+++ b/tests/test_edit_task_cover_mode_route.py
@@ -1,0 +1,89 @@
+"""Regression tests for the edit-task cover mode JSON endpoint."""
+
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import app as web_app
+from modules import config_manager
+
+
+class EditTaskCoverModeRouteTests(unittest.TestCase):
+    def setUp(self):
+        web_app.app.config['TESTING'] = True
+        self.client = web_app.app.test_client()
+
+    def _post(self, payload):
+        return self.client.post('/settings/update_cover_mode', json=payload)
+
+    def test_valid_modes_are_persisted_and_returned(self):
+        for mode in ('crop', 'pad'):
+            with self.subTest(mode=mode), \
+                    patch.object(web_app, 'load_config', return_value={'password_protection_enabled': False}), \
+                    patch.object(web_app, 'update_config', return_value={'COVER_PROCESSING_MODE': mode}) as update_mock, \
+                    patch.object(web_app, 'configure_app') as configure_mock, \
+                    patch('modules.task_manager.get_global_task_processor') as processor_mock:
+                response = self._post({'mode': mode})
+
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.get_json(), {
+                'success': True,
+                'mode': mode,
+                'cover_processing_mode': mode,
+                'message': '封面处理模式已更新。',
+            })
+            update_mock.assert_called_once_with({'COVER_PROCESSING_MODE': mode})
+            configure_mock.assert_called_once_with(web_app.app, {'COVER_PROCESSING_MODE': mode})
+            processor_mock.assert_called_once_with({'COVER_PROCESSING_MODE': mode})
+
+    def test_mode_is_written_to_config_file(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            def temp_app_subdir(name):
+                path = os.path.join(temp_dir, name)
+                os.makedirs(path, exist_ok=True)
+                return path
+
+            with patch.object(web_app, 'load_config', return_value={'password_protection_enabled': False}), \
+                    patch.object(config_manager, 'get_app_subdir', side_effect=temp_app_subdir), \
+                    patch.object(web_app, 'configure_app'), \
+                    patch('modules.task_manager.get_global_task_processor'):
+                response = self._post({'mode': 'pad'})
+                persisted = config_manager.load_config()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(persisted['COVER_PROCESSING_MODE'], 'pad')
+
+    def test_invalid_modes_are_rejected_without_persisting(self):
+        invalid_payloads = ({}, {'mode': ''}, {'mode': 'crop '}, {'mode': 'CROP'}, {'mode': 'fit'}, {'mode': None})
+        for payload in invalid_payloads:
+            with self.subTest(payload=payload), \
+                    patch.object(web_app, 'load_config', return_value={'password_protection_enabled': False}), \
+                    patch.object(web_app, 'update_config') as update_mock:
+                response = self._post(payload)
+
+            self.assertEqual(response.status_code, 400)
+            self.assertEqual(response.get_json()['success'], False)
+            update_mock.assert_not_called()
+
+    def test_non_json_body_is_rejected(self):
+        with patch.object(web_app, 'load_config', return_value={'password_protection_enabled': False}), \
+                patch.object(web_app, 'update_config') as update_mock:
+            response = self.client.post('/settings/update_cover_mode', data={'mode': 'crop'})
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.get_json()['success'], False)
+        update_mock.assert_not_called()
+
+    def test_route_requires_login_when_password_protection_is_enabled(self):
+        with patch.object(web_app, 'load_config', return_value={'password_protection_enabled': True}), \
+                patch.object(web_app, 'update_config') as update_mock:
+            response = self._post({'mode': 'crop'})
+
+        self.assertEqual(response.status_code, 302)
+        self.assertIn('/login', response.headers.get('Location', ''))
+        update_mock.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_subtitle_qc_timeout_persistence.py
+++ b/tests/test_subtitle_qc_timeout_persistence.py
@@ -83,6 +83,13 @@ class SubtitleQcTimeoutPersistenceChainTests(unittest.TestCase):
             _build_openai_client("k", "https://x/v1", "m")
         return saved, reloaded, captured['cfg']
 
+    def test_first_update_does_not_mutate_module_defaults(self):
+        self.assertFalse(os.path.exists(os.path.join(self._tmp, 'config', 'config.json')))
+
+        update_config({'SUBTITLE_QC_TIMEOUT_SECONDS': '200'})
+
+        self.assertEqual(cm.DEFAULT_CONFIG['SUBTITLE_QC_TIMEOUT_SECONDS'], 120)
+
     def test_valid_value_persists_and_is_used(self):
         saved, reloaded, used = self._save_and_trace('200')
         self.assertEqual(saved.get('SUBTITLE_QC_TIMEOUT_SECONDS'), '200')

--- a/tests/test_task_manager_delete_task_files.py
+++ b/tests/test_task_manager_delete_task_files.py
@@ -4,7 +4,7 @@ import pathlib
 import shutil
 import tempfile
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 
 def _safe_join(base, *paths):
@@ -79,6 +79,17 @@ class DeleteTaskFilesTests(unittest.TestCase):
 
         self.assertTrue(result)
         self.assertFalse(os.path.exists(task_dir))
+
+    def test_delete_task_files_reports_rmtree_failure(self):
+        task_dir = os.path.join(self.downloads_dir, self.TASK_ID)
+        os.makedirs(task_dir, exist_ok=True)
+
+        with patch.object(shutil, 'rmtree', side_effect=PermissionError('in use')):
+            result = self.delete_task_files(self.TASK_ID)
+
+        self.assertFalse(result)
+        self.assertTrue(os.path.exists(task_dir))
+        self.mock_logger.error.assert_called()
 
 
 if __name__ == '__main__':

--- a/tests/test_youtube_monitor_dedup_before_truncation.py
+++ b/tests/test_youtube_monitor_dedup_before_truncation.py
@@ -118,6 +118,106 @@ def _make_raw_video(vid):
     }
 
 
+class _FakeResource:
+    def __init__(self, request_kind, calls):
+        self.request_kind = request_kind
+        self.calls = calls
+
+    def list(self, **params):
+        self.calls.append((self.request_kind, params))
+        return self.request_kind
+
+
+class _FakeYouTube:
+    def __init__(self):
+        self.calls = []
+
+    def search(self):
+        return _FakeResource('search.list', self.calls)
+
+    def videos(self):
+        return _FakeResource('videos.list', self.calls)
+
+
+class SearchKeywordQueryTests(unittest.TestCase):
+    def _new_monitor(self):
+        monitor = YouTubeMonitor.__new__(YouTubeMonitor)
+        monitor.youtube = _FakeYouTube()
+        monitor._last_fetch_had_errors = False
+        return monitor
+
+    @staticmethod
+    def _config(keywords):
+        return {
+            'keywords': keywords,
+            'max_results': 5,
+            'region_code': 'US',
+            'order_by': 'date',
+            'video_types': 'video,short,live',
+            'category_id': '0',
+        }
+
+    def test_multiple_keywords_use_one_native_or_search_request(self):
+        monitor = self._new_monitor()
+
+        def execute(request, _operation):
+            if request == 'search.list':
+                return {'items': [
+                    {'id': {'videoId': 'v1'}},
+                    {'id': {'videoId': 'v2'}},
+                ]}
+            return {'items': [_make_raw_video('v1'), _make_raw_video('v2')]}
+
+        monitor._execute_with_retry = execute
+
+        videos = monitor._fetch_search_videos(
+            self._config('alpha beta,gamma'),
+            '2024-01-01T00:00:00Z',
+        )
+
+        search_calls = [params for kind, params in monitor.youtube.calls if kind == 'search.list']
+        self.assertEqual(len(search_calls), 1)
+        self.assertEqual(search_calls[0]['q'], 'alpha|beta|gamma')
+        self.assertEqual([video['id'] for video in videos], ['v1', 'v2'])
+        self.assertFalse(monitor._last_fetch_had_errors)
+
+    def test_failed_search_marks_run_incomplete(self):
+        monitor = self._new_monitor()
+
+        def execute(_request, _operation):
+            raise RuntimeError('quota unavailable')
+
+        monitor._execute_with_retry = execute
+
+        videos = monitor._fetch_search_videos(
+            self._config('alpha beta'),
+            '2024-01-01T00:00:00Z',
+        )
+
+        self.assertEqual(videos, [])
+        self.assertTrue(monitor._last_fetch_had_errors)
+        search_calls = [params for kind, params in monitor.youtube.calls if kind == 'search.list']
+        self.assertEqual(len(search_calls), 1)
+
+    def test_invalid_video_details_response_marks_run_incomplete(self):
+        monitor = self._new_monitor()
+
+        def execute(request, _operation):
+            if request == 'search.list':
+                return {'items': [{'id': {'videoId': 'v1'}}]}
+            return {}
+
+        monitor._execute_with_retry = execute
+
+        videos = monitor._fetch_search_videos(
+            self._config('alpha'),
+            '2024-01-01T00:00:00Z',
+        )
+
+        self.assertEqual(videos, [])
+        self.assertTrue(monitor._last_fetch_had_errors)
+
+
 class DedupBeforeTruncationTests(unittest.TestCase):
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp()


### PR DESCRIPTION
## 变更概览

- 按实际端点隔离 AI 故障转移的能力缓存、模型/API 模式和 thinking 参数，避免备用端点污染恢复后的主端点。
- 将 YouTube 多关键词合并为原生 OR 查询，减少 search.list 请求；抓取异常时不推进 last_run_time。
- 修复首次加载默认配置时污染模块级默认值，以及上传后文件删除失败仍误报成功的问题。
- 补齐受登录保护的封面处理模式接口，并同步持久化配置与运行时任务处理器。
- Windows 手动发布准确 checkout 指定 tag；Docker 和 Windows 构建前加入完整测试门禁。

## 验证

- python -m pytest -q：437 passed
- python -m unittest discover -s tests -p test*.py：437 passed
- python -m compileall -q app.py modules tests：通过
- 两个 workflow 通过 PyYAML 解析，git diff --check 通过
- Edge 桌面/390px 移动端冒烟：首页、任务、设置、YouTube 监控均为 200，无横向溢出或严重控制台错误

## 发布注意

发布 tag 使用三段式 4.10.0（或 v4.10.0）；两段式 4.10 不会触发 Docker 发布，并会被 Windows 发布校验拒绝。

本地未执行完整 Docker 构建和 PyInstaller 打包，交由 PR/发布 CI 验证。