### PR TITLE
fix(asr): normalize inherited LLM endpoint for Whisper

### DIFF
--- a/modules/config_manager.py
+++ b/modules/config_manager.py
@@ -170,9 +170,10 @@ DEFAULT_CONFIG = {
     # 语音识别（无字幕转写）
     "SPEECH_RECOGNITION_ENABLED": False,  # 启用语音识别生成字幕
     "SPEECH_RECOGNITION_PROVIDER": "whisper",  # whisper（OpenAI兼容）
-    # Whisper/OpenAI 兼容配置（可单独配置，未设置则回退到 OPENAI_*）
+    # Whisper/OpenAI 兼容配置。ASR 与 LLM 端点独立，避免全局 LLM 使用
+    # /responses 时被错误地用于 /audio/transcriptions。
     "WHISPER_API_KEY": "",
-    "WHISPER_BASE_URL": "",
+    "WHISPER_BASE_URL": "https://api.openai.com/v1",
     "WHISPER_MODEL_NAME": "whisper-1",
     "WHISPER_TIMESTAMP_GRANULARITIES": "segment,word",
     # Voxtral（Mistral /v1/audio/transcriptions）配置

--- a/modules/config_manager.py
+++ b/modules/config_manager.py
@@ -170,10 +170,9 @@ DEFAULT_CONFIG = {
     # 语音识别（无字幕转写）
     "SPEECH_RECOGNITION_ENABLED": False,  # 启用语音识别生成字幕
     "SPEECH_RECOGNITION_PROVIDER": "whisper",  # whisper（OpenAI兼容）
-    # Whisper/OpenAI 兼容配置。ASR 与 LLM 端点独立，避免全局 LLM 使用
-    # /responses 时被错误地用于 /audio/transcriptions。
+    # Whisper/OpenAI 兼容配置（留空时继承 OPENAI_*，继承地址会先规范化为 API 根地址）
     "WHISPER_API_KEY": "",
-    "WHISPER_BASE_URL": "https://api.openai.com/v1",
+    "WHISPER_BASE_URL": "",
     "WHISPER_MODEL_NAME": "whisper-1",
     "WHISPER_TIMESTAMP_GRANULARITIES": "segment,word",
     # Voxtral（Mistral /v1/audio/transcriptions）配置

--- a/modules/speech_pipeline_settings.py
+++ b/modules/speech_pipeline_settings.py
@@ -35,8 +35,8 @@ SPEECH_PIPELINE_DEFAULTS: Dict[str, Any] = {
     "SPEECH_RECOGNITION_ENABLED": False,
     "SPEECH_RECOGNITION_PROVIDER": "whisper",
     "WHISPER_API_KEY": "",
-    # ASR 不继承 OPENAI_BASE_URL：后者可能是仅供 LLM 的 /responses 端点。
-    "WHISPER_BASE_URL": "https://api.openai.com/v1",
+    # 留空时继承全局 OpenAI 地址；创建 ASR 客户端前会移除生成端点后缀。
+    "WHISPER_BASE_URL": "",
     "WHISPER_MODEL_NAME": "whisper-1",
     "WHISPER_TIMESTAMP_GRANULARITIES": "segment,word",
     "VOXTRAL_API_KEY": "",

--- a/modules/speech_pipeline_settings.py
+++ b/modules/speech_pipeline_settings.py
@@ -35,7 +35,8 @@ SPEECH_PIPELINE_DEFAULTS: Dict[str, Any] = {
     "SPEECH_RECOGNITION_ENABLED": False,
     "SPEECH_RECOGNITION_PROVIDER": "whisper",
     "WHISPER_API_KEY": "",
-    "WHISPER_BASE_URL": "",
+    # ASR 不继承 OPENAI_BASE_URL：后者可能是仅供 LLM 的 /responses 端点。
+    "WHISPER_BASE_URL": "https://api.openai.com/v1",
     "WHISPER_MODEL_NAME": "whisper-1",
     "WHISPER_TIMESTAMP_GRANULARITIES": "segment,word",
     "VOXTRAL_API_KEY": "",

--- a/modules/speech_recognition.py
+++ b/modules/speech_recognition.py
@@ -524,10 +524,16 @@ def create_speech_recognizer_from_config(
             timeout_s = float(app_config.get('OPENAI_TIMEOUT_SECONDS', 600) or 600.0)
         else:
             api_provider = 'whisper'
-            # ASR 与 LLM 配置必须保持隔离。全局 OPENAI_BASE_URL 可能是完整
-            # /responses 地址，该协议不能用于 audio/transcriptions。
-            api_key = app_config.get('WHISPER_API_KEY') or ''
-            base_url = app_config.get('WHISPER_BASE_URL') or 'https://api.openai.com/v1'
+            api_key = app_config.get('WHISPER_API_KEY') or app_config.get('OPENAI_API_KEY', '')
+            configured_base_url = (
+                app_config.get('WHISPER_BASE_URL')
+                or app_config.get('OPENAI_BASE_URL')
+                or 'https://api.openai.com/v1'
+            )
+            # 兼容旧配置继续继承全局端点，但不能把完整的 /responses 或
+            # /chat/completions 生成地址直接拼接为 /audio/transcriptions。
+            from .utils import normalize_openai_base_url
+            base_url = normalize_openai_base_url(configured_base_url)
             model_name = app_config.get('WHISPER_MODEL_NAME') or 'whisper-1'
             language = app_config.get('WHISPER_LANGUAGE') or ''
             prompt = app_config.get('WHISPER_PROMPT') or ''

--- a/modules/speech_recognition.py
+++ b/modules/speech_recognition.py
@@ -524,8 +524,10 @@ def create_speech_recognizer_from_config(
             timeout_s = float(app_config.get('OPENAI_TIMEOUT_SECONDS', 600) or 600.0)
         else:
             api_provider = 'whisper'
-            api_key = app_config.get('WHISPER_API_KEY') or app_config.get('OPENAI_API_KEY', '')
-            base_url = app_config.get('WHISPER_BASE_URL') or app_config.get('OPENAI_BASE_URL', 'https://api.openai.com/v1')
+            # ASR 与 LLM 配置必须保持隔离。全局 OPENAI_BASE_URL 可能是完整
+            # /responses 地址，该协议不能用于 audio/transcriptions。
+            api_key = app_config.get('WHISPER_API_KEY') or ''
+            base_url = app_config.get('WHISPER_BASE_URL') or 'https://api.openai.com/v1'
             model_name = app_config.get('WHISPER_MODEL_NAME') or 'whisper-1'
             language = app_config.get('WHISPER_LANGUAGE') or ''
             prompt = app_config.get('WHISPER_PROMPT') or ''

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -885,7 +885,7 @@
                                                     <div class="col-md-6">
                                                         <div class="form-group">
                                                             <label for="whisper-api-key" class="form-label">Whisper API 密钥</label>
-                                                            <input type="password" id="whisper-api-key" name="WHISPER_API_KEY" value="{{ config.get('WHISPER_API_KEY', '') }}" class="form-control" placeholder="ASR 服务的 API 密钥">
+                                                            <input type="password" id="whisper-api-key" name="WHISPER_API_KEY" value="{{ config.get('WHISPER_API_KEY', '') }}" class="form-control" placeholder="留空沿用 OpenAI 密钥">
                                                         </div>
                                                     </div>
                                                     <div class="col-md-6">
@@ -897,8 +897,8 @@
                                                     <div class="col-12">
                                                         <div class="form-group">
                                                             <label for="whisper-base-url" class="form-label">Whisper 接口地址</label>
-                                                            <input type="text" id="whisper-base-url" name="WHISPER_BASE_URL" value="{{ config.get('WHISPER_BASE_URL', 'https://api.openai.com/v1') }}" class="form-control" placeholder="如 https://api.openai.com/v1">
-                                                            <p class="help-text mb-0 mt-2">ASR 使用独立接口，不会继承全局 LLM 的地址或密钥；请填写支持 <code>/audio/transcriptions</code> 的 API 根地址，不能填写 <code>/responses</code>。</p>
+                                                            <input type="text" id="whisper-base-url" name="WHISPER_BASE_URL" value="{{ config.get('WHISPER_BASE_URL', '') }}" class="form-control" placeholder="留空沿用 OpenAI 接口地址">
+                                                            <p class="help-text mb-0 mt-2">建议填写支持 <code>/audio/transcriptions</code> 的 API 根地址。留空时继续沿用全局 OpenAI 地址和密钥；系统会自动移除末尾的 <code>/responses</code> 或 <code>/chat/completions</code>，兼容旧配置。若 LLM 与 ASR 使用不同服务，请在此显式填写 ASR 地址和密钥。</p>
                                                         </div>
                                                     </div>
                                                 </div>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -885,7 +885,7 @@
                                                     <div class="col-md-6">
                                                         <div class="form-group">
                                                             <label for="whisper-api-key" class="form-label">Whisper API 密钥</label>
-                                                            <input type="password" id="whisper-api-key" name="WHISPER_API_KEY" value="{{ config.get('WHISPER_API_KEY', '') }}" class="form-control" placeholder="留空沿用 OpenAI 密钥">
+                                                            <input type="password" id="whisper-api-key" name="WHISPER_API_KEY" value="{{ config.get('WHISPER_API_KEY', '') }}" class="form-control" placeholder="ASR 服务的 API 密钥">
                                                         </div>
                                                     </div>
                                                     <div class="col-md-6">
@@ -897,7 +897,8 @@
                                                     <div class="col-12">
                                                         <div class="form-group">
                                                             <label for="whisper-base-url" class="form-label">Whisper 接口地址</label>
-                                                            <input type="text" id="whisper-base-url" name="WHISPER_BASE_URL" value="{{ config.get('WHISPER_BASE_URL', '') }}" class="form-control" placeholder="留空沿用 OpenAI 接口地址">
+                                                            <input type="text" id="whisper-base-url" name="WHISPER_BASE_URL" value="{{ config.get('WHISPER_BASE_URL', 'https://api.openai.com/v1') }}" class="form-control" placeholder="如 https://api.openai.com/v1">
+                                                            <p class="help-text mb-0 mt-2">ASR 使用独立接口，不会继承全局 LLM 的地址或密钥；请填写支持 <code>/audio/transcriptions</code> 的 API 根地址，不能填写 <code>/responses</code>。</p>
                                                         </div>
                                                     </div>
                                                 </div>

--- a/tests/test_speech_recognition_config.py
+++ b/tests/test_speech_recognition_config.py
@@ -16,7 +16,7 @@ class SpeechRecognitionConfigTests(unittest.TestCase):
         self.assertEqual(recognizer.config.api_provider, 'whisper')
         self.assertEqual(recognizer.config.whisper_timestamp_granularities, 'word')
 
-    def test_whisper_does_not_inherit_global_responses_endpoint_or_key(self):
+    def test_whisper_inherits_key_and_normalizes_global_responses_endpoint(self):
         recognizer = create_speech_recognizer_from_config({
             'SPEECH_RECOGNITION_ENABLED': True,
             'SPEECH_RECOGNITION_PROVIDER': 'whisper',
@@ -25,8 +25,20 @@ class SpeechRecognitionConfigTests(unittest.TestCase):
         }, task_id='unit-test-whisper-isolated')
 
         self.assertIsNotNone(recognizer)
-        self.assertEqual(recognizer.config.api_key, '')
-        self.assertEqual(recognizer.config.base_url, 'https://api.openai.com/v1')
+        self.assertEqual(recognizer.config.api_key, 'global-llm-key')
+        self.assertEqual(recognizer.config.base_url, 'https://llm.example/v1')
+
+    def test_whisper_keeps_inheriting_custom_global_api_root(self):
+        recognizer = create_speech_recognizer_from_config({
+            'SPEECH_RECOGNITION_ENABLED': True,
+            'SPEECH_RECOGNITION_PROVIDER': 'whisper',
+            'OPENAI_API_KEY': 'gateway-key',
+            'OPENAI_BASE_URL': 'https://gateway.example/custom/v1',
+        }, task_id='unit-test-whisper-custom-global')
+
+        self.assertIsNotNone(recognizer)
+        self.assertEqual(recognizer.config.api_key, 'gateway-key')
+        self.assertEqual(recognizer.config.base_url, 'https://gateway.example/custom/v1')
 
     def test_whisper_uses_its_own_endpoint_and_key(self):
         recognizer = create_speech_recognizer_from_config({

--- a/tests/test_speech_recognition_config.py
+++ b/tests/test_speech_recognition_config.py
@@ -16,6 +16,32 @@ class SpeechRecognitionConfigTests(unittest.TestCase):
         self.assertEqual(recognizer.config.api_provider, 'whisper')
         self.assertEqual(recognizer.config.whisper_timestamp_granularities, 'word')
 
+    def test_whisper_does_not_inherit_global_responses_endpoint_or_key(self):
+        recognizer = create_speech_recognizer_from_config({
+            'SPEECH_RECOGNITION_ENABLED': True,
+            'SPEECH_RECOGNITION_PROVIDER': 'whisper',
+            'OPENAI_API_KEY': 'global-llm-key',
+            'OPENAI_BASE_URL': 'https://llm.example/v1/responses',
+        }, task_id='unit-test-whisper-isolated')
+
+        self.assertIsNotNone(recognizer)
+        self.assertEqual(recognizer.config.api_key, '')
+        self.assertEqual(recognizer.config.base_url, 'https://api.openai.com/v1')
+
+    def test_whisper_uses_its_own_endpoint_and_key(self):
+        recognizer = create_speech_recognizer_from_config({
+            'SPEECH_RECOGNITION_ENABLED': True,
+            'SPEECH_RECOGNITION_PROVIDER': 'whisper',
+            'WHISPER_API_KEY': 'asr-key',
+            'WHISPER_BASE_URL': 'https://asr.example/v1',
+            'OPENAI_API_KEY': 'global-llm-key',
+            'OPENAI_BASE_URL': 'https://llm.example/v1/responses',
+        }, task_id='unit-test-whisper-own-config')
+
+        self.assertIsNotNone(recognizer)
+        self.assertEqual(recognizer.config.api_key, 'asr-key')
+        self.assertEqual(recognizer.config.base_url, 'https://asr.example/v1')
+
     def test_voxtral_config_keeps_voxtral_timestamp_granularities(self):
         recognizer = create_speech_recognizer_from_config({
             'SPEECH_RECOGNITION_ENABLED': True,


### PR DESCRIPTION
## Summary
- normalize inherited OpenAI `/responses` or `/chat/completions` URLs to an API root before constructing Whisper `/audio/transcriptions` requests
- preserve backward compatibility for installations that leave `WHISPER_API_KEY` and `WHISPER_BASE_URL` empty to reuse a self-hosted OpenAI-compatible gateway
- keep explicit Whisper credentials and endpoint as the highest-priority override
- clarify the inheritance and separate-service migration path in Settings

## Compatibility
Existing users do not need to migrate when their global gateway supports both LLM and audio APIs: blank Whisper fields continue to inherit the global key and normalized root URL. Users whose ASR runs on a different service should explicitly fill `WHISPER_API_KEY` and `WHISPER_BASE_URL`.

## Tests
- `python -m pytest -q`
- 473 passed, 32 subtests passed