### PR TITLE
fix(ai): 移除客户端输出 token 限制

### DIFF
--- a/modules/ai_enhancer.py
+++ b/modules/ai_enhancer.py
@@ -540,7 +540,6 @@ def _request_chat_completion(
     system_prompt: str,
     payload: Dict[str, Any],
     *,
-    max_tokens: Optional[int] = None,
     temperature: float,
     thinking_enabled: bool,
     logger_obj,
@@ -560,8 +559,6 @@ def _request_chat_completion(
         ],
         "temperature": temperature,
     }
-    if max_tokens is not None:
-        create_kwargs["max_tokens"] = max_tokens
     if response_format is not None:
         create_kwargs["response_format"] = response_format
     request_start = time.time()
@@ -588,7 +585,6 @@ def _request_json_object(
     system_prompt: str,
     payload: Dict[str, Any],
     *,
-    max_tokens: Optional[int] = None,
     temperature: float,
     thinking_enabled: bool,
     logger_obj,
@@ -598,7 +594,7 @@ def _request_json_object(
     try:
         response = _request_chat_completion(
             client, model_name, system_prompt, payload,
-            max_tokens=max_tokens, temperature=temperature,
+            temperature=temperature,
             thinking_enabled=thinking_enabled, logger_obj=logger_obj,
             scene_name=scene_name, user_content=user_content,
             response_format={"type": "json_object"},
@@ -611,7 +607,7 @@ def _request_json_object(
                 )
             response = _request_chat_completion(
                 client, model_name, system_prompt, payload,
-                max_tokens=max_tokens, temperature=temperature,
+                temperature=temperature,
                 thinking_enabled=thinking_enabled, logger_obj=logger_obj,
                 scene_name=f"{scene_name}_fallback_plain_json",
                 user_content=user_content,
@@ -638,7 +634,7 @@ def _request_json_object(
     try:
         response = _request_chat_completion(
             client, model_name, retry_system, payload,
-            max_tokens=max_tokens, temperature=temperature,
+            temperature=temperature,
             thinking_enabled=thinking_enabled, logger_obj=logger_obj,
             scene_name=f"{scene_name}_retry_json",
             user_content=user_content,
@@ -668,7 +664,6 @@ def _request_raw_text(
     system_prompt: str,
     payload: Dict[str, Any],
     *,
-    max_tokens: Optional[int] = None,
     temperature: float,
     thinking_enabled: bool,
     logger_obj,
@@ -678,7 +673,7 @@ def _request_raw_text(
     """请求 LLM 返回原始文本（不做 JSON 解析），用于索引制分段等场景。"""
     response = _request_chat_completion(
         client, model_name, system_prompt, payload,
-        max_tokens=max_tokens, temperature=temperature,
+        temperature=temperature,
         thinking_enabled=thinking_enabled, logger_obj=logger_obj,
         scene_name=scene_name, user_content=user_content,
     )
@@ -704,16 +699,6 @@ def _sanitize_metadata_field(
         title_limit=title_limit,
         description_limit=description_limit,
     )
-
-
-def _estimate_metadata_max_tokens(field_names: Sequence[str]) -> int:
-    total = 0
-    field_set = set(field_names)
-    if "title" in field_set:
-        total += 160
-    if "description" in field_set:
-        total += 900
-    return max(total, 160)
 
 
 def _collect_invalid_metadata_fields(
@@ -833,7 +818,6 @@ def _request_translated_metadata_fields(
     system_prompt: str,
     payload: Dict[str, Any],
     *,
-    max_tokens: int,
     thinking_enabled: bool,
     logger,
     scene_name: str,
@@ -847,7 +831,6 @@ def _request_translated_metadata_fields(
         model_name=model_name,
         system_prompt=system_prompt,
         payload=payload,
-        max_tokens=max_tokens,
         temperature=0.2,
         thinking_enabled=thinking_enabled,
         logger_obj=logger,
@@ -937,7 +920,6 @@ def _translate_video_metadata_once(
         model_name=model_name,
         system_prompt=_build_metadata_translation_system_prompt(target_language, retry=False, openai_config=openai_config),
         payload=payload,
-        max_tokens=_estimate_metadata_max_tokens(requestable_fields),
         thinking_enabled=thinking_enabled,
         scene_name="ai_enhancer_metadata_translate",
         logger=logger,
@@ -968,7 +950,6 @@ def _translate_video_metadata_once(
                 model_name=model_name,
                 system_prompt=_build_metadata_translation_system_prompt(target_language, retry=True, openai_config=openai_config),
                 payload=retry_payload,
-                max_tokens=_estimate_metadata_max_tokens(["title"]),
                 thinking_enabled=thinking_enabled,
                 scene_name="ai_enhancer_metadata_translate_title_retry",
                 logger=logger,
@@ -1000,7 +981,6 @@ def _translate_video_metadata_once(
                 model_name=model_name,
                 system_prompt=description_retry_prompt,
                 payload=description_retry_payload,
-                max_tokens=_estimate_metadata_max_tokens(["description"]),
                 thinking_enabled=thinking_enabled,
                 scene_name=description_retry_scene,
                 logger=logger,
@@ -1235,7 +1215,6 @@ def generate_acfun_tags(title, description, openai_config=None, task_id=None):
                 "title": title,
                 "description": description[:200],
             },
-            max_tokens=160,
             temperature=0.2,
             thinking_enabled=openai_config.get('OPENAI_THINKING_ENABLED', False),
             logger_obj=logger,
@@ -1900,7 +1879,6 @@ def _request_partition_selection(
         model_name=model_name,
         system_prompt=system_prompt,
         payload=payload,
-        max_tokens=320,
         temperature=0.0,
         thinking_enabled=openai_config.get('OPENAI_THINKING_ENABLED', False),
         logger_obj=logger,

--- a/modules/ai_fallback_client.py
+++ b/modules/ai_fallback_client.py
@@ -386,13 +386,10 @@ def _responses_create_kwargs(chat_kwargs):
         result['instructions'] = '\n\n'.join(instructions)
     result['input'] = response_input
 
-    token_limit = result.pop('max_completion_tokens', None)
-    if token_limit is None:
-        token_limit = result.pop('max_tokens', None)
-    else:
-        result.pop('max_tokens', None)
-    if token_limit is not None:
-        result['max_output_tokens'] = token_limit
+    # 思考与最终正文共享输出额度；项目统一不向上游发送输出 token 上限。
+    result.pop('max_completion_tokens', None)
+    result.pop('max_tokens', None)
+    result.pop('max_output_tokens', None)
 
     response_format = result.pop('response_format', None)
     if response_format is not None:
@@ -476,6 +473,10 @@ def _raise_for_responses_failure(response):
 
 
 def _create_on_endpoint(raw_client, endpoint, chat_kwargs):
+    chat_kwargs = dict(chat_kwargs or {})
+    chat_kwargs.pop('max_tokens', None)
+    chat_kwargs.pop('max_completion_tokens', None)
+    chat_kwargs.pop('max_output_tokens', None)
     if endpoint.get('api_mode') == 'responses':
         response = raw_client.responses.create(**_responses_create_kwargs(chat_kwargs))
         _raise_for_responses_failure(response)

--- a/modules/ai_segmentation.py
+++ b/modules/ai_segmentation.py
@@ -452,13 +452,6 @@ def build_batches(
 # AI 调用与解析
 # ---------------------------------------------------------------------------
 
-def _estimate_max_tokens(char_count: int) -> int:
-    """根据输入字符数估算输出 max_tokens。"""
-    # 输出文本≈输入文本，CJK 约 1 字/token，ASCII 约 0.5 token/字；加结构开销
-    estimated = max(1024, int(char_count * 1.5) + 256)
-    return min(8192, estimated)
-
-
 def _build_word_payload(words: List[AsrWordTiming]) -> Dict[str, Any]:
     return {
         'words': [
@@ -1475,10 +1468,9 @@ class AISegmenter:
         self,
         system_prompt: str,
         payload: Dict[str, Any],
-        char_count: int,
+        _char_count: int,
     ) -> Optional[Dict[str, Any]]:
         client = self._create_client()
-        max_tokens = _estimate_max_tokens(char_count)
         last_exc: Optional[Exception] = None
         for attempt in range(self.config.max_retries + 1):
             if attempt > 0:
@@ -1491,7 +1483,6 @@ class AISegmenter:
                     model_name=self.config.resolved_model_name,
                     system_prompt=system_prompt,
                     payload=payload,
-                    max_tokens=max_tokens,
                     temperature=self.config.temperature,
                     thinking_enabled=self.config.thinking_enabled,
                     logger_obj=self.logger,
@@ -1518,11 +1509,10 @@ class AISegmenter:
         self,
         system_prompt: str,
         payload: Dict[str, Any],
-        char_count: int,
+        _char_count: int,
     ) -> str:
         """调用 LLM 并返回原始文本（不做 JSON 解析），用于索引制分段。"""
         client = self._create_client()
-        max_tokens = _estimate_max_tokens(char_count)
         last_exc: Optional[Exception] = None
         for attempt in range(self.config.max_retries + 1):
             if attempt > 0:
@@ -1535,7 +1525,6 @@ class AISegmenter:
                     model_name=self.config.resolved_model_name,
                     system_prompt=system_prompt,
                     payload=payload,
-                    max_tokens=max_tokens,
                     temperature=self.config.temperature,
                     thinking_enabled=self.config.thinking_enabled,
                     logger_obj=self.logger,

--- a/modules/ai_segmentation.py
+++ b/modules/ai_segmentation.py
@@ -1415,7 +1415,7 @@ class AISegmenter:
             has_context=bool(context_cues),
         )
         payload = _build_word_payload_with_context(batch.words, context_cues or [])
-        raw_text = self._call_with_retry_raw(system_prompt, payload, batch.char_count)
+        raw_text = self._call_with_retry_raw(system_prompt, payload)
         # 索引制解析：AI 返回 [{start_index, end_index}]
         ranges = _parse_index_ranges(raw_text, len(batch.words))
         cues = _cues_from_index_ranges(ranges, batch.words, provider, logger=self.logger)
@@ -1439,7 +1439,7 @@ class AISegmenter:
             has_context=bool(context_cues),
         )
         payload = _build_segment_payload_with_context(batch.segments, context_cues or [])
-        parsed = self._call_with_retry(system_prompt, payload, batch.char_count)
+        parsed = self._call_with_retry(system_prompt, payload)
         cues_data = _parse_cues_response(
             parsed, batch.time_start_s, batch.time_end_s, len(batch.segments),
         )
@@ -1468,7 +1468,6 @@ class AISegmenter:
         self,
         system_prompt: str,
         payload: Dict[str, Any],
-        _char_count: int,
     ) -> Optional[Dict[str, Any]]:
         client = self._create_client()
         last_exc: Optional[Exception] = None
@@ -1509,7 +1508,6 @@ class AISegmenter:
         self,
         system_prompt: str,
         payload: Dict[str, Any],
-        _char_count: int,
     ) -> str:
         """调用 LLM 并返回原始文本（不做 JSON 解析），用于索引制分段。"""
         client = self._create_client()
@@ -1608,7 +1606,7 @@ class AISegmenter:
                     max_duration_s=self.config.max_cue_duration_s,
                     max_cps=self.config.max_cps,
                 )
-                parsed = self._call_with_retry(system_prompt, payload, sum(len(w.text or '') for w in boundary_words))
+                parsed = self._call_with_retry(system_prompt, payload)
                 refined_cues_data = _parse_cues_response(
                     parsed,
                     boundary_prev[0].start_s,

--- a/modules/subtitle_qc.py
+++ b/modules/subtitle_qc.py
@@ -772,7 +772,6 @@ def _call_ai_judge(
                     {'role': 'user', 'content': json.dumps(user, ensure_ascii=False)}
                 ],
                 'temperature': 0.0,
-                'max_tokens': 120,
                 'response_format': {'type': 'json_object'},
             },
             thinking_enabled=config.get('SUBTITLE_QC_THINKING_ENABLED', False),

--- a/modules/subtitle_translator.py
+++ b/modules/subtitle_translator.py
@@ -473,7 +473,6 @@ class LLMRequester:
                 {"role": "system", "content": system_prompt},
                 {"role": "user", "content": user_prompt},
             ],
-            "max_tokens": 4096,
         }
         if json_mode:
             create_kwargs["response_format"] = {"type": "json_object"}

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -357,9 +357,6 @@ def _is_parameter_compatibility_error(exc, parameter: str) -> bool:
             'response_format', 'response format', 'text.format',
             'text.format.type', 'json_object', 'json mode',
         ),
-        'max_tokens': ('max_tokens', 'max tokens'),
-        'max_completion_tokens': ('max_completion_tokens', 'max completion tokens'),
-        'max_output_tokens': ('max_output_tokens', 'max output tokens'),
         'temperature': ('temperature',),
         'system_role': (
             'system role', "role 'system'", 'role: system', 'messages[0].role',
@@ -507,13 +504,6 @@ def _cache_compatibility_actions(cache_key: str, discovered_actions) -> None:
             actions = set()
             _OPENAI_COMPATIBILITY_CACHE.pop(cache_key, None)
         actions.update(discovered_actions)
-        if 'drop_max_output_tokens' in discovered_actions:
-            actions.discard('use_max_tokens')
-            actions.discard('use_max_completion_tokens')
-        elif 'use_max_completion_tokens' in discovered_actions:
-            actions.discard('use_max_tokens')
-        elif 'use_max_tokens' in discovered_actions:
-            actions.discard('use_max_completion_tokens')
         if 'inline_instructions' in discovered_actions or 'minimal_request' in discovered_actions:
             actions.discard('use_developer_role')
         if (
@@ -590,13 +580,6 @@ def _apply_compatibility_actions(create_kwargs, actions):
         _drop_thinking_control(adapted)
     if 'drop_response_format' in actions:
         adapted.pop('response_format', None)
-    if 'drop_max_output_tokens' in actions:
-        adapted.pop('max_tokens', None)
-        adapted.pop('max_completion_tokens', None)
-    elif 'use_max_completion_tokens' in actions and 'max_tokens' in adapted:
-        adapted['max_completion_tokens'] = adapted.pop('max_tokens')
-    elif 'use_max_tokens' in actions and 'max_completion_tokens' in adapted:
-        adapted['max_tokens'] = adapted.pop('max_completion_tokens')
     if 'drop_temperature' in actions:
         adapted.pop('temperature', None)
     if 'inline_instructions' in actions:
@@ -620,9 +603,6 @@ def _warn_compatibility_fallback(logger, cache_key: str, action: str, scene_name
     descriptions = {
         'drop_thinking': '不支持当前模型的思考控制参数，已移除该扩展参数',
         'drop_response_format': '不支持 JSON response_format，已改用提示词约束并解析文本 JSON',
-        'use_max_completion_tokens': '不支持 max_tokens，已改用 max_completion_tokens',
-        'use_max_tokens': '不支持 max_completion_tokens，已回退 max_tokens',
-        'drop_max_output_tokens': '不支持 Responses max_output_tokens，已使用模型默认输出上限',
         'drop_temperature': '不支持自定义 temperature，已使用模型默认值',
         'use_developer_role': '不支持 system role，已改用 developer role',
         'inline_instructions': '不支持独立指令角色，已将指令合并到 user 消息',
@@ -647,6 +627,11 @@ def _openai_chat_create_with_thinking_control_single(
     鉴权、限流、配额和服务端错误不会在这里被误判为兼容问题。
     """
     base_kwargs = copy.deepcopy(create_kwargs or {})
+    # 思考模型会把推理过程和最终正文共同计入输出额度。统一移除客户端侧输出
+    # token 上限，避免短额度在生成最终正文前耗尽；实际上限交由模型服务端管理。
+    base_kwargs.pop('max_tokens', None)
+    base_kwargs.pop('max_completion_tokens', None)
+    base_kwargs.pop('max_output_tokens', None)
     effective_model = _effective_client_model(client, base_kwargs)
     if effective_model and effective_model != 'unknown':
         # Compatibility retries (especially minimal_request) must carry the
@@ -691,21 +676,6 @@ def _openai_chat_create_with_thinking_control_single(
             ):
                 action = 'drop_response_format'
             elif (
-                ('max_tokens' in request_kwargs or 'max_completion_tokens' in request_kwargs)
-                and _is_parameter_compatibility_error(exc, 'max_output_tokens')
-            ):
-                action = 'drop_max_output_tokens'
-            elif (
-                'max_tokens' in request_kwargs
-                and _is_parameter_compatibility_error(exc, 'max_tokens')
-            ):
-                action = 'use_max_completion_tokens'
-            elif (
-                'max_completion_tokens' in request_kwargs
-                and _is_parameter_compatibility_error(exc, 'max_completion_tokens')
-            ):
-                action = 'use_max_tokens'
-            elif (
                 'temperature' in request_kwargs
                 and _is_parameter_compatibility_error(exc, 'temperature')
             ):
@@ -734,17 +704,6 @@ def _openai_chat_create_with_thinking_control_single(
             attempted_actions.add(action)
             actions.add(action)
             discovered_actions.add(action)
-            if action == 'use_max_completion_tokens':
-                actions.discard('use_max_tokens')
-                discovered_actions.discard('use_max_tokens')
-            elif action == 'use_max_tokens':
-                actions.discard('use_max_completion_tokens')
-                discovered_actions.discard('use_max_completion_tokens')
-            elif action == 'drop_max_output_tokens':
-                actions.discard('use_max_tokens')
-                actions.discard('use_max_completion_tokens')
-                discovered_actions.discard('use_max_tokens')
-                discovered_actions.discard('use_max_completion_tokens')
             if action == 'inline_instructions':
                 actions.discard('use_developer_role')
                 discovered_actions.discard('use_developer_role')

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -688,7 +688,7 @@
                                                             <div class="form-group">
                                                                 <label for="openai-url" class="form-label">接口地址</label>
                                                                 <input type="text" id="openai-url" name="OPENAI_BASE_URL" value="{{ config.OPENAI_BASE_URL }}" class="form-control" placeholder="如 https://api.openai.com/v1">
-                                                                <p class="help-text mb-0 mt-2">填写 OpenAI 兼容 API 的根地址；也可粘贴完整 <code>/chat/completions</code> 或 <code>/responses</code> 地址，系统会自动选择并规范化协议。请求参数和消息格式会按端点实际能力自动协商。</p>
+                                                                <p class="help-text mb-0 mt-2">填写 OpenAI 兼容 API 的根地址；也可粘贴完整 <code>/chat/completions</code> 或 <code>/responses</code> 地址，系统会自动选择并规范化协议。请求参数和消息格式会按端点实际能力自动协商。客户端不限制模型的生成 token 数；如需控制费用或最长输出，请在模型网关设置额度上限和账单告警。</p>
                                                             </div>
                                                         </div>
                                                         <div class="col-md-6">

--- a/tests/test_content_profile_ai.py
+++ b/tests/test_content_profile_ai.py
@@ -140,7 +140,7 @@ class RequestJsonObjectTests(unittest.TestCase):
                    side_effect=client.chat.completions.create.side_effect):
             result = _request_json_object(
                 client, "test-model", "system prompt", {},
-                max_tokens=220, temperature=0.0, thinking_enabled=False,
+                temperature=0.0, thinking_enabled=False,
                 logger_obj=logging.getLogger("test"),
                 scene_name="test_scene",
             )
@@ -155,7 +155,7 @@ class RequestJsonObjectTests(unittest.TestCase):
                    side_effect=client.chat.completions.create.side_effect):
             result = _request_json_object(
                 client, "test-model", "system prompt", {},
-                max_tokens=220, temperature=0.0, thinking_enabled=False,
+                temperature=0.0, thinking_enabled=False,
                 logger_obj=logging.getLogger("test"),
                 scene_name="test_scene",
             )
@@ -171,7 +171,7 @@ class RequestJsonObjectTests(unittest.TestCase):
                    side_effect=client.chat.completions.create.side_effect):
             result = _request_json_object(
                 client, "test-model", "system prompt", {},
-                max_tokens=220, temperature=0.0, thinking_enabled=False,
+                temperature=0.0, thinking_enabled=False,
                 logger_obj=logging.getLogger("test"),
                 scene_name="test_scene",
             )

--- a/tests/test_openai_chat_compatibility.py
+++ b/tests/test_openai_chat_compatibility.py
@@ -86,6 +86,25 @@ class OpenAIChatCompatibilityTests(unittest.TestCase):
 
         self.assertNotIn('extra_body', client.completions.calls[0])
 
+    def test_all_output_token_limits_are_removed_before_request(self):
+        client = _FakeClient()
+        kwargs = _base_kwargs(
+            max_tokens=160,
+            max_completion_tokens=320,
+            max_output_tokens=640,
+        )
+
+        utils.openai_chat_create_with_thinking_control(
+            client,
+            kwargs,
+            thinking_enabled=True,
+        )
+
+        request = client.completions.calls[0]
+        self.assertNotIn('max_tokens', request)
+        self.assertNotIn('max_completion_tokens', request)
+        self.assertNotIn('max_output_tokens', request)
+
     def test_deepseek_thinking_rejection_retries_without_private_parameter(self):
         def responder(kwargs, _call_number):
             if 'extra_body' in kwargs:
@@ -204,42 +223,6 @@ class OpenAIChatCompatibilityTests(unittest.TestCase):
         self.assertNotIn('response_format', client.completions.calls[1])
         self.assertNotIn('response_format', client.completions.calls[2])
 
-    def test_switches_from_max_tokens_to_max_completion_tokens(self):
-        def responder(kwargs, _call_number):
-            if 'max_tokens' in kwargs:
-                raise _CompatError(
-                    "Unsupported parameter: 'max_tokens'. Use 'max_completion_tokens' instead."
-                )
-            return SimpleNamespace(choices=[])
-
-        client = _FakeClient(responder=responder)
-
-        utils.openai_chat_create_with_thinking_control(client, _base_kwargs())
-
-        self.assertEqual(len(client.completions.calls), 2)
-        self.assertEqual(client.completions.calls[1]['max_completion_tokens'], 100)
-        self.assertNotIn('max_tokens', client.completions.calls[1])
-
-    def test_switches_from_max_completion_tokens_to_legacy_max_tokens(self):
-        def responder(kwargs, _call_number):
-            if 'max_completion_tokens' in kwargs:
-                raise _CompatError("Unknown parameter: 'max_completion_tokens'")
-            return SimpleNamespace(choices=[])
-
-        client = _FakeClient(responder=responder)
-        kwargs = _base_kwargs()
-        kwargs.pop('max_tokens')
-        kwargs['max_completion_tokens'] = 100
-
-        utils.openai_chat_create_with_thinking_control(
-            client,
-            kwargs,
-        )
-
-        first_call = client.completions.calls[0]
-        self.assertIn('max_completion_tokens', first_call)
-        self.assertEqual(client.completions.calls[1]['max_tokens'], 100)
-
     def test_removes_unsupported_temperature(self):
         def responder(kwargs, _call_number):
             if 'temperature' in kwargs:
@@ -311,8 +294,6 @@ class OpenAIChatCompatibilityTests(unittest.TestCase):
         def responder(kwargs, _call_number):
             if 'response_format' in kwargs:
                 raise _CompatError("Unknown parameter: 'response_format'")
-            if 'max_tokens' in kwargs:
-                raise _CompatError("Unsupported parameter: 'max_tokens'")
             if 'temperature' in kwargs:
                 raise _CompatError("Unsupported parameter: 'temperature'")
             return SimpleNamespace(choices=[])
@@ -321,11 +302,11 @@ class OpenAIChatCompatibilityTests(unittest.TestCase):
 
         utils.openai_chat_create_with_thinking_control(client, _base_kwargs())
 
-        self.assertEqual(len(client.completions.calls), 4)
+        self.assertEqual(len(client.completions.calls), 3)
         final_call = client.completions.calls[-1]
         self.assertNotIn('response_format', final_call)
         self.assertNotIn('max_tokens', final_call)
-        self.assertEqual(final_call['max_completion_tokens'], 100)
+        self.assertNotIn('max_completion_tokens', final_call)
         self.assertNotIn('temperature', final_call)
 
     def test_authentication_error_is_not_retried(self):

--- a/tests/test_openai_responses_compatibility.py
+++ b/tests/test_openai_responses_compatibility.py
@@ -182,7 +182,7 @@ class ResponsesRequestTests(unittest.TestCase):
         self.assertEqual(request['model'], 'response-model')
         self.assertEqual(request['instructions'], 'Return JSON only.')
         self.assertEqual(request['input'], [{'role': 'user', 'content': 'hello'}])
-        self.assertEqual(request['max_output_tokens'], 256)
+        self.assertNotIn('max_output_tokens', request)
         self.assertEqual(request['text'], {'format': {'type': 'json_object'}})
         self.assertEqual(request['temperature'], 0.2)
         self.assertIs(request['store'], False)
@@ -254,7 +254,7 @@ class ResponsesRequestTests(unittest.TestCase):
 
         self.assertIs(request['store'], True)
 
-    def test_unsupported_max_output_tokens_is_dropped_and_cached(self):
+    def test_output_token_limits_are_removed_before_responses_request(self):
         raw_response = {
             'id': 'resp_token_fallback',
             'status': 'completed',
@@ -265,11 +265,7 @@ class ResponsesRequestTests(unittest.TestCase):
             }],
         }
         raw_client = _FakeRawClient(responses_result=raw_response)
-        raw_client.responses.create = MagicMock(side_effect=[
-            _StatusError('Unsupported parameter: max_output_tokens', 400),
-            raw_response,
-            raw_response,
-        ])
+        raw_client.responses.create = MagicMock(return_value=raw_response)
         with patch.object(afc, '_load_global_config', return_value={}), \
              patch.object(afc, '_make_raw_client', return_value=raw_client):
             client = afc.get_ai_client(self._config())
@@ -277,16 +273,19 @@ class ResponsesRequestTests(unittest.TestCase):
             'model': 'response-model',
             'messages': [{'role': 'user', 'content': 'hello'}],
             'max_tokens': 256,
+            'max_completion_tokens': 512,
+            'max_output_tokens': 1024,
         }
 
         utils.openai_chat_create_with_thinking_control(client, kwargs)
         utils.openai_chat_create_with_thinking_control(client, kwargs)
 
         calls = [call.kwargs for call in raw_client.responses.create.call_args_list]
-        self.assertEqual(len(calls), 3)
-        self.assertEqual(calls[0]['max_output_tokens'], 256)
-        self.assertNotIn('max_output_tokens', calls[1])
-        self.assertNotIn('max_output_tokens', calls[2])
+        self.assertEqual(len(calls), 2)
+        for call in calls:
+            self.assertNotIn('max_tokens', call)
+            self.assertNotIn('max_completion_tokens', call)
+            self.assertNotIn('max_output_tokens', call)
 
     def test_fallback_can_switch_from_responses_to_chat_completions(self):
         primary = _FakeRawClient(error=_StatusError('service unavailable', 503))


### PR DESCRIPTION
## 问题

开启模型思考后，推理内容与最终正文共享输出 token 额度。元数据标题等场景原先设置了较小的 `max_tokens`，导致兼容模型在完成推理前耗尽额度，接口虽然返回 HTTP 200，但 `message.content` 为空。

## 修复

- 移除元数据翻译、标签、分区推荐、字幕翻译、字幕 QC 和 AI 分段中的输出 token 限制
- 在统一 Chat Completions 兼容层剥离 `max_tokens`、`max_completion_tokens` 和 `max_output_tokens`
- 在 Responses API 转换层执行同样的兜底剥离
- 删除已经不再需要的 token 参数兼容降级分支
- 不修改思考开关语义，不针对具体模型或供应商做特判

## 验证

- `python -m pytest -q`
- 469 passed, 32 subtests passed
- 使用开启思考的兼容模型实测：即使调用方遗留传入 `max_tokens=160`，统一层也会移除限制，并正常返回最终 JSON 正文