### PR TITLE
fix(vad): 提升语音窗口边界精度与配置可靠性

### DIFF
--- a/modules/speech_recognition.py
+++ b/modules/speech_recognition.py
@@ -30,6 +30,26 @@ except Exception:  # pragma: no cover - 防御性兜底
     AISegmentationError = Exception  # type: ignore[assignment]
 
 
+def _config_float(config: Dict[str, Any], key: str, default: float) -> float:
+    value = config.get(key)
+    if value is None or (isinstance(value, str) and not value.strip()):
+        return default
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _config_int(config: Dict[str, Any], key: str, default: int) -> int:
+    value = config.get(key)
+    if value is None or (isinstance(value, str) and not value.strip()):
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
 def _setup_task_logger(task_id: str) -> logging.Logger:
     from .utils import get_app_subdir
     from logging.handlers import RotatingFileHandler
@@ -548,19 +568,19 @@ def create_speech_recognizer_from_config(
             model_name=model_name,
             vad_enabled=coerce_bool(app_config.get('VAD_ENABLED', True)),
             vad_provider=app_config.get('VAD_PROVIDER') or 'silero-vad',
-            vad_threshold=float(app_config.get('VAD_SILERO_THRESHOLD', 0.55) or 0.55),
-            vad_min_speech_ms=int(app_config.get('VAD_SILERO_MIN_SPEECH_MS', 300) or 300),
-            vad_min_silence_ms=int(app_config.get('VAD_SILERO_MIN_SILENCE_MS', 320) or 320),
-            vad_max_speech_s=int(app_config.get('VAD_SILERO_MAX_SPEECH_S', 120) or 120),
-            vad_speech_pad_ms=int(app_config.get('VAD_SILERO_SPEECH_PAD_MS', 120) or 120),
-            chunk_window_s=float(app_config.get('AUDIO_CHUNK_WINDOW_S', 15.0) or 15.0),
-            chunk_overlap_s=float(app_config.get('AUDIO_CHUNK_OVERLAP_S', 0.4) or 0.4),
-            vad_merge_gap_s=float(app_config.get('VAD_MERGE_GAP_S', 0.35) or 0.35),
-            vad_min_segment_s=float(app_config.get('VAD_MIN_SEGMENT_S', 0.8) or 0.8),
-            vad_max_segment_s=float(app_config.get('VAD_MAX_SEGMENT_S', 15.0) or 15.0),
-            vad_max_segment_s_for_split=float(app_config.get('VAD_MAX_SEGMENT_S_FOR_SPLIT', 15.0) or 15.0),
+            vad_threshold=_config_float(app_config, 'VAD_SILERO_THRESHOLD', 0.55),
+            vad_min_speech_ms=_config_int(app_config, 'VAD_SILERO_MIN_SPEECH_MS', 300),
+            vad_min_silence_ms=_config_int(app_config, 'VAD_SILERO_MIN_SILENCE_MS', 320),
+            vad_max_speech_s=_config_int(app_config, 'VAD_SILERO_MAX_SPEECH_S', 120),
+            vad_speech_pad_ms=_config_int(app_config, 'VAD_SILERO_SPEECH_PAD_MS', 120),
+            chunk_window_s=_config_float(app_config, 'AUDIO_CHUNK_WINDOW_S', 15.0),
+            chunk_overlap_s=_config_float(app_config, 'AUDIO_CHUNK_OVERLAP_S', 0.4),
+            vad_merge_gap_s=_config_float(app_config, 'VAD_MERGE_GAP_S', 0.35),
+            vad_min_segment_s=_config_float(app_config, 'VAD_MIN_SEGMENT_S', 0.8),
+            vad_max_segment_s=_config_float(app_config, 'VAD_MAX_SEGMENT_S', 15.0),
+            vad_max_segment_s_for_split=_config_float(app_config, 'VAD_MAX_SEGMENT_S_FOR_SPLIT', 15.0),
             vad_refinement_enabled=coerce_bool(app_config.get('VAD_REFINEMENT_ENABLED', True)),
-            vad_min_speech_coverage_ratio=float(app_config.get('VAD_MIN_SPEECH_COVERAGE_RATIO', 0.015) or 0.015),
+            vad_min_speech_coverage_ratio=_config_float(app_config, 'VAD_MIN_SPEECH_COVERAGE_RATIO', 0.015),
             language=language,
             prompt=prompt,
             translate=coerce_bool(app_config.get('WHISPER_TRANSLATE', False)) if not use_voxtral else False,

--- a/modules/vad_processor.py
+++ b/modules/vad_processor.py
@@ -26,12 +26,12 @@ class VadConfig:
     min_silence_ms: int = 320
     max_speech_s: int = 120
     speech_pad_ms: int = 120
-    chunk_window_s: float = 30.0
+    chunk_window_s: float = 15.0
     chunk_overlap_s: float = 0.4
     merge_gap_s: float = 0.35
     min_segment_s: float = 0.8
-    max_segment_s: float = 30.0
-    max_segment_s_for_split: float = 30.0
+    max_segment_s: float = 15.0
+    max_segment_s_for_split: float = 15.0
     refinement_enabled: bool = True
     min_speech_coverage_ratio: float = 0.015
 
@@ -256,6 +256,7 @@ class VadProcessor:
                     max_speech_duration_s=self._effective_vad_max_speech_s(config),
                     sampling_rate=sample_rate,
                     return_seconds=True,
+                    time_resolution=2,
                 )
             if not speech_timestamps:
                 self._set_run_state(False)
@@ -521,8 +522,14 @@ class VadProcessor:
             last = merged[-1]
             boundary_gap = start - last[1]
             combined_duration = max(last[1], end) - last[0]
-            can_merge = boundary_gap < merge_gap if allow_gap_merge else (
-                boundary_gap <= chunk_stitch_gap and combined_duration <= max_dur
+            merge_limit = merge_gap if allow_gap_merge else chunk_stitch_gap
+            within_merge_gap = (
+                boundary_gap < merge_limit
+                if allow_gap_merge
+                else boundary_gap <= merge_limit
+            )
+            can_merge = boundary_gap <= 0.0 or (
+                within_merge_gap and combined_duration <= max_dur
             )
             if can_merge:
                 last[1] = max(last[1], end)
@@ -536,11 +543,30 @@ class VadProcessor:
             seg = merged[idx]
             duration = seg[1] - seg[0]
             if duration < min_dur:
-                if filtered:
+                merge_limit = merge_gap if allow_gap_merge else chunk_stitch_gap
+                previous_gap = seg[0] - filtered[-1][1] if filtered else float('inf')
+                next_seg = merged[idx + 1] if idx < len(merged) - 1 else None
+                next_gap = next_seg[0] - seg[1] if next_seg else float('inf')
+
+                can_merge_previous = (
+                    bool(filtered)
+                    and previous_gap <= merge_limit
+                    and seg[1] - filtered[-1][0] <= max_dur
+                )
+                can_merge_next = (
+                    next_seg is not None
+                    and next_gap <= merge_limit
+                    and next_seg[1] - seg[0] <= max_dur
+                )
+
+                if can_merge_previous and (not can_merge_next or previous_gap <= next_gap):
                     filtered[-1][1] = seg[1]
-                elif idx < len(merged) - 1:
-                    merged[idx + 1][0] = seg[0]
+                elif can_merge_next:
+                    next_seg[0] = seg[0]
                 else:
+                    # Silero has already filtered sub-min_speech noise. Keep an
+                    # isolated short utterance instead of spanning arbitrary
+                    # silence to force it into a neighbouring ASR window.
                     filtered.append(seg)
             else:
                 filtered.append(seg)
@@ -626,7 +652,7 @@ class VadProcessor:
     def _build_relaxed_retry_config(self) -> VadConfig:
         return replace(
             self.config,
-            threshold=max(0.35, float(self.config.threshold or 0.55) - 0.12),
+            threshold=max(0.35, float(self.config.threshold) - 0.12),
             min_speech_ms=max(120, int(self.config.min_speech_ms * 0.6)),
             min_silence_ms=max(160, int(self.config.min_silence_ms * 0.6)),
             speech_pad_ms=min(320, int(self.config.speech_pad_ms + 60)),
@@ -635,7 +661,7 @@ class VadProcessor:
     def _build_refinement_config(self, config: VadConfig) -> VadConfig:
         return replace(
             config,
-            threshold=min(0.80, float(config.threshold or 0.55) + 0.08),
+            threshold=min(0.80, float(config.threshold) + 0.08),
             min_speech_ms=max(80, int(config.min_speech_ms * 0.6)),
             min_silence_ms=max(120, int(config.min_silence_ms * 0.75)),
             speech_pad_ms=max(40, int(config.speech_pad_ms * 0.5)),

--- a/tests/test_speech_recognition_config.py
+++ b/tests/test_speech_recognition_config.py
@@ -67,6 +67,40 @@ class SpeechRecognitionConfigTests(unittest.TestCase):
         self.assertEqual(recognizer.config.api_provider, 'voxtral')
         self.assertEqual(recognizer.config.voxtral_timestamp_granularities, 'segment,word')
 
+    def test_vad_numeric_config_preserves_explicit_zero_values(self):
+        recognizer = create_speech_recognizer_from_config({
+            'SPEECH_RECOGNITION_ENABLED': True,
+            'VAD_SILERO_THRESHOLD': 0,
+            'VAD_SILERO_MIN_SPEECH_MS': 0,
+            'VAD_SILERO_MIN_SILENCE_MS': 0,
+            'VAD_SILERO_SPEECH_PAD_MS': 0,
+            'AUDIO_CHUNK_OVERLAP_S': 0,
+            'VAD_MERGE_GAP_S': 0,
+            'VAD_MIN_SEGMENT_S': 0,
+            'VAD_MIN_SPEECH_COVERAGE_RATIO': 0,
+        }, task_id='unit-test-vad-zero-values')
+
+        self.assertIsNotNone(recognizer)
+        self.assertEqual(recognizer.config.vad_threshold, 0.0)
+        self.assertEqual(recognizer.config.vad_min_speech_ms, 0)
+        self.assertEqual(recognizer.config.vad_min_silence_ms, 0)
+        self.assertEqual(recognizer.config.vad_speech_pad_ms, 0)
+        self.assertEqual(recognizer.config.chunk_overlap_s, 0.0)
+        self.assertEqual(recognizer.config.vad_merge_gap_s, 0.0)
+        self.assertEqual(recognizer.config.vad_min_segment_s, 0.0)
+        self.assertEqual(recognizer.config.vad_min_speech_coverage_ratio, 0.0)
+
+    def test_invalid_vad_numeric_config_uses_defaults(self):
+        recognizer = create_speech_recognizer_from_config({
+            'SPEECH_RECOGNITION_ENABLED': True,
+            'VAD_SILERO_THRESHOLD': 'invalid',
+            'VAD_SILERO_MIN_SPEECH_MS': '',
+        }, task_id='unit-test-vad-invalid-values')
+
+        self.assertIsNotNone(recognizer)
+        self.assertEqual(recognizer.config.vad_threshold, 0.55)
+        self.assertEqual(recognizer.config.vad_min_speech_ms, 300)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_vad_processor.py
+++ b/tests/test_vad_processor.py
@@ -1,0 +1,102 @@
+import os
+import tempfile
+import unittest
+import wave
+from unittest.mock import Mock, patch
+
+from modules.vad_processor import VadConfig, VadProcessor
+
+
+class VadProcessorTests(unittest.TestCase):
+    def test_direct_defaults_match_production_window_limits(self):
+        config = VadConfig()
+
+        self.assertEqual(config.chunk_window_s, 15.0)
+        self.assertEqual(config.max_segment_s, 15.0)
+        self.assertEqual(config.max_segment_s_for_split, 15.0)
+
+    def test_isolated_short_segment_does_not_span_long_silence(self):
+        processor = VadProcessor(VadConfig())
+
+        result = processor._apply_constraints(
+            [(0.0, 1.0), (10.0, 10.3)],
+            config=processor.config,
+        )
+
+        self.assertEqual(result, [(0.0, 1.0), (10.0, 10.3)])
+
+    def test_leading_short_segment_does_not_expand_distant_next_segment(self):
+        processor = VadProcessor(VadConfig())
+
+        result = processor._apply_constraints(
+            [(0.0, 0.3), (10.0, 11.0)],
+            config=processor.config,
+        )
+
+        self.assertEqual(result, [(0.0, 0.3), (10.0, 11.0)])
+
+    def test_nearby_segments_still_merge_within_configured_gap(self):
+        processor = VadProcessor(VadConfig())
+
+        result = processor._apply_constraints(
+            [(0.0, 1.0), (1.2, 1.5)],
+            config=processor.config,
+        )
+
+        self.assertEqual(result, [(0.0, 1.5)])
+
+    def test_gap_merge_does_not_create_overlong_window(self):
+        config = VadConfig(min_segment_s=0.0)
+        processor = VadProcessor(config)
+
+        result = processor._apply_constraints(
+            [(0.0, 14.8), (15.0, 15.8)],
+            config=config,
+        )
+
+        self.assertEqual(result, [(0.0, 14.8), (15.0, 15.8)])
+
+    def test_overlapping_segments_are_unioned_before_force_split(self):
+        config = VadConfig(min_segment_s=0.0)
+        processor = VadProcessor(config)
+
+        result = processor._apply_constraints(
+            [(0.0, 14.8), (14.0, 16.0)],
+            config=config,
+        )
+
+        self.assertEqual(result, [(0.0, 15.0), (15.0, 16.0)])
+
+    def test_silero_seconds_use_centisecond_resolution(self):
+        handle = tempfile.NamedTemporaryFile(suffix='.wav', delete=False)
+        wav_path = handle.name
+        handle.close()
+        self.addCleanup(lambda: os.path.exists(wav_path) and os.unlink(wav_path))
+
+        with wave.open(wav_path, 'wb') as wav_file:
+            wav_file.setnchannels(1)
+            wav_file.setsampwidth(2)
+            wav_file.setframerate(16000)
+            wav_file.writeframes(b'\x00\x00' * 16000)
+
+        get_speech_timestamps = Mock(return_value=[{'start': 0.12, 'end': 0.98}])
+        processor = VadProcessor(VadConfig())
+        with patch.object(
+            processor,
+            '_load_silero_vad',
+            return_value=(object(), {'get_speech_timestamps': get_speech_timestamps}),
+        ):
+            result = processor._run_vad_on_audio(wav_path, 1.0, processor.config)
+
+        self.assertEqual(result, [(0.12, 0.98)])
+        self.assertEqual(get_speech_timestamps.call_args.kwargs['time_resolution'], 2)
+
+    def test_adaptive_thresholds_preserve_explicit_zero_base(self):
+        processor = VadProcessor(VadConfig(threshold=0.0))
+
+        self.assertEqual(processor._build_relaxed_retry_config().threshold, 0.35)
+        self.assertEqual(processor._build_refinement_config(processor.config).threshold, 0.08)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## 概要

- 将 Silero 秒级时间戳精度从 0.1 秒提升至 0.01 秒
- 修复短语音片段跨任意长度静音强行并入相邻窗口的问题
- 合并前约束最大片段长度，避免先生成超长窗口再硬切
- 保留 VAD 数值配置中的显式 `0`，非法或空值才回退默认值
- 统一 `VadConfig` 与生产链路的 15 秒窗口默认值
- 保持现有 `.55 / 300ms / 320ms` 生产检测参数不变

## 行为权衡

孤立短语音现在会保留为独立 ASR 窗口，不再通过吞入长静音来减少请求。真实 58.9 秒样本的窗口数由 9 增至 13；这是质量优先的预期权衡，可能略增 API 调用量，但避免无语音区间进入 ASR 并改善字幕边界。

## 验证

- `python -m pytest -q`：482 passed
- 真实 58.9 秒视频完整 VAD：success，13 windows，时间戳达到 0.01 秒精度
- 10 秒低幅白噪声：0 windows
- 10 秒低幅纯音：0 windows
- GPT-5.6 Luna max 独立审查：无高风险；唯一中风险为上述预期的窗口数增加